### PR TITLE
Pass window.id through if not None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ Release Notes
 - Fixed issue where a non-string assigned to window.id caused
   'Select Window' and 'Get Window *' keywords to fail.
 
+A big thank you to [eweitz] and [HelioGuilherme66] for getting the
+continuous integration builds to go green by fixing internal tests.
+
 1.5
 ---
 - Copy Desired Capabilities before modifying to prevent affecting future

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@ Release Notes
 - Fixed issue where 'Select Window’ with url strategy fails to locate window
   [laulaz]
 
+- Fixed issue where a non-string assigned to window.id caused
+  'Select Window' and 'Get Window *' keywords to fail.
+
 1.5
 ---
 - Copy Desired Capabilities before modifying to prevent affecting future

--- a/src/Selenium2Library/webdrivermonkeypatches.py
+++ b/src/Selenium2Library/webdrivermonkeypatches.py
@@ -21,10 +21,10 @@ class WebDriverMonkeyPatches:
         return self.current_window_handle
 
     def get_current_window_info(self):
-        atts = self.execute_script("return [ window.id, window.name, document.title, document.URL ];")
-        atts = [ att if att is not None and len(att) else 'undefined'
-            for att in atts ]
-        return (self.current_window_handle, atts[0], atts[1], atts[2], atts[3])
+        id_, name, title, url = self.execute_script("return [ window.id, window.name, document.title, document.URL ];")
+        id_ = id_ if id_ is not None else 'undefined'
+        name, title, url = (att if att else 'undefined' for att in (name, title, url))
+        return self.current_window_handle, id_, name, title, url
 
     def get_page_source(self):
         return self.page_source

--- a/test/unit/test_webdrivermonkeypatches.py
+++ b/test/unit/test_webdrivermonkeypatches.py
@@ -1,0 +1,66 @@
+import unittest
+from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
+from mockito import *
+
+SCRIPT = "return [ window.id, window.name, document.title, document.URL ];"
+HANDLE = "17c3dc18-0443-478b-aec6-ed7e2a5da7e1"
+
+
+class MockWebDriver(RemoteWebDriver):
+    def __init__(self):
+        pass
+
+    current_window_handle = HANDLE
+
+
+class WebDriverMonkeyPatchesTests(unittest.TestCase):
+
+    def test_window_info_values_are_strings(self):
+        driver = MockWebDriver()
+        when(driver).execute_script(SCRIPT).thenReturn(['id', 'name', 'title', 'url'])
+        info = driver.get_current_window_info()
+        self.assertEqual(info, (HANDLE, 'id', 'name', 'title', 'url'))
+
+    def test_window_info_values_are_empty_strings(self):
+        driver = MockWebDriver()
+        when(driver).execute_script(SCRIPT).thenReturn([''] * 4)
+        info = driver.get_current_window_info()
+        self.assertEqual(info, (HANDLE, '', 'undefined', 'undefined', 'undefined'))
+
+    def test_window_info_values_are_none(self):
+        driver = MockWebDriver()
+        when(driver).execute_script(SCRIPT).thenReturn([None] * 4)
+        info = driver.get_current_window_info()
+        self.assertEqual(info, (HANDLE, 'undefined', 'undefined', 'undefined', 'undefined'))
+
+    def test_window_id_is_bool(self):
+        driver = MockWebDriver()
+        when(driver).execute_script(SCRIPT).thenReturn([True, '', '', '']).thenReturn([False, '', '', ''])
+        info = driver.get_current_window_info()
+        self.assertEqual(info[1], True)
+        info = driver.get_current_window_info()
+        self.assertEqual(info[1], False)
+
+    def test_window_id_is_web_element(self):
+        driver = MockWebDriver()
+        elem = WebElement(None, '052b083c-0d6e-45ca-bda6-73ca13c42561')
+        when(driver).execute_script(SCRIPT).thenReturn([elem, '', '', ''])
+        info = driver.get_current_window_info()
+        self.assertEqual(info[1], elem)
+
+    def test_window_id_is_container(self):
+        driver = MockWebDriver()
+        when(driver).execute_script(SCRIPT).thenReturn([['1'], '', '', '']).thenReturn([{'a': 2}, '', '', ''])
+        info = driver.get_current_window_info()
+        self.assertEqual(info[1], ['1'])
+        info = driver.get_current_window_info()
+        self.assertEqual(info[1], {'a': 2})
+
+    def test_window_id_is_empty_container(self):
+        driver = MockWebDriver()
+        when(driver).execute_script(SCRIPT).thenReturn([[], '', '', '']).thenReturn([{}, '', '', ''])
+        info = driver.get_current_window_info()
+        self.assertEqual(info[1], [])
+        info = driver.get_current_window_info()
+        self.assertEqual(info[1], {})


### PR DESCRIPTION
Slight behavior change. If someone had set window.id to [] or {}, id would become 'undefined'. Now it will be passed as is. This is not worth mentioning in the changelog.
Fixes #270 
