### PR TITLE
browser cache reliability fix

### DIFF
--- a/src/Selenium2Library/utils/browsercache.py
+++ b/src/Selenium2Library/utils/browsercache.py
@@ -26,8 +26,10 @@ class BrowserCache(ConnectionCache):
             self._closed.add(browser)
 
     def close_all(self):
-        for browser in self._connections:
-            if browser not in self._closed:
-                browser.quit()
-        self.empty_cache()
+        try:
+            for browser in self._connections:
+                if browser not in self._closed:
+                    browser.quit()
+        finally:  
+            self.empty_cache()
         return self.current


### PR DESCRIPTION
there are cases when browser.quit will throw exceptions, then browser cache will not be cleaned,and all future close_all will fail for same reason
