### PR TITLE
Temporary fix for missing VERSION string after removing metadata.py.

### DIFF
--- a/src/Selenium2Library/__init__.py
+++ b/src/Selenium2Library/__init__.py
@@ -1,5 +1,5 @@
 from keywords import *
-from metadata import VERSION
+VERSION = '0.5.3'
 
 __version__ = VERSION
 


### PR DESCRIPTION
This should be the last fix in moving away from static libraries and refactoring setup.py.  Realized that the version string was needed elsewhere and removing metadata.py broke the package.
