### PR TITLE
Adding Wait Until Element Is Enabled

### DIFF
--- a/src/Selenium2Library/keywords/_waiting.py
+++ b/src/Selenium2Library/keywords/_waiting.py
@@ -85,6 +85,32 @@ class _WaitingKeywords(KeywordGroup):
                 return error or "Element '%s' was not visible in %s" % (locator, self._format_timeout(timeout))
         self._wait_until_no_error(timeout, check_visibility)
 
+    def wait_until_element_is_enabled(self, locator, timeout=None, error=None):
+        """Waits until element specified with `locator` is enabled.
+
+        Fails if `timeout` expires before the element is enabled. See
+        `introduction` for more information about `timeout` and its
+        default value.
+
+        `error` can be used to override the default error message.
+
+        See also `Wait Until Page Contains`, `Wait Until Page Contains
+        Element`, `Wait For Condition` and BuiltIn keyword `Wait Until Keyword
+        Succeeds`.
+        """
+        def check_enabled():
+            element = self._element_find(locator, True, False)
+            if not element:
+                return error or "Element locator '%s' did not match any elements after %s" % (locator, self._format_timeout(timeout))
+
+            enabled = not element.get_attribute("disabled")
+            if enabled:
+                return
+            else:
+                return error or "Element '%s' was not enabled in %s" % (locator, self._format_timeout(timeout))
+
+        self._wait_until_no_error(timeout, check_enabled)
+
     # Private
 
     def _wait_until(self, timeout, error, function, *args):

--- a/test/acceptance/keywords/waiting.txt
+++ b/test/acceptance/keywords/waiting.txt
@@ -23,3 +23,9 @@ Wait Until Element Is Visible
     Run Keyword And Expect Error  Element locator 'invalid' did not match any elements after 100 milliseconds  Wait Until Element Is Visible  invalid  0.1
     Run Keyword And Expect Error  User error message  Wait Until Element Is Visible  invalid  0.1  User error message
 
+Wait Until Element Is Enabled
+    Run Keyword And Expect Error  Element 'id=disabled' was not enabled in 100 milliseconds  Wait Until Element Is Enabled  id=disabled  0.1
+    Wait Until Element Is Enabled  id=disabled  2 s
+    Run Keyword And Expect Error  Element locator 'id=invalid' did not match any elements after 100 milliseconds  Wait Until Element Is Enabled  id=invalid  0.1
+    Run Keyword And Expect Error  User error message  Wait Until Element Is Enabled  id=invalid  0.1  User error message
+

--- a/test/resources/html/javascript/delayed_events.html
+++ b/test/resources/html/javascript/delayed_events.html
@@ -7,6 +7,7 @@
         setTimeout('changeContent()', 1000)
         setTimeout('changeTitle()', 1000)
         setTimeout('unhideContent()', 1000)
+        setTimeout('enableContent()', 1000)
     }
     
     function addElement() {
@@ -28,6 +29,9 @@
     function unhideContent() {
         document.getElementById("hidden").style.display = "block"
     }
+    function enableContent() {
+        document.getElementById("disabled").disabled = false;
+    }
     </script>
     </head>
     
@@ -35,5 +39,6 @@
     <div id="content">This is content</div>
     <div id="container"></div>
     <div id="hidden" style="display:none;">Inititally hidden content</div>
+    <button id="disabled" disabled>Inititally disabled content</button>
     </body>
 </html>


### PR DESCRIPTION
Adding keyword "Wait Until Element Is Enabled" to wait for an element to be enabled before proceeding with testing
