### PR TITLE
added iframe support, by allowing the element finder to handle filters w...

### DIFF
--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -173,7 +173,7 @@ class _BrowserManagementKeywords(KeywordGroup):
         details about locating elements.
         """
         self._info("Selecting frame '%s'." % locator)
-        element = self._element_find(locator, True, True, tag='frame')
+        element = self._element_find(locator, True, True, tag=['frame','iframe'])
         self._current_browser().switch_to_frame(element)
 
     def select_window(self, locator=None):

--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -508,7 +508,8 @@ return !element.dispatchEvent(evt);
 
     def _frame_contains(self, locator, text):
         browser = self._current_browser()
-        element = self._element_find(locator, True, True, 'frame')
+
+        element = self._element_find(locator, True, True, ['frame','iframe'])
         browser.switch_to_frame(element)
         self._info("Searching for text from frame '%s'." % locator)
         found = self._is_text_present(text)
@@ -590,6 +591,7 @@ return !element.dispatchEvent(evt);
             return True
 
         subframes = self._element_find("tag=frame", False, False, 'frame')
+        subframes.extend(self._element_find("tag=iframe", False, False, 'iframe'))
         self._debug('Current frame has %d subframes' % len(subframes))
         for frame in subframes:
             browser.switch_to_frame(frame)

--- a/src/Selenium2Library/locators/elementfinder.py
+++ b/src/Selenium2Library/locators/elementfinder.py
@@ -76,23 +76,36 @@ class ElementFinder(object):
             return self._find_by_xpath(browser, criteria, tag, constraints)
         return self._find_by_key_attrs(browser, criteria, tag, constraints)
 
-    def _find_by_key_attrs(self, browser, criteria, tag, constraints):
+    def _find_by_key_attrs(self, browser, criteria, tags, constraints):
         key_attrs = self._key_attrs.get(None)
-        if tag is not None:
-            key_attrs = self._key_attrs.get(tag, key_attrs)
+        if tags is not None and not isinstance(tags, (list, tuple)):
+            key_attrs = self._key_attrs.get(tags, key_attrs)
 
         xpath_criteria = utils.escape_xpath_value(criteria)
-        xpath_tag = tag if tag is not None else '*'
-        xpath_constraints = ["@%s='%s'" % (name, constraints[name]) for name in constraints]
-        xpath_searchers = ["%s=%s" % (attr, xpath_criteria) for attr in key_attrs]
-        xpath_searchers.extend(
-            self._get_attrs_with_url(key_attrs, criteria, browser))
-        xpath = "//%s[%s(%s)]" % (
-            xpath_tag,
-            ' and '.join(xpath_constraints) + ' and ' if len(xpath_constraints) > 0 else '',
-            ' or '.join(xpath_searchers))
+        #if not tag:
+        #    xpath_tag = '*'
+        #elif tag and not isinstance(tag,(list,tuple)):
+        #    xpath_tag = tag
+        #elif isinstance(tag,(list,tuple)):
+        #    xpath_tag = ' or '.join(t for t in tag)
+        if not isinstance(tags,(list,tuple)): tags =[tags]
 
-        return browser.find_elements_by_xpath(xpath)
+        full_xpath = ""
+        for tag in tags:
+            xpath_tag = tag if tag is not None else '*'
+            xpath_constraints = ["@%s='%s'" % (name, constraints[name]) for name in constraints]
+            xpath_searchers = ["%s=%s" % (attr, xpath_criteria) for attr in key_attrs]
+            xpath_searchers.extend(
+                self._get_attrs_with_url(key_attrs, criteria, browser))
+            xpath = "//%s[%s(%s)]" % (
+                xpath_tag,
+                ' and '.join(xpath_constraints) + ' and ' if len(xpath_constraints) > 0 else '',
+                ' or '.join(xpath_searchers))
+            if len(full_xpath) > 1:
+                full_xpath = "%s | %s" % (full_xpath,xpath)
+            else:
+                full_xpath = xpath
+        return browser.find_elements_by_xpath(full_xpath)
 
     # Private
 
@@ -106,6 +119,8 @@ class ElementFinder(object):
 
     def _get_tag_and_constraints(self, tag):
         if tag is None: return None, {}
+        #we want to allow a list of tags as well
+        if isinstance(tag, (list,tuple)): return tag, {}
 
         tag = tag.lower()
         constraints = {}
@@ -130,7 +145,7 @@ class ElementFinder(object):
         return tag, constraints
 
     def _element_matches(self, element, tag, constraints):
-        if not element.tag_name.lower() == tag:
+        if not element.tag_name.lower() in tag:
             return False
         for name in constraints:
             if not element.get_attribute(name) == constraints[name]:

--- a/test/acceptance/keywords/frames.txt
+++ b/test/acceptance/keywords/frames.txt
@@ -10,6 +10,10 @@ Frame Should Contain
   Frame Should contain  right  You're looking at right.
   Frame Should Contain  left  Links
 
+iFrame Should Contain
+    Select Frame    right
+    Frame Should contain    iframe_right    You're looking at iframe right.
+
 Select And Unselect Frame
   [Documentation]  LOG 1 Selecting frame 'left'.
   Select Frame  left
@@ -17,3 +21,4 @@ Select And Unselect Frame
   Unselect Frame
   Select Frame  right
   Current Frame Contains  You're looking at foo.
+

--- a/test/resources/html/frames/frameset.html
+++ b/test/resources/html/frames/frameset.html
@@ -1,6 +1,8 @@
 <html>
   <frameset cols="20%, 80%">
     <frame name="left"  src="left.html"/>
-    <frame name="right" src="right.html"/>
+    <frame name="right" src="right.html">
+    <iframe name="iframe_right" src="iframe_right.html"  frameborder="0" scrolling="auto" width="500" height="180" marginwidth="5" marginheight="5"/>
+    </frame>
   </frameset>
 </html>

--- a/test/resources/html/frames/iframe_right.html
+++ b/test/resources/html/frames/iframe_right.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <p>You're looking at iframe right</span>.</p>
+  </body>
+</html>

--- a/test/resources/html/frames/right.html
+++ b/test/resources/html/frames/right.html
@@ -1,5 +1,6 @@
 <html>
   <body>
     <p>You're looking at <span id="page_identifier">right</span>.</p>
+     <iframe name="iframe_right" src="iframe_right.html"  frameborder="2" scrolling="auto" width="500" height="180" marginwidth="5" marginheight="5"/>
   </body>
 </html>

--- a/test/run_unit_tests.py
+++ b/test/run_unit_tests.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import env
 import os, sys
 import unittest

--- a/test/unit/locators/test_elementfinder.py
+++ b/test/unit/locators/test_elementfinder.py
@@ -207,6 +207,24 @@ class ElementFinderTests(unittest.TestCase):
         result = finder.find(browser, "name=test1", tag='a')
         self.assertEqual(result, [elements[1], elements[3]])
 
+
+    def test_find_by_name_filter_on_multiple_tags(self):
+        finder = ElementFinder()
+        browser = mock()
+
+        elements = self._make_mock_elements('div', 'a', 'span', 'a')
+        when(browser).find_elements_by_name("test1").thenReturn(elements)
+
+        result = finder.find(browser, "name=test1")
+        self.assertEqual(result, elements)
+        result = finder.find(browser, "name=test1", tag=['div','span'])
+        self.assertEqual(result, [elements[0], elements[2]])
+        result = finder.find(browser, "name=test1", tag=['div','span','a'])
+        self.assertEqual(result, elements)
+        
+
+
+
     def test_find_by_xpath(self):
         finder = ElementFinder()
         browser = mock()


### PR DESCRIPTION
ok here is my attempt at getting frames to work in painless manner.  Basically I changed the element_finder functionality so that the filter could handled a list of tags.  ie. ['frame','iframe'] as opposed to a single tag.  This also required some changes to the xpath generation for find by default stuff.

Also I updated all the appropriate functions that have to do with frames to look for both frames and frames.  Finally I added a couple of tests.

All the test pass.  But I'm would be interested in feedback, especially if there is a way to make the code cleaner... cooler... nicer :)
