### PR TITLE
Adds support for the PhantomJS browser

### DIFF
--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -17,6 +17,7 @@ BROWSER_NAMES = {'ff': "_make_ff",
                  'gc': "_make_chrome",
                  'chrome': "_make_chrome",
                  'opera' : "_make_opera",
+                 'phantomjs' : "_make_phantomjs",
                  'htmlunit' : "_make_htmlunit",
                  'htmlunitwithjs' : "_make_htmlunitwithjs"
                 }
@@ -74,6 +75,7 @@ class _BrowserManagementKeywords(KeywordGroup):
         | gc               | Google Chrome |
         | chrome           | Google Chrome |
         | opera            | Opera         |
+        | phantomjs        | PhantomJS     |
         | htmlunit         | HTMLUnit      |
         | htmlunitwithjs   | HTMLUnit with Javascipt support |
         
@@ -433,6 +435,10 @@ class _BrowserManagementKeywords(KeywordGroup):
     def _make_opera(self , remote , desired_capabilities , profile_dir):
         return self._generic_make_browser(webdriver.Opera, 
                 webdriver.DesiredCapabilities.OPERA, remote, desired_capabilities)
+
+    def _make_phantomjs(self , remote , desired_capabilities , profile_dir):
+        return self._generic_make_browser(webdriver.PhantomJS, 
+                webdriver.DesiredCapabilities.PHANTOMJS, remote, desired_capabilities)
 
     def _make_htmlunit(self , remote , desired_capabilities , profile_dir):
         return self._generic_make_browser(webdriver.Remote, 

--- a/test/unit/keywords/test_browsermanagement.py
+++ b/test/unit/keywords/test_browsermanagement.py
@@ -32,6 +32,9 @@ class BrowserManagementTests(unittest.TestCase):
     def test_create_opera_browser(self):
         self.verify_browser(webdriver.Opera, "OPERA")
 
+    def test_create_phantomjs_browser(self):
+        self.verify_browser(webdriver.PhantomJS, "PHANTOMJS")
+
     def test_create_remote_browser(self):
         self.verify_browser(webdriver.Remote, "chrome", remote="http://127.0.0.1/wd/hub")
 


### PR DESCRIPTION
Selenium now has native support for the PhantomJS driver "ghostdriver" (webdriver.PhantomJS).  This pull request adds the appropriate method to _browsermanagemnet as well as a unittest.

This change allows Robotframework-selenium2library users to use phantomjs (installed separately) as a browser type.  e.g.:

```
Open Browser    http://google.com    phantomjs
```

PhantomJS can be installed from http://phantomjs.org/download.html
