### PR TITLE
Allow spaces in locator prefix

### DIFF
--- a/src/Selenium2Library/locators/elementfinder.py
+++ b/src/Selenium2Library/locators/elementfinder.py
@@ -4,14 +4,14 @@ from robot.api import logger
 class ElementFinder(object):
 
     def __init__(self):
-        self._strategies = {
+        self._strategies = {  # keys must be lower-case w/ no spaces
             'identifier': self._find_by_identifier,
             'id': self._find_by_id,
             'name': self._find_by_name,
             'xpath': self._find_by_xpath,
             'dom': self._find_by_dom,
             'link': self._find_by_link_text,
-            'partial link': self._find_by_partial_link_text,
+            'partiallink': self._find_by_partial_link_text,
             'css': self._find_by_css_selector,
             'jquery': self._find_by_sizzle_selector,
             'sizzle': self._find_by_sizzle_selector,
@@ -187,7 +187,7 @@ class ElementFinder(object):
         if not locator.startswith('//'):
             locator_parts = locator.partition('=')
             if len(locator_parts[1]) > 0:
-                prefix = locator_parts[0].strip().lower()
+                prefix = locator_parts[0].lower().replace(' ', '')
                 criteria = locator_parts[2].strip()
         return (prefix, criteria)
 

--- a/test/unit/locators/test_elementfinder.py
+++ b/test/unit/locators/test_elementfinder.py
@@ -285,6 +285,7 @@ class ElementFinderTests(unittest.TestCase):
 
         elements = self._make_mock_elements('div', 'a', 'span', 'a')
         when(browser).find_elements_by_id("test1").thenReturn(elements)
+        when(browser).find_elements_by_partial_link_text("test1").thenReturn(elements)
 
         result = finder.find(browser, "ID=test1")
         self.assertEqual(result, elements)
@@ -293,6 +294,10 @@ class ElementFinderTests(unittest.TestCase):
         result = finder.find(browser, "id=test1")
         self.assertEqual(result, elements)
         result = finder.find(browser, "  id =test1")
+        self.assertEqual(result, elements)
+        result = finder.find(browser, "  partiallink =test1")
+        self.assertEqual(result, elements)
+        result = finder.find(browser, "  p art iallin k =test1")
         self.assertEqual(result, elements)
 
     def test_find_with_sloppy_criteria(self):


### PR DESCRIPTION
@emanlove Do you see any problem with doing this?
The motivation was to avoid failing for a simple mistake like not having a space between partial and link
partial link=text
partiallink=text
