### PR TITLE
Fixed Mouse Up keyword attempting to click and hold one more time before release

### DIFF
--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -274,7 +274,7 @@ class _ElementKeywords(KeywordGroup):
 
     def click_element_at_coordinates(self, locator, xoffset, yoffset):
         """Click element identified by `locator` at x/y coordinates of the element.
-        Cursor is moved and the center of the element and x/y coordinates are 
+        Cursor is moved and the center of the element and x/y coordinates are
         calculted from that point.
 
         Key attributes for arbitrary elements are `id` and `name`. See
@@ -384,7 +384,7 @@ class _ElementKeywords(KeywordGroup):
         element = self._element_find(locator, True, False)
         if element is None:
             raise AssertionError("ERROR: Element %s not found." % (locator))
-        ActionChains(self._current_browser()).click_and_hold(element).release(element).perform()
+        ActionChains(self._current_browser()).release(element).perform()
 
     def open_context_menu(self, locator):
         """Opens context menu on element identified by `locator`."""

--- a/test/acceptance/keywords/click_element_at_coordinates.txt
+++ b/test/acceptance/keywords/click_element_at_coordinates.txt
@@ -7,8 +7,8 @@ Resource          ../resource.txt
 Click Element At Coordinates
     [Documentation]    LOG 2 Click clicking element 'Clickable' in coordinates '10', '20'. 
     Click Element At Coordinates    Clickable    ${10}   ${20}
-    Element Text Should Be    outputX    10
-    Element Text Should Be    outputY    20
+    Element Text Should Be    outputX    110
+    Element Text Should Be    outputY    120
 
 *** Keywords ***
 Initialize page

--- a/test/acceptance/keywords/javascript.txt
+++ b/test/acceptance/keywords/javascript.txt
@@ -29,9 +29,11 @@ Mouse Down On Link
     [Setup]  Go To Page "javascript/mouse_events.html"
     Mouse Down On Image  image_mousedown
     Text Field Should Contain  textfield  onmousedown
+    Mouse Up  image_mousedown
     Input text  textfield  ${EMPTY}
-    Mouse Down On Link  onmousedown
+    Mouse Down On Link  link_mousedown
     Text Field Should Contain  textfield  onmousedown
+    Mouse Up  link_mousedown
 
 Confirm Action
     Click Button  Change the title

--- a/test/acceptance/keywords/lists.txt
+++ b/test/acceptance/keywords/lists.txt
@@ -99,7 +99,7 @@ Select Non-Existing Item From Multi-Selection List
     ...  Select From List  possible_channels  Tin Can Phone  Email  Smoke Signals
  
 Unselect Non-Existing Item From List
-    [Documentation]  LOG 5 Unselecting non-existing items will not throw an error.
+    [Documentation]  LOG 3 Unselecting option(s) 'Tin Can Phone, Smoke Signals, Email' from list 'possible_channels'.
     [Tags]  OnlyThisOne
     Unselect From List  possible_channels  Tin Can Phone  Smoke Signals
     Unselect From List  possible_channels  Tin Can Phone  Smoke Signals  Email

--- a/test/resources/html/javascript/mouse_events.html
+++ b/test/resources/html/javascript/mouse_events.html
@@ -16,11 +16,11 @@
   <img src="foo.jpg" id="image_mousedown" />
 </a>
 
-<a href="javascript:void(0);" 
+<a id="link" href="javascript:void(0);" 
    onclick="document.forms[0].textfield.value='onclick';return false;" 
    onmousedown="document.forms[0].textfield.value='onmousedown';return false;">both</a>
 
-<a href="javascript:void(0);" 
+<a id="link_mousedown" href="javascript:void(0);" 
    onmousedown="document.forms[0].textfield.value='onmousedown';return false;">onmousedown</a>
 
 </body>


### PR DESCRIPTION
I've almost fixed all failing tests, please take a look at the details below:
1. Fixed Mouse Up keyword attempting to `click_and_hold` before `release` therefore emitting `mousedown` event;
2. Fixed `Unselect Non-Existing Item From List` test post-processing `LOG` command failing with wrong keyword index;
3. Refactored `Mouse Down On Link` test to be clearer;
4. Updated `Click Element At Coordinates` test with more "expected" coordinates.

Also I would like you to take a look at `Click Element At Coordinates` test one more time. It seems to me that selenium doesn't perform `move_to_element.move_by_offset.click` action chain well. I've submitted the issue on [google code](http://code.google.com/p/selenium/issues/detail?id=6370). Actually it's the last issue remained, and it would be really cool to get it fixed soon.
