### PR TITLE
Known issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 script:
-  - "python test/run_tests.py python $BROWSER --noncritical ignore_${BROWSER}_error"
+  - "python test/run_tests.py python $BROWSER --noncritical known_issue_-_travisci
 env:
   matrix:
   - BROWSER=firefox

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 script:
-  - "python test/run_tests.py python $BROWSER --noncritical known_issue_-_travisci
+  - "python test/run_tests.py python $BROWSER --noncritical known_issue_-_travisci"
 env:
   matrix:
   - BROWSER=firefox

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,11 @@ Release Notes
 - Added new locator strategy, scLocator, for finding SmartClient and SmartGWT elements.
   [IlfirinPL]
 
+- Edited acceptance test scripts to automatically make known issues for the currently
+  known browser and python version noncritical. Also added a noncritical case to the
+  travis config for situations where testing is failing on travis for an unknown reason.
+  [zephraph]
+
 1.6
 ---
 - Added examples to 'Execute Javascript' and 'Execute Async Javascript'
@@ -27,7 +32,7 @@ Release Notes
 
 - Fixed issue where the browser failed to properly register if 'Open Browser'
   did not complete.
-  [Mika Batsman][elizaleong][emanlove] 
+  [Mika Batsman][elizaleong][emanlove]
 
 - Added support for negative indices for rows and columns in table-related
   keywords.
@@ -37,7 +42,7 @@ Release Notes
   prefix 'partial link'.
   [lina1]
 
-- Added new keyword 'Clear Element Text' for clearing the text of text entry 
+- Added new keyword 'Clear Element Text' for clearing the text of text entry
   elements.
   [emanlove]
 
@@ -97,7 +102,7 @@ continuous integration builds to go green by fixing internal tests.
 - Raise exception in selecting non-existing item in list. Error handling varies
   between single-select and multi-select lists. See keyword documentation for
   more information.
-  [adwu73][emanlove] 
+  [adwu73][emanlove]
 
 - Added 'Get Window Size' and 'Set Window Size' keywords matching the
   Selenium functionality.
@@ -110,11 +115,11 @@ continuous integration builds to go green by fixing internal tests.
 
 - Beautified README.rst.
   [j1z0][emanlove]
-  
+
 - Changed press key test to use Line Feed (\10) instead of
   Carriage Return (\13).
   [emanlove]
- 
+
 - Added new keyword 'Click Element At Coordinates'.
   [aaltat][pierreroth64][ombre42][emanlove]
 
@@ -165,7 +170,7 @@ continuous integration builds to go green by fixing internal tests.
   [emanlove]
 
 - Use Selenium's Select class within Selenium2Library's "Select *" keywords.
-  Optimization of certain "Select *" keywords to increase performance. 
+  Optimization of certain "Select *" keywords to increase performance.
   [emanlove] [schminitz]
 
 - Replace maximize current browser window from JS to webdriver.

--- a/test/acceptance/keywords/click_element.txt
+++ b/test/acceptance/keywords/click_element.txt
@@ -10,8 +10,8 @@ Click Element
     Element Text Should Be   output  single clicked
 
 Double Click Element
-    [Tags]  Known Issue - Firefox
 	[Documentation]  LOG 2 Double clicking element 'doubleClickButton'.
+    [Tags]  Known Issue - Firefox
     Double Click Element  doubleClickButton
     Element Text Should Be   output  double clicked
 

--- a/test/acceptance/keywords/click_element_at_coordinates.txt
+++ b/test/acceptance/keywords/click_element_at_coordinates.txt
@@ -5,8 +5,8 @@ Resource          ../resource.txt
 
 *** Test Cases ***
 Click Element At Coordinates
-    [Documentation]    LOG 2 Click clicking element 'Clickable' in coordinates '10', '20'. 
-    [Tags]  known_firefox_issue  ignore_firefox_error
+    [Documentation]    LOG 2 Click clicking element 'Clickable' in coordinates '10', '20'.
+    [Tags]    Known Issue - Firefox
     Click Element At Coordinates    Clickable    ${10}   ${20}
     Element Text Should Be    outputX    110
     Element Text Should Be    outputY    120

--- a/test/acceptance/windows.txt
+++ b/test/acceptance/windows.txt
@@ -15,6 +15,7 @@ Popup Windows Created With Javascript
   Select Main Window And Verify
 
 Get Window Titles
+  [Tags]  Known Issue - TravisCI
   ${exp_titles}=  Create List  Click link to show a popup window  Original
   Click Link  my popup
   ${titles}=  Get Window Titles

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -28,6 +28,8 @@ REBOT_ARGS = [
     '--escape', 'space:SP',
     '--critical', 'regression',
     '--noncritical', 'inprogress',
+    '--noncritical', 'known_issue_-_%(pyVersion)s',
+    '--noncritical', 'known_issue_-_%(browser)s',
 ]
 ARG_VALUES = {'outdir': env.RESULTS_DIR, 'pythonpath': env.SRC_DIR}
 

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -12,12 +12,15 @@ ROBOT_ARGS = [
     '--doc', 'SeleniumSPacceptanceSPtestsSPwithSP%(browser)s',
     '--outputdir', '%(outdir)s',
     '--variable', 'browser:%(browser)s',
+    '--variable', 'pyversion:%(pyVersion)s',
     '--escape', 'space:SP',
     '--report', 'none',
     '--log', 'none',
     #'--suite', 'Acceptance.Keywords.Textfields',
     '--loglevel', 'DEBUG',
     '--pythonpath', '%(pythonpath)s',
+    '--noncritical', 'known_issue_-_%(pyVersion)s',
+    '--noncritical', 'known_issue_-_%(browser)s',
 ]
 REBOT_ARGS = [
     '--outputdir', '%(outdir)s',
@@ -30,6 +33,7 @@ ARG_VALUES = {'outdir': env.RESULTS_DIR, 'pythonpath': env.SRC_DIR}
 
 def acceptance_tests(interpreter, browser, args):
     ARG_VALUES['browser'] = browser.replace('*', '')
+    ARG_VALUES['pyVersion'] = interpreter + sys.version[:3]
     start_http_server()
     runner = {'python': 'pybot', 'jython': 'jybot', 'ipy': 'ipybot'}[interpreter]
     if os.sep == '\\':


### PR DESCRIPTION
This PR unifies how known errors are handled in acceptance tests for the purposes of CI. 

To classify a failing testcase as a known issue for a particular browser add the tag `Known Issue - Firefox` (or the corresponding browser) to the test case. You can also specify if something is a known issue on a particular version of python by specifying the tag `Known Issue - Python2.7` or whatever python version you're working with. Only specify the first two digits of the version though. 

Lastly if a testcase is failing for whatever reason because of TravisCI you can also tag a testcase as `Known Issue - TravisCI`. 
