### PR TITLE
Implemented "Shift Click Element" keyword

### DIFF
--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -272,20 +272,29 @@ class _ElementKeywords(KeywordGroup):
         self._info("Clicking element '%s'." % locator)
         self._element_find(locator, True, True).click()
 
-    def shift_click_element(self, locator):
-        """Shift-Click element identified by `locator`. Simulates holding down
-        the Shift key while clicking an element.
+    def key_click_element(self, keyname, locator):
+        """Click element identified by `locator` while holding down a key.
+        The 'keyname' value should be expressed as a Keys constant as specified
+        in the selenium.webdriver.common.keys module.
 
         Key attributes for arbitrary elements are `id` and `name`. See
         `introduction` for details about locating elements.
+        
+        Example:
+        | Key Click Element | CONTROL | id=downloadLink |
         """
-        self._info("Shift-Clicking element '%s'." % locator)
+        self._info("Clicking element '%s' while holding down the '%s' key." % (locator, keyname))
+        
+        # get the key code which corresponds to the passed key name
+        # invalid values will fail here (but meaningfully)
+        key = eval("Keys." + keyname)
+        
         element = self._element_find(locator, True, True)
-        # press the Shift key
-        ActionChains(self._current_browser()).key_down(Keys.SHIFT)
+        # press the key
+        ActionChains(self._current_browser()).key_down(key)
         element.click()
-        # release the Shift key
-        ActionChains(self._current_browser()).key_up(Keys.SHIFT)
+        # release the key
+        ActionChains(self._current_browser()).key_up(key)
 
     def click_element_at_coordinates(self, locator, xoffset, yoffset):
         """Click element identified by `locator` at x/y coordinates of the element.

--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -272,6 +272,21 @@ class _ElementKeywords(KeywordGroup):
         self._info("Clicking element '%s'." % locator)
         self._element_find(locator, True, True).click()
 
+    def shift_click_element(self, locator):
+        """Shift-Click element identified by `locator`. Simulates holding down
+        the Shift key while clicking an element.
+
+        Key attributes for arbitrary elements are `id` and `name`. See
+        `introduction` for details about locating elements.
+        """
+        self._info("Shift-Clicking element '%s'." % locator)
+        element = self._element_find(locator, True, True)
+        # press the Shift key
+        ActionChains(self._current_browser()).key_down(Keys.SHIFT)
+        element.click()
+        # release the Shift key
+        ActionChains(self._current_browser()).key_up(Keys.SHIFT)
+
     def click_element_at_coordinates(self, locator, xoffset, yoffset):
         """Click element identified by `locator` at x/y coordinates of the element.
         Cursor is moved and the center of the element and x/y coordinates are


### PR DESCRIPTION
I've implemented a new keyword "Shift Click Element" which allows user to click an element while holding down the Shift Key.  In Firefox, this combination maps to "Open in New Window".  (In-house, we use this routine to initiate the downloads of files which are produced by the reporting features of our application.)  The implementation could easily be re-used for other key/click combinations (Alt-Click, Ctrl-Click, etc.)  We've been using this routine in-house for a few months now.

If you'd prefer, I could re-implement this as Key Click Element (a more generic implementation) and re-implement the Shift Click Element keyword as a user of the generic keyword (passing Keys.SHIFT as a parameter to the generic keyword implementation).
