### PR TITLE
fix for issue 10 - Get Window Titles break in IE

### DIFF
--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -465,7 +465,7 @@ class _BrowserManagementKeywords(KeywordGroup):
         desired_capabilities = capabilities_type
         if capabilities_string:
             for cap in capabilities_string.split(","):
-                (key, value) = cap.split(":")
+                (key, value) = cap.split(":",1)
                 desired_capabilities[key.strip()] = value.strip()
         return desired_capabilities
     

--- a/src/Selenium2Library/utils/browsercache.py
+++ b/src/Selenium2Library/utils/browsercache.py
@@ -26,8 +26,10 @@ class BrowserCache(ConnectionCache):
             self._closed.add(browser)
 
     def close_all(self):
-        for browser in self._connections:
-            if browser not in self._closed:
-                browser.quit()
-        self.empty_cache()
+        try:
+            for browser in self._connections:
+                if browser not in self._closed:
+                    browser.quit()
+        finally:
+            self.empty_cache()
         return self.current

--- a/src/Selenium2Library/webdrivermonkeypatches.py
+++ b/src/Selenium2Library/webdrivermonkeypatches.py
@@ -21,7 +21,7 @@ class WebDriverMonkeyPatches:
         return self.current_window_handle
 
     def get_current_window_info(self):
-        atts = self.execute_script("return [ window.id, window.name, document.title, document.location ];")
+        atts = self.execute_script("return [ window.id, window.name, document.title, document.url ];")
         atts = [ att if att is not None and len(att) else 'undefined'
             for att in atts ]
         return (self.current_window_handle, atts[0], atts[1], atts[2], atts[3])


### PR DESCRIPTION
The cause appears to be triggered by document.location parameter in the execute_script call on line 24.
atts = self.execute_script("return [ window.id, window.name, document.title, document.location ];")

IE driver returns a web element object but Firefox driver returns a dictionary:

IE driver returns
[None, '', u'Page Title', ]

Firefox driver returns
[None, '', u'Page Title', {u'search': '', u'assign': u'function assign() {\n [native code]\n}', u'hash': '', u'hostname': u'host.domain', u'replace': u'function replace() {\n [native code]\n}', u'reload': u'function reload() {\n [native code]\n}', u'host': u'host.domain', u'href': u'http://qtst.atpco.org/fmhome/login.jsp', u'pathname': u'/path/to/file.html', u'protocol': u'http:', u'port': ''}] 

Since "Select Window" keyword offers locator options for name, title & url can you change line 24 to:
atts = self.execute_script("return [ window.id, window.name, document.title, document.url ];")

This tested ok for me on IE & Chrome and trusting this reference
http://www.w3schools.com/jsref/prop_doc_url.asp it appears document.url is supported by all browser versions

Hope this helps
