### PR TITLE
add actual error message to rundemo.py import exception

### DIFF
--- a/demo/rundemo.py
+++ b/demo/rundemo.py
@@ -32,8 +32,8 @@ from subprocess import Popen, call, STDOUT
 
 try:
     import Selenium2Library
-except ImportError:
-    print 'Importing Selenium2Library module failed.'
+except ImportError as e:
+    print 'Importing Selenium2Library module failed (%s).' % e
     print 'Please make sure you have SeleniumLibrary installed.'
     sys.exit(1)
 


### PR DESCRIPTION
If decorator (or any other dependent module) is not installed when running the rundemo.py, it give ambiguous error message. This prints the actual error message (eg. No module named decorator) 
