### PR TITLE
Update browsercache.py

### DIFF
--- a/src/Selenium2Library/utils/browsercache.py
+++ b/src/Selenium2Library/utils/browsercache.py
@@ -20,7 +20,7 @@ class BrowserCache(ConnectionCache):
     def close(self):
         if self.current:
             browser = self.current
-            browser.quit()
+            browser.close()
             self.current = self._no_current
             self._closed.add(browser)
 


### PR DESCRIPTION
It will have the problem “[ WARN ] Keyword ‘Capture Page Screenshot’ could not be run on failure: No browser is open” using browser.quit().
