### PR TITLE
Check for element found under 'Get Text' and 'Element Should Contain' keywords

### DIFF
--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -523,7 +523,7 @@ return !element.dispatchEvent(evt);
         return found
 
     def _get_text(self, locator):
-        element = self._element_find(locator, True, False)
+        element = self._element_find(locator, True, True)
         if element is not None:
             return element.text
         return None

--- a/test/acceptance/keywords/content_assertions.txt
+++ b/test/acceptance/keywords/content_assertions.txt
@@ -81,6 +81,7 @@ Page Should Not Contain Element With Disabling Source Logging
 Element Should Contain
     Element Should Contain  some_id  This text is inside an identified element
     Run Keyword And Expect Error  Element 'some_id' should have contained text 'non existing text' but its text was 'This text is inside an identified element'.  Element Should Contain  some_id  non existing text
+    Run Keyword And Expect Error  ValueError: Element locator 'missing_id' did not match any elements.  Element Should Contain  missing_id  This should report missing element.
 
 Element Text Should Be
     Element Text Should Be  some_id  This text is inside an identified element
@@ -89,6 +90,7 @@ Element Text Should Be
 Get Text
     ${str} =  Get Text  some_id
     Should Match  ${str}  This text is inside an identified element
+    Run Keyword And Expect Error  ValueError: Element locator 'missing_id' did not match any elements.  Get Text  missing_id
 
 Element Should Be Visible
     [Setup]  Go To Page "visibility.html"


### PR DESCRIPTION
Require 'Get Text' and 'Element Should Contain' keywords to find elements as indicated by locator. Otherwise these keywords should report a ValueError indicating element could not be found.
