### PR TITLE
cleanup "Wait Until Element Is Not Visible".

### DIFF
--- a/src/Selenium2Library/keywords/_waiting.py
+++ b/src/Selenium2Library/keywords/_waiting.py
@@ -103,9 +103,9 @@ class _WaitingKeywords(KeywordGroup):
             if not visible:
                 return
             elif visible is None:
-                return error or "Element locator '%s' did not match any elements after %s" % (locator, self._format_timeout(timeout))
+                return error or "Element locator '%s' did not return display:none after %s" % (locator, self._format_timeout(timeout))
             else:
-                return error or "Element '%s' was not visible in %s" % (locator, self._format_timeout(timeout))
+                return error or "Element '%s' was still visible in %s" % (locator, self._format_timeout(timeout))
         self._wait_until_no_error(timeout, check_hidden)
 
     # Private


### PR DESCRIPTION
corrected error messages in new keyword "Wait Until Element Is Not
Visible" to reflect element being visible instead of not visible.

Previously these were left as a copy/paste of the errors from the "Wait Until Element Is Visible" keyword. 
