### PR TITLE
Add support for jQuery selectors (uses window's jQuery)

### DIFF
--- a/src/Selenium2Library/__init__.py
+++ b/src/Selenium2Library/__init__.py
@@ -56,6 +56,8 @@ class Selenium2Library(
     | dom        | Click Element `|` dom=document.images[56] | Matches with arbitrary DOM express            |
     | link       | Click Element `|` link=My Link          | Matches anchor elements by their link text      |
     | css        | Click Element `|` css=div.my_class      | Matches by CSS selector                         |
+    | jquery     | Click Element `|` jquery=div.my_class   | Matches by jQuery/sizzle selector                         |
+    | sizzle     | Click Element `|` sizzle=div.my_class   | Matches by jQuery/sizzle selector                         |
     | tag        | Click Element `|` tag=div               | Matches by HTML tag name                        |
 
     Table related keywords, such as `Table Should Contain`, work differently.

--- a/src/Selenium2Library/locators/elementfinder.py
+++ b/src/Selenium2Library/locators/elementfinder.py
@@ -11,6 +11,8 @@ class ElementFinder(object):
             'dom': self._find_by_dom,
             'link': self._find_by_link_text,
             'css': self._find_by_css_selector,
+            'jquery': self._find_by_sizzle_selector,
+            'sizzle': self._find_by_sizzle_selector,
             'tag': self._find_by_tag_name,
             None: self._find_by_default
         }
@@ -55,6 +57,12 @@ class ElementFinder(object):
         if not isinstance(result, list):
             result = [result]
         return self._filter_elements(result, tag, constraints)
+
+    def _find_by_sizzle_selector(self, browser, criteria, tag, constraints):
+        js = "return jQuery('%s').get();" % criteria.replace("'", "\\'")
+        return self._filter_elements(
+            browser.execute_script(js),
+            tag, constraints)
 
     def _find_by_link_text(self, browser, criteria, tag, constraints):
         return self._filter_elements(

--- a/src/Selenium2Library/locators/tableelementfinder.py
+++ b/src/Selenium2Library/locators/tableelementfinder.py
@@ -68,6 +68,8 @@ class TableElementFinder(object):
     def _parse_table_locator(self, table_locator, location_method):
         if table_locator.startswith('xpath='):
             table_locator_type = 'xpath'
+        elif table_locator.startswith('jquery=') or table_locator.startswith('sizzle='):
+            table_locator_type = 'sizzle'
         else:
             if not table_locator.startswith('css='):
                 table_locator = "css=table#%s" % table_locator

--- a/src/Selenium2Library/locators/tableelementfinder.py
+++ b/src/Selenium2Library/locators/tableelementfinder.py
@@ -17,6 +17,20 @@ class TableElementFinder(object):
             ('css', 'row'): [' tr:nth-child(%s)'],
             ('css', 'col'): [' tr td:nth-child(%s)', ' tr th:nth-child(%s)'],
 
+            ('jquery', 'default'): [''],
+            ('jquery', 'content'): [''],
+            ('jquery', 'header'): [' th'],
+            ('jquery', 'footer'): [' tfoot td'],
+            ('jquery', 'row'): [' tr:nth-child(%s)'],
+            ('jquery', 'col'): [' tr td:nth-child(%s)', ' tr th:nth-child(%s)'],
+
+            ('sizzle', 'default'): [''],
+            ('sizzle', 'content'): [''],
+            ('sizzle', 'header'): [' th'],
+            ('sizzle', 'footer'): [' tfoot td'],
+            ('sizzle', 'row'): [' tr:nth-child(%s)'],
+            ('sizzle', 'col'): [' tr td:nth-child(%s)', ' tr th:nth-child(%s)'],
+
             ('xpath', 'default'): [''],
             ('xpath', 'content'): ['//*'],
             ('xpath', 'header'): ['//th'],

--- a/test/acceptance/keywords/tables/finding_tables.txt
+++ b/test/acceptance/keywords/tables/finding_tables.txt
@@ -11,3 +11,13 @@ Should Identify Table By CSS
     Table Cell Should Contain  css=table#formattedTable  1  1  formattedTable_A1
     Table Cell Should Contain  css=table#formattedTable  2  4  äöü€&äöü€&
     Table Cell Should Contain  css=h2.someClass ~ table:last-child  2  4  äöü€&äöü€&
+
+Should Identify Table By Sizzle
+    Table Should Contain  jquery=table#simpleTable  simpleTable
+    Table Header Should Contain  jquery=table#tableWithTwoHeaders  tableWithTwoHeaders_C2
+    Table Footer Should Contain  jquery=table#withHeadAndFoot  withHeadAndFoot_AF1
+    Table Row Should Contain  jquery=table#mergedRows  1  mergedRows_D1
+    Table Column Should Contain  jquery=table#mergedCols  1  mergedCols_D1
+    Table Cell Should Contain  jquery=table#formattedTable  1  1  formattedTable_A1
+    Table Cell Should Contain  jquery=table#formattedTable  2  4  äöü€&äöü€&
+    Table Cell Should Contain  jquery=h2.someClass ~ table:last-child  2  4  äöü€&äöü€&

--- a/test/acceptance/keywords/tables/finding_tables.txt
+++ b/test/acceptance/keywords/tables/finding_tables.txt
@@ -1,23 +1,13 @@
 *** Settings ***
-Resource        table_resource.txt
+Resource          table_resource.txt
 
 *** Test Cases ***
 Should Identify Table By CSS
-    Table Should Contain  css=table#simpleTable  simpleTable
-    Table Header Should Contain  css=table#tableWithTwoHeaders  tableWithTwoHeaders_C2
-    Table Footer Should Contain  css=table#withHeadAndFoot  withHeadAndFoot_AF1
-    Table Row Should Contain  css=table#mergedRows  1  mergedRows_D1
-    Table Column Should Contain  css=table#mergedCols  1  mergedCols_D1
-    Table Cell Should Contain  css=table#formattedTable  1  1  formattedTable_A1
-    Table Cell Should Contain  css=table#formattedTable  2  4  äöü€&äöü€&
-    Table Cell Should Contain  css=h2.someClass ~ table:last-child  2  4  äöü€&äöü€&
-
-Should Identify Table By Sizzle
-    Table Should Contain  jquery=table#simpleTable  simpleTable
-    Table Header Should Contain  jquery=table#tableWithTwoHeaders  tableWithTwoHeaders_C2
-    Table Footer Should Contain  jquery=table#withHeadAndFoot  withHeadAndFoot_AF1
-    Table Row Should Contain  jquery=table#mergedRows  1  mergedRows_D1
-    Table Column Should Contain  jquery=table#mergedCols  1  mergedCols_D1
-    Table Cell Should Contain  jquery=table#formattedTable  1  1  formattedTable_A1
-    Table Cell Should Contain  jquery=table#formattedTable  2  4  äöü€&äöü€&
-    Table Cell Should Contain  jquery=h2.someClass ~ table:last-child  2  4  äöü€&äöü€&
+    Table Should Contain    css=table#simpleTable    simpleTable
+    Table Header Should Contain    css=table#tableWithTwoHeaders    tableWithTwoHeaders_C2
+    Table Footer Should Contain    css=table#withHeadAndFoot    withHeadAndFoot_AF1
+    Table Row Should Contain    css=table#mergedRows    1    mergedRows_D1
+    Table Column Should Contain    css=table#mergedCols    1    mergedCols_D1
+    Table Cell Should Contain    css=table#formattedTable    1    1    formattedTable_A1
+    Table Cell Should Contain    css=table#formattedTable    2    4    äöü€&äöü€&
+    Table Cell Should Contain    css=h2.someClass ~ table:last-child    2    4    äöü€&äöü€&

--- a/test/acceptance/locators/__init__.txt
+++ b/test/acceptance/locators/__init__.txt
@@ -1,0 +1,4 @@
+*** Settings ***
+Suite Setup       Open Browser To Start Page
+Suite Teardown    Close All Browsers
+Resource          ../resource.txt

--- a/test/acceptance/locators/sizzle.txt
+++ b/test/acceptance/locators/sizzle.txt
@@ -1,0 +1,26 @@
+*** Settings ***
+Test Setup        Go To Page "jquery.html"
+Resource          ../resource.txt
+
+*** Test Cases ***
+Find By Id
+    Page Should Contain Element    jquery=#div_id
+    Element Should Contain    jquery=#foo    Text and image
+    Click Link    sizzle=#some_id
+    Title Should Be    (root)/broken.html
+
+Find In Table
+    Table Should Contain    jquery=table#simpleTable    simpleTable
+    Table Header Should Contain    jquery=table#tableWithTwoHeaders    tableWithTwoHeaders_C2
+    Table Footer Should Contain    jquery=table#withHeadAndFoot    withHeadAndFoot_AF1
+    Table Row Should Contain    jquery=table#mergedRows    1    mergedRows_D1
+    Table Column Should Contain    jquery=table#mergedCols    1    mergedCols_D1
+    Table Cell Should Contain    jquery=table#formattedTable    1    1    formattedTable_A1
+    Table Cell Should Contain    jquery=table#formattedTable    2    4    äöü€&äöü€&
+    Table Cell Should Contain    jquery=h2.someClass ~ table:last-child    2    4    äöü€&äöü€&
+
+Find By Everything Else
+    Page Should Contain Element    jquery=[href="index.html"]
+    Element Should Contain    jquery=[target="_blank"]    Target opens in new window
+    Click Link    sizzle=:has(img[alt="tooltip"])
+    Title Should Be    (root)/index.html

--- a/test/resources/html/jquery.html
+++ b/test/resources/html/jquery.html
@@ -1,0 +1,256 @@
+<html>
+  <head>
+    <title>(root)/links.html</title>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <script src="http://code.jquery.com/jquery-1.9.1.min.js" type="text/javascript"></script>
+  </head>
+  <body>
+    <div id="div_id">
+      <a href="index.html">Relative</a><br/>
+      <a href="sub/index.html">Relative to sub-directory</a><br/>
+      <a href="http://www.google.com">Absolute external link</a><br/>
+      <a id="some_id" href="broken.html">Link with id</a><br/>
+      <a href="index.html"><img src="image.jpg" id="image_id"/></a><br/>
+      <a href="index.html"><img src="robot.png" alt="tooltip"/></a><br/>
+      <a href="index.html" id="foo"><img src="robot.png"/>Text and image</a><br/>
+      <a href="index.html">Link with double " quote</a><br/>
+      <a href="index.html">Link with &lt; &amp; &gt; \</a><br/>
+      <a href="index.html">Link with asterisk * and another *</a><br/>
+      <a href="index.html">Link with Unicode äöüÄÖÜß</a>
+    </div>
+    <div>
+      <a href="target/second.html">
+      	Link with whitespace
+      </a><br/>
+      <a href="target/third.html">
+      	Link with 
+      	whitespace   within
+      </a><br/>
+      <a href="target/first.html" id="bold_id"><b>Link with bolded text</b></a>
+    </div>
+    <div id="first_div">
+      <a href="target/first.html"><img src="robot.png" alt="Image"/></a>
+      <a href="target/first.html">Link</a>
+    </div>
+    <div id="second_div" class="Second Class">
+      <a href="target/second.html"><img src="robot.png" alt="Image"/></a>
+      <a href="target/second.html">Link</a>
+    </div>
+    <a href="index.html" target="_blank">Target opens in new window</a>
+    <h2>Simple Table</h2>
+    <table id="simpleTable" border="1">
+      <tr>
+        <td>simpleTable_A1</td>
+        <td>simpleTable_B1</td>
+        <td>simpleTable_C1</td>
+      </tr>
+      <tr>
+        <td>simpleTable_A2</td>
+        <td>simpleTable_B2</td>
+        <td>simpleTable_C2</td>
+      </tr>
+      <tr>
+        <td>simpleTable_A3</td>
+        <td>simpleTable_B3</td>
+        <td>simpleTable_C3</td>
+      </tr>
+    </table>
+    <h2>Simple Table by Name</h2>
+    <table name="simpleTableName" border="1">
+      <tr>
+        <td>simpleTableName_A1</td>
+        <td>simpleTableName_B1</td>
+        <td>simpleTableName_C1</td>
+      </tr>
+      <tr>
+        <td>simpleTableName_A2</td>
+        <td>simpleTableName_B2</td>
+        <td>simpleTableName_C2</td>
+      </tr>
+      <tr>
+        <td>simpleTableName_A3</td>
+        <td>simpleTableName_B3</td>
+        <td>simpleTableName_C3</td>
+      </tr>
+    </table>
+
+    <h2>Simple Table With Nested Table</h2>
+    <table id="simpleWithNested" border="1">
+      <tr>
+        <td>simpleWithNested_A1</td>
+        <td>simpleWithNested_B1</td>
+        <td>simpleWithNested_C1</td>
+      </tr>
+      <tr>
+        <td>simpleWithNested_A2</td>
+        <td><table id="nestedTable" border="1">
+      <tr>
+        <td>nestedTable_A1</td>
+        <td>nestedTable_B1</td>
+        <td>nestedTable_C1</td>
+      </tr>
+      <tr>
+        <td>nestedTable_A2</td>
+        <td>nestedTable_B2</td>
+        <td>nestedTable_C2</td>
+      </tr>
+      <tr>
+        <td>nestedTable_A3</td>
+        <td>nestedTable_B3</td>
+        <td>nestedTable_C3</td>
+      </tr>
+    </table></td>
+        <td>simpleWithNested_C2</td>
+      </tr>
+      <tr>
+        <td>simpleWithNested_A3</td>
+        <td>simpleWithNested_B3</td>
+        <td>simpleWithNested_C3</td>
+      </tr>
+    </table>
+
+    <h2>Simple Table With Header</h2>
+    <table id="tableWithSingleHeader" border="1">
+      <tr>
+        <th>tableWithSingleHeader_A1</th>
+        <th>tableWithSingleHeader_B1</th>
+        <th>tableWithSingleHeader_C1</th>
+      </tr>
+      <tr>
+        <td>tableWithSingleHeader_A2</td>
+        <td>tableWithSingleHeader_B2</td>
+        <td>tableWithSingleHeader_C2</td>
+      </tr>
+      <tr>
+        <td>tableWithSingleHeader_A3</td>
+        <td>tableWithSingleHeader_B3</td>
+        <td>tableWithSingleHeader_C3</td>
+      </tr>
+    </table>
+
+    <h2>Simple Table With Two Header Rows</h2>
+    <table id="tableWithTwoHeaders" border="1">
+      <tr>
+        <th>tableWithTwoHeaders_A1</th>
+        <th>tableWithTwoHeaders_B1</th>
+        <th>tableWithTwoHeaders_C1</th>
+      </tr>
+      <tr>
+        <th>tableWithTwoHeaders_A2</th>
+        <th>tableWithTwoHeaders_B2</th>
+        <th>tableWithTwoHeaders_C2</th>
+      </tr>
+      <tr>
+        <td>tableWithTwoHeaders_A3</td>
+        <td>tableWithTwoHeaders_B3</td>
+        <td>tableWithTwoHeaders_C3</td>
+      </tr>
+      <tr>
+        <td>tableWithTwoHeaders_A4</td>
+        <td>tableWithTwoHeaders_B4</td>
+        <td>tableWithTwoHeaders_C4</td>
+      </tr>
+    </table>
+
+    <h2>Table with thead, tfoot and tbody sections</h2>
+    <table id="withHeadAndFoot" border="1" rules="groups">
+      <thead>
+        <tr>
+          <th>withHeadAndFoot_AH1</th>
+          <th>withHeadAndFoot_BH1</th>
+          <th>withHeadAndFoot_CH1</th>
+        </tr>
+        <tr>
+          <th>withHeadAndFoot_AH2</th>
+          <th>withHeadAndFoot_BH2</th>
+          <th>withHeadAndFoot_CH2</th>
+        </tr>
+      </thead>
+      <tfoot>
+        <tr>
+          <td>withHeadAndFoot_AF1</td>
+          <td>withHeadAndFoot_BF1</td>
+          <td>withHeadAndFoot_CF1</td>
+        </tr>
+        <tr>
+          <td>withHeadAndFoot_AF2</td>
+          <td>withHeadAndFoot_BF2</td>
+          <td>withHeadAndFoot_CF2</td>
+        </tr>
+      </tfoot>
+      <tbody>
+        <tr>
+          <td>withHeadAndFoot_A1</td>
+          <td>withHeadAndFoot_B1</td>
+          <td>withHeadAndFoot_C1</td>
+        </tr>
+        <tr>
+          <td>withHeadAndFoot_A2</td>
+          <td>withHeadAndFoot_B2</td>
+          <td>withHeadAndFoot_C2</td>
+        </tr>
+        <tr>
+          <td>withHeadAndFoot_A3</td>
+          <td>withHeadAndFoot_B3</td>
+          <td>withHeadAndFoot_C3</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Table With Merged Cells In a Row</h2>
+    <table id="mergedRows" border="1">
+      <tr>
+        <td rowspan="2">mergedRows_A1</td>
+        <td>mergedRows_B1</td>
+        <td>mergedRows_C1</td>
+        <td rowspan="4">mergedRows_D1</td>
+      </tr>
+      <tr>
+        <td rowspan="2">mergedRows_B2</td>
+        <td>mergedRows_C2</td>
+      </tr>
+      <tr>
+    	<td>mergedRows_A3</td>
+        <td>mergedRows_C3</td>
+      </tr>
+    </table>
+
+    <h2>Table With Merged Cells In a Column</h2>
+    <table id="mergedCols" border="1">
+      <tr>
+        <td colspan="2">mergedCols_A1</td>
+        <td>mergedCols_C1</td>
+      </tr>
+      <tr>
+        <td>mergedCols_A2</td>
+        <td colspan="2">mergedCols_B2</td>
+      </tr>
+      <tr>
+        <td>mergedCols_A3</td>
+        <td>mergedCols_B3</td>
+        <td>mergedCols_C3</td>
+      </tr>
+      <tr>
+        <td colspan="4">mergedCols_D1</td>
+      </tr>
+    </table>
+
+    <h2 class="someClass">Table With Formatting and Unicode</h2>
+    <table><tr><td>dummy Table</td></tr></table>
+    <table><tr><td>dummy Table</td></tr></table>
+    <table id="formattedTable" border="1">
+      <tr>
+        <td><strong>formattedTable_A1</strong></td>
+        <td><b>formattedTable_B1</b></td>
+        <td><i>formattedTable_C1</i></td>
+        <td><strong>form<b>atted</b><i>Table_</i></strong>D1</td>
+      </tr>
+      <tr>
+        <td><h2>formattedTable_A2</h2></td>
+        <td><a href="../index.html">formattedTable_B2</a></td>
+        <td>formattedTable_ÄÖÜäöüß</td>
+        <td>&auml;&ouml;&uuml;&euro;&amp;äöü€&</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/test/resources/html/tables/tables.html
+++ b/test/resources/html/tables/tables.html
@@ -4,6 +4,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <title>Tables</title>
+<script src="http://code.jquery.com/jquery-1.9.1.min.js" type="text/javascript"></script>
 </head>
 <body>
 <h2>Simple Table</h2>

--- a/test/resources/html/tables/tables.html
+++ b/test/resources/html/tables/tables.html
@@ -4,7 +4,6 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <title>Tables</title>
-<script src="http://code.jquery.com/jquery-1.9.1.min.js" type="text/javascript"></script>
 </head>
 <body>
 <h2>Simple Table</h2>


### PR DESCRIPTION
This allows "jquery" and "sizzle" locator prefixes, which delegate to the window's jQuery.  Probably not suitable for merging as-is; I think it would be better if jQuery was provided by selenium2library.

But it is easy and probably\* works, so I thought I'd share.  Maybe it will inspire someone to enhance it.
- I have the change working on a work computer, but due to in-house restrictions, I had to type it in by hand on another computer in order to push to github.  The other computer doesn't have robot, so I haven't actually tested the re-typed-in code.... sorry!
