### PR TITLE
Allow desired_capabilities= to be a dictionary

### DIFF
--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -88,9 +88,10 @@ class _BrowserManagementKeywords(KeywordGroup):
         http://127.0.0.1/wd/hub.  If you specify a value for remote you can
         also specify 'desired_capabilities' which is a string in the form
         key1:val1,key2:val2 that will be used to specify desired_capabilities
-        to the remote server.  This is useful for doing things like specify a
+        to the remote server. This is useful for doing things like specify a
         proxy server for internet explorer or for specify browser and os if your
-        using saucelabs.com.
+        using saucelabs.com. 'desired_capabilities' can also be a dictonary
+        (created with 'Create Dictionary') to allow for more complex configurations.
 
         Optional 'ff_profile_dir' is the path to the firefox profile dir if you
         wish to overwrite the default.
@@ -454,17 +455,31 @@ class _BrowserManagementKeywords(KeywordGroup):
     
 
     def _create_remote_web_driver(self , capabilities_type , remote_url , desired_capabilities=None , profile=None):
+        '''parses the string based desired_capabilities if neccessary and
+        creates the associated remote web driver'''
+
+        desired_capabilities_object = capabilities_type
+
+        if type(desired_capabilities) in (str, unicode):
+            desired_capabilities = self._parse_capabilities_string(desired_capabilities)
+
+        desired_capabilities_object.update(desired_capabilities or {})
+
+        return webdriver.Remote(desired_capabilities=desired_capabilities_object,
+                command_executor=str(remote_url), browser_profile=profile)
+
+    def _parse_capabilities_string(self, capabilities_string):
         '''parses the string based desired_capabilities which should be in the form
-        key1:val1,key2:val2 and creates the associated remote web driver'''
-        desired_cap = self._create_desired_capabilities(capabilities_type , desired_capabilities)
-        return webdriver.Remote(desired_capabilities=desired_cap , command_executor=str(remote_url) ,                                       browser_profile=profile)
+        key1:val1,key2:val2
+        '''
+        desired_capabilities = {}
 
+        if not capabilities_string:
+            return desired_capabilities
 
-    def _create_desired_capabilities(self, capabilities_type, capabilities_string):
-        desired_capabilities = capabilities_type
-        if capabilities_string:
-            for cap in capabilities_string.split(","):
-                (key, value) = cap.split(":")
-                desired_capabilities[key.strip()] = value.strip()
+        for cap in capabilities_string.split(","):
+            (key, value) = cap.split(":")
+            desired_capabilities[key.strip()] = value.strip()
+
         return desired_capabilities
     

--- a/test/unit/keywords/test_browsermanagement.py
+++ b/test/unit/keywords/test_browsermanagement.py
@@ -41,16 +41,20 @@ class BrowserManagementTests(unittest.TestCase):
     def test_create_htmlunitwihtjs_browser(self):
         self.verify_browser(webdriver.Remote, "htmlunitwithjs")
 
-    def test_create_desired_capabilities(self):
+    def test_parse_capabilities_string(self):
         bm = _BrowserManagementKeywords()
         expected_caps = "key1:val1,key2:val2"
-        capabilities = bm._create_desired_capabilities(webdriver.DesiredCapabilities.CHROME, expected_caps)
-        self.assertTrue(type(capabilities), webdriver.DesiredCapabilities.CHROME)
+        capabilities = bm._parse_capabilities_string(expected_caps)
         self.assertTrue("val1", capabilities["key1"])
         self.assertTrue("val2", capabilities["key2"])
         self.assertTrue(2, len(capabilities))
 
     def test_create_remote_browser_with_desired_prefs(self):
+        expected_caps = {"key1":"val1","key2":"val2"}
+        self.verify_browser(webdriver.Remote, "chrome", remote="http://127.0.0.1/wd/hub",
+            desired_capabilities=expected_caps)
+
+    def test_create_remote_browser_with_string_desired_prefs(self):
         expected_caps = "key1:val1,key2:val2"
         self.verify_browser(webdriver.Remote, "chrome", remote="http://127.0.0.1/wd/hub",
             desired_capabilities=expected_caps)


### PR DESCRIPTION
This should address the motivation described at https://github.com/rtomac/robotframework-selenium2library/issues/139#issuecomment-12780551.
