### PR TITLE
Fixed bad browser name raising AttributeError.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Release Notes
 
 1.4 (unreleased)
 -----------------
+- Fixed bad browser name raising AttributeError.
+  [ombre42]
+
 - Raise exception in selecting non-existing item in list. Error handling varies
   between single-select and multi-select lists. See keyword documentation for
   more information.

--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -415,22 +415,18 @@ class _BrowserManagementKeywords(KeywordGroup):
             raise RuntimeError('No browser is open')
         return self._cache.current
 
-    def _get_browser_token(self, browser_name):
-        return BROWSER_NAMES.get(browser_name.lower().replace(' ', ''), browser_name)
+    def _get_browser_creation_function(self, browser_name):
+        func_name = BROWSER_NAMES.get(browser_name.lower().replace(' ', ''))
+        return getattr(self, func_name) if func_name else None
 
-
-    def _get_browser_creation_function(self,browser_name):
-        return BROWSER_NAMES.get(browser_name.lower().replace(' ', ''), browser_name)
-
-    def _make_browser(self , browser_name , desired_capabilities=None , profile_dir=None,
-                    remote=None):
-
+    def _make_browser(self, browser_name, desired_capabilities=None,
+                      profile_dir=None, remote=None):
         creation_func = self._get_browser_creation_function(browser_name)
-        browser = getattr(self,creation_func)(remote , desired_capabilities , profile_dir)
 
-        if browser is None:
+        if not creation_func:
             raise ValueError(browser_name + " is not a supported browser.")
 
+        browser = creation_func(remote, desired_capabilities, profile_dir)
         browser.set_speed(self._speed_in_secs)
         browser.set_script_timeout(self._timeout_in_secs)
         browser.implicitly_wait(self._implicit_wait_in_secs)

--- a/test/unit/keywords/test_browsermanagement.py
+++ b/test/unit/keywords/test_browsermanagement.py
@@ -77,6 +77,13 @@ class BrowserManagementTests(unittest.TestCase):
         verifyNoMoreInteractions(first_browser)
         verifyNoMoreInteractions(second_browser)
 
+    def test_bad_browser_name(self):
+        bm = _BrowserManagementKeywords()
+        try:
+            bm._make_browser("fireox")
+            self.fail("Exception not raised")
+        except ValueError, e:
+            self.assertEquals("fireox is not a supported browser.", e.message)
 
     def verify_browser(self , webdriver_type , browser_name, **kw):
         #todo try lambda *x: was_called = true


### PR DESCRIPTION
Fix for bad browser name raising AttributeError: 'Selenium2Library'
object has no attribute 'fireox' instead of ValueError: fireox is not a
supported browser.
PEP8 near code change and some housekeeping
