### PR TITLE
fix bad browser name raising AttributeError

### DIFF
--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -388,22 +388,18 @@ class _BrowserManagementKeywords(KeywordGroup):
             raise RuntimeError('No browser is open')
         return self._cache.current
 
-    def _get_browser_token(self, browser_name):
-        return BROWSER_NAMES.get(browser_name.lower().replace(' ', ''), browser_name)
+    def _get_browser_creation_function(self, browser_name):
+        func_name = BROWSER_NAMES.get(browser_name.lower().replace(' ', ''))
+        return getattr(self, func_name) if func_name else None
 
-
-    def _get_browser_creation_function(self,browser_name):
-        return BROWSER_NAMES.get(browser_name.lower().replace(' ', ''), browser_name)
-
-    def _make_browser(self , browser_name , desired_capabilities=None , profile_dir=None,
-                    remote=None):
-
+    def _make_browser(self, browser_name, desired_capabilities=None,
+                      profile_dir=None, remote=None):
         creation_func = self._get_browser_creation_function(browser_name)
-        browser = getattr(self,creation_func)(remote , desired_capabilities , profile_dir)
 
-        if browser is None:
+        if not creation_func:
             raise ValueError(browser_name + " is not a supported browser.")
 
+        browser = creation_func(remote, desired_capabilities, profile_dir)
         browser.set_speed(self._speed_in_secs)
         browser.set_script_timeout(self._timeout_in_secs)
         browser.implicitly_wait(self._implicit_wait_in_secs)

--- a/test/unit/keywords/test_browsermanagement.py
+++ b/test/unit/keywords/test_browsermanagement.py
@@ -54,6 +54,14 @@ class BrowserManagementTests(unittest.TestCase):
         self.verify_browser(webdriver.Remote, "chrome", remote="http://127.0.0.1/wd/hub",
             desired_capabilities=expected_caps)
 
+    def test_bad_browser_name(self):
+        bm = _BrowserManagementKeywords()
+        try:
+            bm._make_browser("fireox")
+            self.fail("Exception not raised")
+        except ValueError, e:
+            self.assertEquals("fireox is not a supported browser.", e.message)
+
 
     def verify_browser(self , webdriver_type , browser_name, **kw):
         #todo try lambda *x: was_called = true


### PR DESCRIPTION
fix for bad browser name raising AttributeError: 'Selenium2Library'
object has no attribute 'fireox' instead of ValueError: fireox is not a
supported browser.
PEP8 near code change and some housekeeping
assertRaisesRegexp not available in py 2.6 :(
