### PR TITLE
Implement 'Create Webdriver' keyword

### DIFF
--- a/test/acceptance/create_webdriver.txt
+++ b/test/acceptance/create_webdriver.txt
@@ -1,0 +1,29 @@
+*Setting*
+Suite Teardown  Close All Browsers
+Resource  resource.txt
+
+
+*Test Cases*
+
+Create Webdriver Creates Functioning WebDriver
+  [Documentation]  LOG 1:1 INFO Creating an instance of the Firefox WebDriver LOG 1:3 DEBUG REGEXP: Created Firefox WebDriver instance with session id (\\w|-)+
+  ${index}=  Create Webdriver  Firefox  firefox
+  Go To  ${FRONT PAGE}
+  Page Should Contain  needle
+  ${index as int}=  Convert To Integer  ${index}
+  Should Be Equal  ${index}  ${index as int}
+  [Teardown]  Close Browser
+
+Create Webdriver With Missing Value
+  Run Keyword And Expect Error  There should be an even number of parameter name-value pairs.  Create Webdriver  Firefox  firefox  proxy
+
+Create Webdriver With WebDriver Argument
+  ${proxy}=  Evaluate  sys.modules['selenium.webdriver'].Proxy()  sys, selenium.webdriver
+  ${proxy.http_proxy}=  Set Variable  localhost:7777
+  Create Webdriver  Firefox  firefox  proxy  ${proxy}
+  Go To  ${FRONT PAGE}
+  Page Should Contain  The proxy server is refusing connections
+  [Teardown]  Close Browser
+
+Create Webdriver With Bad Driver Name
+  Run Keyword And Expect Error  'Fireox' is not a valid WebDriver name  Create Webdriver  Fireox

--- a/test/acceptance/create_webdriver.txt
+++ b/test/acceptance/create_webdriver.txt
@@ -5,8 +5,8 @@ Library  Collections
 *Test Cases*
 Create Webdriver Creates Functioning WebDriver
   [Documentation]  LOG 2:1 INFO REGEXP: Creating an instance of the \\w+ WebDriver LOG 2:3 DEBUG REGEXP: Created \\w+ WebDriver instance with session id (\\w|-)+
-  [Setup]  Set Driver Name
-  Create Webdriver  ${DRIVER NAME}  createwebdriver
+  [Setup]  Set Driver Variables
+  Create Webdriver  ${DRIVER_NAME}  kwargs=${KWARGS}
   Go To  ${FRONT PAGE}
   Page Should Contain  needle
   [Teardown]  Close Browser
@@ -22,7 +22,14 @@ Create Webdriver With Bad Keyword Argument Dictionary
   Run Keyword And Expect Error  kwargs must be a dictionary.  Create Webdriver  Firefox  kwargs={'spam': 'eggs'}
 
 *Keywords*
-Set Driver Name
-  ${drivers}=  Create Dictionary  firefox  Firefox  ie  Ie  internetexplorer  Ie  googlechrome  Chrome  gc  Chrome  opera  Opera  phantomjs  PhantomJS  safari  Safari
-  ${name}=  Get From Dictionary  ${drivers}  ${browser.lower().replace(' ', '')}
-  Set Test Variable  ${DRIVER NAME}  ${name}
+Set Driver Variables
+  ${drivers}=  Create Dictionary  ff  Firefox  firefox  Firefox  ie  Ie  internetexplorer  Ie  googlechrome  Chrome  gc  Chrome  chome  Chrome  opera  Opera  phantomjs  PhantomJS  safari  Safari
+  ${name}=  Evaluate  "Remote" if "${REMOTE_URL}"!="None" else ${drivers}["${BROWSER.lower().replace(' ', '')}"]
+  Set Test Variable  ${DRIVER_NAME}  ${name}
+  ${dc names}=  Create Dictionary  ff  FIREFOX  firefox  FIREFOX  ie  INTERNETEXPLORER  internetexplorer  INTERNETEXPLORER  googlechrome  CHROME  gc  CHROME  opera  OPERA  phantomjs  PHANTOMJS  htmlunit  HTMLUNIT  htmlunitwithjs  HTMLUNITWITHJS  android  ANDROID  iphone  IPHONE  safari  SAFARI
+  ${dc name}=  Get From Dictionary  ${dc names}  ${BROWSER.lower().replace(' ', '')}
+  ${caps}=  Evaluate  sys.modules['selenium.webdriver'].DesiredCapabilities.${dc name}  selenium.webdriver,sys
+  ${url as str}=  Evaluate  str('${REMOTE_URL}')  # cannot be unicode for several versions >= 2.32
+  ${kwargs}=  Create Dictionary
+  Run Keyword If  "${name}"=="Remote"  Set To Dictionary  ${kwargs}  command_executor  ${url as str}  desired_capabilities  ${caps}
+  Set Test Variable  ${KWARGS}  ${kwargs}

--- a/test/acceptance/create_webdriver.txt
+++ b/test/acceptance/create_webdriver.txt
@@ -1,35 +1,30 @@
 *Setting*
 Suite Teardown  Close All Browsers
 Resource  resource.txt
-
+Library  Collections
 
 *Test Cases*
-
 Create Webdriver Creates Functioning WebDriver
   [Documentation]  LOG 1:1 INFO Creating an instance of the Firefox WebDriver LOG 1:3 DEBUG REGEXP: Created Firefox WebDriver instance with session id (\\w|-)+
-  ${index}=  Create Webdriver  Firefox  firefox
+  ${index}=  Create Webdriver  Firefox  createwebdriver
   Go To  ${FRONT PAGE}
   Page Should Contain  needle
   ${index as int}=  Convert To Integer  ${index}
   Should Be Equal  ${index}  ${index as int}
-  Switch Browser  firefox
+  Switch Browser  createwebdriver
   [Teardown]  Close Browser
 
-Create Webdriver With Missing Value
-  Run Keyword And Expect Error  There should be an even number of argument name-value pairs.  Create Webdriver  Firefox  firefox  proxy
-
 Create Webdriver With Keyword Argument
-  ${proxy}=  Evaluate  sys.modules['selenium.webdriver'].Proxy()  sys, selenium.webdriver
-  ${proxy.http_proxy}=  Set Variable  localhost:7777
+  ${proxy}=  Create Bad Proxy
   Create Webdriver  Firefox  proxy=${proxy}
   Go To  ${FRONT PAGE}
   Page Should Contain  The proxy server is refusing connections
   [Teardown]  Close Browser
 
-Create Webdriver With List Argument
-  ${proxy}=  Evaluate  sys.modules['selenium.webdriver'].Proxy()  sys, selenium.webdriver
-  ${proxy.http_proxy}=  Set Variable  localhost:7777
-  Create Webdriver  Firefox  firefox  proxy  ${proxy}
+Create Webdriver With Keyword Argument Dictionary
+  ${proxy}=  Create Bad Proxy
+  ${kwargs}=  Create Dictionary  proxy  ${proxy}
+  Create Webdriver  Firefox  kwargs=${kwargs}
   Go To  ${FRONT PAGE}
   Page Should Contain  The proxy server is refusing connections
   [Teardown]  Close Browser
@@ -38,6 +33,14 @@ Create Webdriver With Bad Driver Name
   Run Keyword And Expect Error  'Fireox' is not a valid WebDriver name  Create Webdriver  Fireox
 
 Create Webdriver With Duplicate Arguments
-  Run Keyword And Expect Error  Got multiple values for argument 'arg'.  Create Webdriver  Firefox  firefox  arg  1  arg=2
-  Run Keyword And Expect Error  Got multiple values for argument 'arg'.  Create Webdriver  Firefox  firefox  arg  1  arg  2
-  
+  ${kwargs}=  Create Dictionary  arg  1
+  Run Keyword And Expect Error  Got multiple values for argument 'arg'.  Create Webdriver  Firefox  kwargs=${kwargs}  arg=2
+
+Create Webdriver With Bad Keyword Argument Dictionary
+  Run Keyword And Expect Error  kwargs must be a dictionary.  Create Webdriver  Firefox  kwargs={'spam': 'eggs'}
+
+*Keywords*
+Create Bad Proxy
+  ${proxy}=  Evaluate  sys.modules['selenium.webdriver'].Proxy()  sys, selenium.webdriver
+  ${proxy.http_proxy}=  Set Variable  localhost:7777
+  [Return]  ${proxy}

--- a/test/acceptance/create_webdriver.txt
+++ b/test/acceptance/create_webdriver.txt
@@ -1,32 +1,14 @@
 *Setting*
-Suite Teardown  Close All Browsers
 Resource  resource.txt
 Library  Collections
 
 *Test Cases*
 Create Webdriver Creates Functioning WebDriver
-  [Documentation]  LOG 1:1 INFO Creating an instance of the Firefox WebDriver LOG 1:3 DEBUG REGEXP: Created Firefox WebDriver instance with session id (\\w|-)+
-  ${index}=  Create Webdriver  Firefox  createwebdriver
+  [Documentation]  LOG 2:1 INFO REGEXP: Creating an instance of the \\w+ WebDriver LOG 2:3 DEBUG REGEXP: Created \\w+ WebDriver instance with session id (\\w|-)+
+  [Setup]  Set Driver Name
+  Create Webdriver  ${DRIVER NAME}  createwebdriver
   Go To  ${FRONT PAGE}
   Page Should Contain  needle
-  ${index as int}=  Convert To Integer  ${index}
-  Should Be Equal  ${index}  ${index as int}
-  Switch Browser  createwebdriver
-  [Teardown]  Close Browser
-
-Create Webdriver With Keyword Argument
-  ${proxy}=  Create Bad Proxy
-  Create Webdriver  Firefox  proxy=${proxy}
-  Go To  ${FRONT PAGE}
-  Page Should Contain  The proxy server is refusing connections
-  [Teardown]  Close Browser
-
-Create Webdriver With Keyword Argument Dictionary
-  ${proxy}=  Create Bad Proxy
-  ${kwargs}=  Create Dictionary  proxy  ${proxy}
-  Create Webdriver  Firefox  kwargs=${kwargs}
-  Go To  ${FRONT PAGE}
-  Page Should Contain  The proxy server is refusing connections
   [Teardown]  Close Browser
 
 Create Webdriver With Bad Driver Name
@@ -40,7 +22,7 @@ Create Webdriver With Bad Keyword Argument Dictionary
   Run Keyword And Expect Error  kwargs must be a dictionary.  Create Webdriver  Firefox  kwargs={'spam': 'eggs'}
 
 *Keywords*
-Create Bad Proxy
-  ${proxy}=  Evaluate  sys.modules['selenium.webdriver'].Proxy()  sys, selenium.webdriver
-  ${proxy.http_proxy}=  Set Variable  localhost:7777
-  [Return]  ${proxy}
+Set Driver Name
+  ${drivers}=  Create Dictionary  firefox  Firefox  ie  Ie  internetexplorer  Ie  googlechrome  Chrome  gc  Chrome  opera  Opera  phantomjs  PhantomJS  safari  Safari
+  ${name}=  Get From Dictionary  ${drivers}  ${browser.lower().replace(' ', '')}
+  Set Test Variable  ${DRIVER NAME}  ${name}

--- a/test/acceptance/create_webdriver.txt
+++ b/test/acceptance/create_webdriver.txt
@@ -12,12 +12,21 @@ Create Webdriver Creates Functioning WebDriver
   Page Should Contain  needle
   ${index as int}=  Convert To Integer  ${index}
   Should Be Equal  ${index}  ${index as int}
+  Switch Browser  firefox
   [Teardown]  Close Browser
 
 Create Webdriver With Missing Value
-  Run Keyword And Expect Error  There should be an even number of parameter name-value pairs.  Create Webdriver  Firefox  firefox  proxy
+  Run Keyword And Expect Error  There should be an even number of argument name-value pairs.  Create Webdriver  Firefox  firefox  proxy
 
-Create Webdriver With WebDriver Argument
+Create Webdriver With Keyword Argument
+  ${proxy}=  Evaluate  sys.modules['selenium.webdriver'].Proxy()  sys, selenium.webdriver
+  ${proxy.http_proxy}=  Set Variable  localhost:7777
+  Create Webdriver  Firefox  proxy=${proxy}
+  Go To  ${FRONT PAGE}
+  Page Should Contain  The proxy server is refusing connections
+  [Teardown]  Close Browser
+
+Create Webdriver With List Argument
   ${proxy}=  Evaluate  sys.modules['selenium.webdriver'].Proxy()  sys, selenium.webdriver
   ${proxy.http_proxy}=  Set Variable  localhost:7777
   Create Webdriver  Firefox  firefox  proxy  ${proxy}
@@ -27,3 +36,8 @@ Create Webdriver With WebDriver Argument
 
 Create Webdriver With Bad Driver Name
   Run Keyword And Expect Error  'Fireox' is not a valid WebDriver name  Create Webdriver  Fireox
+
+Create Webdriver With Duplicate Arguments
+  Run Keyword And Expect Error  Got multiple values for argument 'arg'.  Create Webdriver  Firefox  firefox  arg  1  arg=2
+  Run Keyword And Expect Error  Got multiple values for argument 'arg'.  Create Webdriver  Firefox  firefox  arg  1  arg  2
+  

--- a/test/unit/keywords/test_browsermanagement.py
+++ b/test/unit/keywords/test_browsermanagement.py
@@ -85,6 +85,27 @@ class BrowserManagementTests(unittest.TestCase):
         except ValueError, e:
             self.assertEquals("fireox is not a supported browser.", e.message)
 
+    def test_create_webdriver(self):
+        bm = _BrowserManagementWithLoggingStubs()
+        capt_data = {}
+        class FakeWebDriver(mock):
+            def __init__(self, some_arg=None):
+                mock.__init__(self)
+                capt_data['some_arg'] = some_arg
+                capt_data['webdriver'] = self
+        webdriver.FakeWebDriver = FakeWebDriver
+        try:
+            index = bm.create_webdriver('FakeWebDriver', some_arg=1)
+            self.assertEquals(capt_data['some_arg'], 1)
+            self.assertEquals(capt_data['webdriver'], bm._current_browser())
+            self.assertEquals(capt_data['webdriver'], bm._cache.get_connection(index))
+            capt_data.clear()
+            my_kwargs = {'some_arg':2}
+            bm.create_webdriver('FakeWebDriver', kwargs=my_kwargs)
+            self.assertEquals(capt_data['some_arg'], 2)
+        finally:
+            del webdriver.FakeWebDriver
+
     def verify_browser(self , webdriver_type , browser_name, **kw):
         #todo try lambda *x: was_called = true
         bm = _BrowserManagementKeywords()
@@ -104,4 +125,11 @@ class BrowserManagementTests(unittest.TestCase):
         self.was_called = True
 
 
+class _BrowserManagementWithLoggingStubs(_BrowserManagementKeywords):
 
+    def __init__(self):
+        _BrowserManagementKeywords.__init__(self)
+        def mock_logging_method(self, *args, **kwargs):
+            pass
+        for name in ['_info', '_debug', '_warn', '_log', '_html']:
+            setattr(self, name, mock_logging_method)

--- a/test/unit/keywords/test_browsermanagement.py
+++ b/test/unit/keywords/test_browsermanagement.py
@@ -95,10 +95,11 @@ class BrowserManagementTests(unittest.TestCase):
                 capt_data['webdriver'] = self
         webdriver.FakeWebDriver = FakeWebDriver
         try:
-            index = bm.create_webdriver('FakeWebDriver', some_arg=1)
+            index = bm.create_webdriver('FakeWebDriver', 'fake', some_arg=1)
             self.assertEquals(capt_data['some_arg'], 1)
             self.assertEquals(capt_data['webdriver'], bm._current_browser())
             self.assertEquals(capt_data['webdriver'], bm._cache.get_connection(index))
+            self.assertEquals(capt_data['webdriver'], bm._cache.get_connection('fake'))
             capt_data.clear()
             my_kwargs = {'some_arg':2}
             bm.create_webdriver('FakeWebDriver', kwargs=my_kwargs)


### PR DESCRIPTION
Please review this commit carefully.
I wish this keyword was not needed, but I do not see the Selenium team moving all options to a desired capabilities argument anytime soon. This keyword will close many issues people have with using a proxy.

A URL parameter is intentionally omitted because an initial get() is not always appropriate (native app testing w/ Appium).

As is, argument names are not checked through reflection and Python will throw an error like:
`TypeError: __init__() got an unexpected keyword argument 'bad_arg_name'.`
Let me know if this is not OK.

possible enancements I can implement if desired:
normalizing argument names and/or WebDriver names and matching via reflection. I did not do this because BuiltIn's Call Method does not do this and this keyword is for advanced users.

possible issues:
The tests will try and launch Firefox even if you call run_tests with another browser.
I tried to test through unit testing, but had problems because the _LoggingKeywords mix-in was not present.
