### PR TITLE
Made known issues non-critical

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 script:
-  - "python test/run_tests.py python $BROWSER --noncritical ignore_${BROWSER}_error"
+  - "python test/run_tests.py python $BROWSER --noncritical ignore_${BROWSER}_error --noncritical known_issue_-_${BROWSER}"
 env:
   matrix:
   - BROWSER=firefox


### PR DESCRIPTION
The double click testcase is failing for Firefox but tagged as a known issue. I've added a non-critical flag to the travis script so that any test labeled as `Known Issue - Browser` will be treated as non-critical and not cause PRs and other tests to fail. 
