### PR TITLE
Possible workaround for #270

### DIFF
--- a/src/Selenium2Library/webdrivermonkeypatches.py
+++ b/src/Selenium2Library/webdrivermonkeypatches.py
@@ -1,6 +1,7 @@
 import time
 from robot import utils
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
+from selenium.webdriver.remote.webelement import WebElement
 from locators import WindowManager
 
 class WebDriverMonkeyPatches:
@@ -21,9 +22,15 @@ class WebDriverMonkeyPatches:
         return self.current_window_handle
 
     def get_current_window_info(self):
-        atts = self.execute_script("return [ window.id, window.name, document.title, document.url ];")
-        atts = [ att if att is not None and len(att) else 'undefined'
-            for att in atts ]
+        raw_atts = self.execute_script("return [ window.id, window.name, document.title, document.url ];")
+        atts = list()
+        for att in raw_atts:
+            if isinstance(att, WebElement):
+                atts.append(att.id)
+            elif att is not None and len(att):
+                atts.append(att)
+            else:
+                atts.append('undefined')
         return (self.current_window_handle, atts[0], atts[1], atts[2], atts[3])
 
     def get_page_source(self):


### PR DESCRIPTION
Hello!

I try to move from SeleniumLibrary to Selenium2Library in tests at my work. The biggest problem I've faced on this way is an impossibility to select some dialogs created by our web system. When a dialog opens, words `Get Window Titles`, `Get Window Identifiers` and `Get Window Names` causes an internal `TypeError`. This bug is 100% reproducible on some dialogs when running tests with Firefox 24.2.0 (I did not test on other browsers).

I've investigated that this bug appears when `WebDriver` returns `WebElement` as window id. It looks like this (just a piece of debug log, when I've added logging into `get_current_window_info`):

> ...
> WARN    [None, u'', u'YC4EmApxD9_Opms.Very Temp_\u041e\u0431\u0437\u0432\u043e\u043d', None]
> WARN    [None, u'', u'\u0424\u043e\u0440\u043c\u0430_ix5EOTKF', None]
> WARN    [<selenium.webdriver.remote.webelement.WebElement object at 0x2a90390>, u'{"pos":{"x1":427,"y1":295,"w":0,"x2":426,"h":0,"y2":294},"win":{"width":429,"height":377}}', u'\u0414\u043e\u0431\u0430\u0432\u043b\u0435\u043d\u0438\u0435 \u0430\u0442\u0440\u0438\u0431\u0443\u0442\u0430 \u0438\u0437 \u043a\u043b\u0438\u0435\u043d\u0442\u0430', None]

The last record appears right before the fail.

So, I've added some code into this function in order to handle `WebElement` correctly. Now none of our dialogs produces this error, and all library unit tests still pass.
