### PR TITLE
Fixed issue with 'Drag and Drop' tests. 

### DIFF
--- a/test/acceptance/keywords/javascript.txt
+++ b/test/acceptance/keywords/javascript.txt
@@ -70,9 +70,9 @@ Drag and Drop
 Drag and Drop by Offset
     [Setup]  Go To Page "javascript/drag_and_drop.html"
     Element Text Should Be   id=droppable   Drop here
-    Drag and Drop by Offset   id=draggable  1  1
+    Drag and Drop by Offset   id=draggable  ${1}  ${1}
     Element Text Should Be   id=droppable   Drop here
-    Drag and Drop by Offset  id=draggable   100  20
+    Drag and Drop by Offset  id=draggable   ${100}  ${20}
     Element Text Should Be   id=droppable   Dropped!
 
 


### PR DESCRIPTION
Arguments should be number variables and not strings.
