### PR TITLE
Non-breaking spaces should be treated as usual spaces

### DIFF
--- a/test/acceptance/keywords/content_assertions.txt
+++ b/test/acceptance/keywords/content_assertions.txt
@@ -218,3 +218,7 @@ Xpath Should Match X Times
     Xpath Should Match X Times  //input[@type="text"]  ${1}
     Run Keyword And Expect Error  Xpath //input[@type="text"] should have matched 2 times but matched 1 times  Xpath Should Match X Times  //input[@type="text"]  2
 
+Non-breaking spaces should be treated as ususal spaces
+    [Setup]  Go To Page "non_ascii.html"
+    Page Should Contain  Non-breaking space
+

--- a/test/resources/html/non_ascii.html
+++ b/test/resources/html/non_ascii.html
@@ -26,5 +26,6 @@
 <li>здравствуйте
 <li>こんにちは
 </ul>
+<p>Non-breaking&nbsp;space</p>
 </body>
 </html>


### PR DESCRIPTION
Hello!

We're trying to move our tests from SeleniumLibrary to Selenium2Library. But we've found that our tests are failing on checks upon elements that contain non-breakable spaces (which works fine with SeleniumLibrary).

Here I provide the simplest test case that demonstrates that behavior. I have no fix yet, but I'll try to provide it ASAP. Maybe you can suggest the way I should follow to fix this (it would be great!).
