### PR TITLE
fix click image locator by 'src' and 'alt'

### DIFF
--- a/src/Selenium2Library/locators/elementfinder.py
+++ b/src/Selenium2Library/locators/elementfinder.py
@@ -12,6 +12,8 @@ class ElementFinder(object):
             'link': self._find_by_link_text,
             'css': self._find_by_css_selector,
             'tag': self._find_by_tag_name,
+            'src': self._find_by_default,
+            'alt': self._find_by_default,
             None: self._find_by_default
         }
 


### PR DESCRIPTION
@rtomac @emanlove @j1z0 
I found 2 way to fix this issue #181.
1. add src and alt in self._strategies
2. add if before self._strategies.get(prefix), if prefix is src or alt,
then make it to None.
I choose the 1. 
