### PR TITLE
Replaced execfile with import

### DIFF
--- a/src/Selenium2Library/__init__.py
+++ b/src/Selenium2Library/__init__.py
@@ -1,16 +1,14 @@
 import os
 from keywords import *
-
-THIS_DIR = os.path.dirname(os.path.abspath(__file__))
-execfile(os.path.join(THIS_DIR, 'version.py'))
+from version import VERSION
 
 __version__ = VERSION
 
 class Selenium2Library(
-    _LoggingKeywords, 
-    _RunOnFailureKeywords, 
-    _BrowserManagementKeywords, 
-    _ElementKeywords, 
+    _LoggingKeywords,
+    _RunOnFailureKeywords,
+    _BrowserManagementKeywords,
+    _ElementKeywords,
     _TableElementKeywords,
     _FormElementKeywords,
     _SelectElementKeywords,
@@ -31,7 +29,7 @@ class Selenium2Library(
     = Before running tests =
 
     Prior to running test cases using Selenium2Library, Selenium2Library must be
-    imported into your Robot test suite (see `importing` section), and the 
+    imported into your Robot test suite (see `importing` section), and the
     `Open Browser` keyword must be used to open a browser to the desired location.
 
     = Locating elements =


### PR DESCRIPTION
I'm trying to use this library with cx_Freeze, but the `execfile` was causing issues because all the dependencies are in a zipped directory. `execfile` doesn't work well with zipped files it seems. 

Regardless, this was somewhat unnecessary anyways. 
