### PR TITLE
add locator prefix 'partial link' for find_elements_by_partial_link_text

### DIFF
--- a/src/Selenium2Library/locators/elementfinder.py
+++ b/src/Selenium2Library/locators/elementfinder.py
@@ -11,6 +11,7 @@ class ElementFinder(object):
             'xpath': self._find_by_xpath,
             'dom': self._find_by_dom,
             'link': self._find_by_link_text,
+            'partial link': self._find_by_partial_link_text,
             'css': self._find_by_css_selector,
             'jquery': self._find_by_sizzle_selector,
             'sizzle': self._find_by_sizzle_selector,
@@ -70,6 +71,11 @@ class ElementFinder(object):
             browser.find_elements_by_link_text(criteria),
             tag, constraints)
 
+    def _find_by_partial_link_text(self, browser, criteria, tag, constraints):
+        return self._filter_elements(
+            browser.find_elements_by_partial_link_text(criteria),
+            tag, constraints)
+
     def _find_by_css_selector(self, browser, criteria, tag, constraints):
         return self._filter_elements(
             browser.find_elements_by_css_selector(criteria),
@@ -119,6 +125,8 @@ class ElementFinder(object):
         tag = tag.lower()
         constraints = {}
         if tag == 'link':
+            tag = 'a'
+        if tag == 'partial link':
             tag = 'a'
         elif tag == 'image':
             tag = 'img'

--- a/test/unit/locators/test_elementfinder.py
+++ b/test/unit/locators/test_elementfinder.py
@@ -241,6 +241,19 @@ class ElementFinderTests(unittest.TestCase):
         self.assertEqual(result, elements)
         result = finder.find(browser, "link=my link", tag='a')
         self.assertEqual(result, [elements[1], elements[3]])
+        
+    def test_find_by_partial_link_text(self):
+        finder = ElementFinder()
+        browser = mock()
+
+        elements = self._make_mock_elements('div', 'a', 'span', 'a')
+        when(browser).find_elements_by_partial_link_text("my link").thenReturn(elements)
+
+        result = finder.find(browser, "partial link=my link")
+        self.assertEqual(result, elements)
+        result = finder.find(browser, "partial link=my link", tag='a')
+        self.assertEqual(result, [elements[1], elements[3]])
+        
 
     def test_find_by_css_selector(self):
         finder = ElementFinder()


### PR DESCRIPTION
add a method '_find_element_by_partial_text' in elementfinder.py and a test function for it.
