### PR TITLE
Updating INSTALL.rst to promote usage of pip in addition to easy_install

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -17,7 +17,11 @@ Installing from PyPI
 --------------------
 
 Selenium2Library is available in the Python Package Index (PyPI_). To install,
-you need to have `easy_install`_ installed. Then run::
+you need to have either: `pip`_ or `easy_install`_ installed. Then run::
+
+	pip install robotframework-selenium2library
+
+or::
 
 	easy_install robotframework-selenium2library
 
@@ -51,3 +55,4 @@ Control Panel (Add/Remove Programs on older versions of Windows).
 .. _Selenium Python Bindings: http://code.google.com/p/selenium/wiki/PythonBindings
 .. _PyPI: http://code.google.com/p/selenium/wiki/PythonBindings
 .. _easy_install: http://pypi.python.org/pypi/setuptools
+.. _pip: http://www.pip-installer.org/


### PR DESCRIPTION
Shouldn't encourage people to use easy_install when pip is now the standard.
