### PR TITLE
Make utests python26 compatible

### DIFF
--- a/test/unit/locators/test_elementfinder.py
+++ b/test/unit/locators/test_elementfinder.py
@@ -8,9 +8,10 @@ class ElementFinderTests(unittest.TestCase):
     def test_find_with_invalid_prefix(self):
         finder = ElementFinder()
         browser = mock()
-        with self.assertRaises(ValueError) as context:
-            finder.find(browser, "something=test1")
-        self.assertEqual(context.exception.message, "Element locator with prefix 'something' is not supported")
+        try:
+            self.assertRaises(ValueError, finder.find, browser, "something=test1")
+        except ValueError as e:
+            self.assertEqual(e.message, "Element locator with prefix 'something' is not supported")
 
     def test_find_with_null_browser(self):
         finder = ElementFinder()

--- a/test/unit/locators/test_elementfinder.py
+++ b/test/unit/locators/test_elementfinder.py
@@ -14,20 +14,20 @@ class ElementFinderTests(unittest.TestCase):
 
     def test_find_with_null_browser(self):
         finder = ElementFinder()
-        with self.assertRaises(AssertionError):
-            finder.find(None, "id=test1")
+        self.assertRaises(AssertionError,
+            finder.find, None, "id=test1")
 
     def test_find_with_null_locator(self):
         finder = ElementFinder()
         browser = mock()
-        with self.assertRaises(AssertionError):
-            finder.find(browser, None)
+        self.assertRaises(AssertionError,
+            finder.find, browser, None)
 
     def test_find_with_empty_locator(self):
         finder = ElementFinder()
         browser = mock()
-        with self.assertRaises(AssertionError):
-            finder.find(browser, "")
+        self.assertRaises(AssertionError,
+            finder.find, browser, "")
 
     def test_find_with_no_tag(self):
         finder = ElementFinder()

--- a/test/unit/locators/test_windowmanager.py
+++ b/test/unit/locators/test_windowmanager.py
@@ -16,8 +16,8 @@ class WindowManagerTests(unittest.TestCase):
 
     def test_select_with_null_browser(self):
         manager = WindowManager()
-        with self.assertRaises(AssertionError):
-            manager.select(None, "name=test1")
+        self.assertRaises(AssertionError,
+            manager.select, None, "name=test1")
 
     def test_select_by_title(self):
         manager = WindowManager()

--- a/test/unit/locators/test_windowmanager.py
+++ b/test/unit/locators/test_windowmanager.py
@@ -10,9 +10,10 @@ class WindowManagerTests(unittest.TestCase):
     def test_select_with_invalid_prefix(self):
         manager = WindowManager()
         browser = mock()
-        with self.assertRaises(ValueError) as context:
-            manager.select(browser, "something=test1")
-        self.assertEqual(context.exception.message, "Window locator with prefix 'something' is not supported")
+        try:
+            self.assertRaises(ValueError, manager.select, browser, "something=test1")
+        except ValueError as e:
+            self.assertEqual(e.message, "Window locator with prefix 'something' is not supported")
 
     def test_select_with_null_browser(self):
         manager = WindowManager()
@@ -56,9 +57,10 @@ class WindowManagerTests(unittest.TestCase):
             { 'name': 'win2', 'title': "Title 2", 'url': 'http://localhost/page2.html' },
             { 'name': 'win3', 'title': "Title 3", 'url': 'http://localhost/page3.html' })
 
-        with self.assertRaises(ValueError) as context:
-            manager.select(browser, "title=Title -1")
-        self.assertEqual(context.exception.message, "Unable to locate window with title 'Title -1'")
+        try:
+            self.assertRaises(ValueError, manager.select, browser, "title=Title -1")
+        except ValueError as e:
+            self.assertEqual(e.message, "Unable to locate window with title 'Title -1'")
 
     def test_select_by_name(self):
         manager = WindowManager()
@@ -97,9 +99,10 @@ class WindowManagerTests(unittest.TestCase):
             { 'name': 'win2', 'title': "Title 2", 'url': 'http://localhost/page2.html' },
             { 'name': 'win3', 'title': "Title 3", 'url': 'http://localhost/page3.html' })
 
-        with self.assertRaises(ValueError) as context:
-            manager.select(browser, "name=win-1")
-        self.assertEqual(context.exception.message, "Unable to locate window with name 'win-1'")
+        try:
+            self.assertRaises(ValueError, manager.select, browser, "name=win-1")
+        except ValueError as e:
+            self.assertEqual(e.message, "Unable to locate window with name 'win-1'")
 
     def test_select_by_url(self):
         manager = WindowManager()
@@ -138,9 +141,10 @@ class WindowManagerTests(unittest.TestCase):
             { 'name': 'win2', 'title': "Title 2", 'url': 'http://localhost/page2.html' },
             { 'name': 'win3', 'title': "Title 3", 'url': 'http://localhost/page3.html' })
 
-        with self.assertRaises(ValueError) as context:
-            manager.select(browser, "url=http://localhost/page-1.html")
-        self.assertEqual(context.exception.message, "Unable to locate window with URL 'http://localhost/page-1.html'")
+        try:
+            self.assertRaises(ValueError, manager.select, browser, "url=http://localhost/page-1.html")
+        except ValueError as e:
+            self.assertEqual(e.message, "Unable to locate window with URL 'http://localhost/page-1.html'")
 
     def test_select_with_null_locator(self):
         manager = WindowManager()
@@ -217,9 +221,10 @@ class WindowManagerTests(unittest.TestCase):
             { 'name': 'win2', 'title': "Title 2", 'url': 'http://localhost/page2.html' },
             { 'name': 'win3', 'title': "Title 3", 'url': 'http://localhost/page3.html' })
 
-        with self.assertRaises(ValueError) as context:
-            manager.select(browser, "win-1")
-        self.assertEqual(context.exception.message, "Unable to locate window with name or title 'win-1'")
+        try:
+            self.assertRaises(ValueError, manager.select, browser, "win-1")
+        except ValueError as e:
+            self.assertEqual(context.exception.message, "Unable to locate window with name or title 'win-1'")
 
     def test_select_with_sloppy_prefix(self):
         manager = WindowManager()

--- a/test/unit/utils/test_browsercache.py
+++ b/test/unit/utils/test_browsercache.py
@@ -7,9 +7,10 @@ class BrowserCacheTests(unittest.TestCase):
 
     def test_no_current_message(self):
         cache = BrowserCache()
-        with self.assertRaises(RuntimeError) as context:
-            cache.current.anyMember()
-        self.assertEqual(context.exception.message, "No current browser")
+        try:
+            self.assertRaises(RuntimeError, cache.current.anyMember())
+        except RuntimeError as e:
+            self.assertEqual(e.message, "No current browser")
 
     def test_browsers_property(self):
         cache = BrowserCache()


### PR DESCRIPTION
Clean branch from rtomac:master which refactors unit tests that were failing with Python 2.6 to make them compatible with both 2.6 and 2.7.
