### PR TITLE
Fix for #372

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,8 @@ Release Notes
   known browser and python version noncritical. Also added a noncritical case to the
   travis config for situations where testing is failing on travis for an unknown reason.
 - 'Capture Screenshot' now attempts to create its containing directory if the directory
-  specified in the filename does not exist. 
+  specified in the filename does not exist.
+- 'Choose File' now fails if the file doesn't exist
   [zephraph]
 
 - Added 'Get Window Position' and 'Set Window Position' keywords matching the

--- a/src/Selenium2Library/keywords/_formelement.py
+++ b/src/Selenium2Library/keywords/_formelement.py
@@ -175,7 +175,7 @@ class _FormElementKeywords(KeywordGroup):
         | Choose File | my_upload_field | /home/user/files/trades.csv |
         """
         if not os.path.isfile(file_path):
-            self._info("File '%s' does not exist on the local file system"
+            raise AssertionError("File '%s' does not exist on the local file system"
                         % file_path)
         self._element_find(locator, True, True).send_keys(file_path)
 

--- a/test/acceptance/keywords/forms_and_buttons.txt
+++ b/test/acceptance/keywords/forms_and_buttons.txt
@@ -53,10 +53,10 @@ Click button created with <button> by tag content
 
 Choose File
     [Setup]    Navigate To File Upload Form And Create Temp File To Upload
-    Choose File    file_to_upload    ${TEMPDIR}${/}temp.txt
+    Choose File    file_to_upload    ${CURDIR}${/}temp.txt
     ${dep_browser}=    Set Variable If    '${BROWSER}'.lower() == 'ff' or '${BROWSER}'.lower() == 'firefox'    temp.txt    C:\\fakepath\\temp.txt    #Needs to be checked in Windows and OS X
     Textfield Value Should Be    name= file_to_upload    ${dep_browser}
-    [Teardown]    Remove File    ${TEMPDIR}${/}temp.txt
+    [Teardown]    Remove File    ${CURDIR}${/}temp.txt
 
 Click Image With Submit Type Images
     [Setup]   Go To Page "forms/form_with_image_submit.html"
@@ -73,4 +73,3 @@ Navigate To File Upload Form And Create Temp File To Upload
   Cannot Be Executed in IE
   Go To Page "forms/file_upload_form.html"
   Touch   ${CURDIR}${/}temp.txt
-


### PR DESCRIPTION
The change makes the **Choose File** keyword fail if the chosen file is not found. 

It fixes an issue in some browsers where the webdriver will lock up if a non-existent file is entered. 
