### PR TITLE
Fix Capture Page Screenshot for RemoteWebDriver

### DIFF
--- a/src/Selenium2Library/keywords/_screenshot.py
+++ b/src/Selenium2Library/keywords/_screenshot.py
@@ -24,7 +24,11 @@ class _ScreenshotKeywords(KeywordGroup):
         background leaking when the page layout is somehow broken.
         """
         path, link = self._get_screenshot_paths(filename)
-        self._current_browser().save_screenshot(path)
+
+        if hasattr(self._current_browser(), 'get_screenshot_as_file'):
+          self._current_browser().get_screenshot_as_file(path)
+        else:
+          self._current_browser().save_screenshot(path)
 
         # Image is shown on its own row and thus prev row is closed on purpose
         self._html('</td></tr><tr><td colspan="3"><a href="%s">'


### PR DESCRIPTION
_For easy merge-button clicking. Thanks for everything!_

Original source for this fix:

  https://github.com/korda/robotframework-selenium2library/commit/0c52e076c335f6804899fee9ea7d1b2a7904773f

Original issue report:

  https://github.com/rtomac/robotframework-selenium2library/issues/43
