### PR TITLE
Fixed issue with Acceptance.Keywords.Waiting test

### DIFF
--- a/test/acceptance/keywords/async_javascript.txt
+++ b/test/acceptance/keywords/async_javascript.txt
@@ -1,5 +1,6 @@
 *** Settings ***
 Test Setup      Go To Page "javascript/dynamic_content.html"
+Suite Teardown  Set Selenium Timeout  5 seconds
 Resource        ../resource.txt
 
 *** Test Cases ***


### PR DESCRIPTION
The cause of this error appears to be two things.  First the "Set Selenium Timeout" keyword was fixed and second another test, async_javascript which runs before the waiting test, set the timeout value to various different values testing another part of the library.  Thus when the waiting test ran it failed. To resolve I reset Selenium Timeout to default 5 seconds at end of async_javascript test suite.
