### PR TITLE
Support checking enabled/disabled state of option elements

### DIFF
--- a/src/Selenium2Library/keywords/_formelement.py
+++ b/src/Selenium2Library/keywords/_formelement.py
@@ -328,4 +328,4 @@ class _FormElementKeywords(KeywordGroup):
         if element is None:
             return False
         tag = element.tag_name.lower()
-        return tag == 'input' or tag == 'select' or tag == 'textarea' or tag == 'button'
+        return tag == 'input' or tag == 'select' or tag == 'textarea' or tag == 'button' or tag == 'option'

--- a/test/acceptance/keywords/element_should_be_enabled_and_disabled.txt
+++ b/test/acceptance/keywords/element_should_be_enabled_and_disabled.txt
@@ -26,6 +26,10 @@ Button
     Should Be Enabled Not Disabled  enabled_button
     Should Be Disabled Not Enabled  disabled_button
 
+Option
+    Should Be Enabled Not Disabled  enabled_option
+    Should Be Disabled Not Enabled  disabled_option
+
 Disabled with different syntaxes
     Should Be Disabled Not Enabled  disabled_only
     Should Be Disabled Not Enabled  disabled_with_equals_sign

--- a/test/resources/html/forms/enabled_disabled_fields_form.html
+++ b/test/resources/html/forms/enabled_disabled_fields_form.html
@@ -35,6 +35,12 @@
 	<tr>
 	  <td colspan="2"><input type="submit" name="disabled_input_button" value="disabled" disabled="disabled"/></td>
 	</tr>
+        <tr>
+          <td colspan="2"><select name="select">
+            <option id="enabled_option" value="enabled">Enabled</option>
+            <option id="disabled_option" value="disabled" disabled="disabled>Disabled</option>
+          </select></td>
+        </tr>
       </table>
     </form>
     <table border="0">


### PR DESCRIPTION
This patch makes it possible to detect enabled/disabled options, like <option disabled="disabled">, with "Element Should Be Enabled/Disabled" keywords.
