### PR TITLE
Textfield value should be -keyword fails, doesn't find the element

### DIFF
--- a/src/Selenium2Library/keywords/_formelement.py
+++ b/src/Selenium2Library/keywords/_formelement.py
@@ -243,7 +243,7 @@ class _FormElementKeywords(KeywordGroup):
         Key attributes for text fields are `id` and `name`. See `introduction`
         for details about locating elements.
         """
-        element = self._element_find(locator, True, False, 'text field')
+        element = self._element_find(locator, True, False, 'input')
         if element is None: element = self._element_find(locator, True, False, 'file upload')
         actual = element.get_attribute('value') if element is not None else None
         if actual != expected:


### PR DESCRIPTION
"Textfield Value Should Be" -keyword did not find the textfield, but just failed with:

FAIL Value of text field 'edit-mail' should have been 'acceptance-user@example.com' but was 'None'

This small change fixes the issue, but is probably not the optimal solution.
