### PR TITLE
Fix issue with Acceptance.Windows test

### DIFF
--- a/test/acceptance/open_and_close.txt
+++ b/test/acceptance/open_and_close.txt
@@ -1,5 +1,6 @@
 *** Settings ***
 Resource        resource.txt
+Suite Teardown  Close All Browsers
 
 *** Test Cases ***
 Browser Should Open And Close


### PR DESCRIPTION
Using Suite Teardown within Acceptance.Open and Close test suite, which comes right before the Acceptance.Windows test, and calling "Close All Browsers" we can resolve the failing windows test. In investigating the cause of failure, the tests passed if ran isolated (using the command "$ python run_tests.py python *ff --suite='Acceptance.Windows'"). Further investigation found the commenting out all the "Close Browser" keywords within the Open and Close test would also fix the issue (but expectantly cause some of those test to fail). It is unclear why calling "Close All Browsers" works while the less inclusive "Close Browser" fails or at least cause an issue latter on.

Although this fixes the problem I am troubled by the test isolation issue and I am still unsure why exactly this fixes the problem.
