### PR TITLE
Screenshot Capture improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Release Notes
 - Edited acceptance test scripts to automatically make known issues for the currently
   known browser and python version noncritical. Also added a noncritical case to the
   travis config for situations where testing is failing on travis for an unknown reason.
+- 'Capture Screenshot' now attempts to create its containing directory if the directory
+  specified in the filename does not exist. 
   [zephraph]
 
 - Added 'Get Window Position' and 'Set Window Position' keywords matching the

--- a/src/Selenium2Library/keywords/_screenshot.py
+++ b/src/Selenium2Library/keywords/_screenshot.py
@@ -18,7 +18,8 @@ class _ScreenshotKeywords(KeywordGroup):
         `selenium-screenshot-<counter>.png` under the directory where
         the Robot Framework log file is written into. The `filename` is
         also considered relative to the same directory, if it is not
-        given in absolute format.
+        given in absolute format. If an absolute or relative path is given
+        but the path does not exist it will be created. 
 
         `css` can be used to modify how the screenshot is taken. By default
         the bakground color is changed to avoid possible problems with

--- a/test/acceptance/keywords/screenshots.txt
+++ b/test/acceptance/keywords/screenshots.txt
@@ -1,9 +1,9 @@
-* Settings *
+*** Settings ***
 Resource     ../resource.txt
 Suite Setup  Go To Page "links.html"
 
 
-* Test Cases *
+*** Test Cases ***
 
 Capture page screenshot to default location
   [Documentation]  LOG 2:3  REGEXP: </td></tr><tr><td colspan="3"><a href="selenium-screenshot-\\d.png"><img src="selenium-screenshot-\\d.png" width="800px"></a>
@@ -26,3 +26,8 @@ Capture page screenshot to custom directory
   [Setup]  Remove Files  ${TEMPDIR}/seleniumlibrary-screenshot-test.png
   Capture Page Screenshot  ${TEMPDIR}/seleniumlibrary-screenshot-test.png
   File Should Exist  ${TEMPDIR}/seleniumlibrary-screenshot-test.png
+
+Capture page screenshot to non-existing directory
+  [Setup]  Remove Directory  ${OUTPUTDIR}/screenshot  recursive
+  Capture Page Screenshot  screenshot/test-screenshot.png
+  File Should Exist  ${OUTPUTDIR}/screenshot/test-screenshot.png


### PR DESCRIPTION
This PR addresses #322 and #324. 

When using the `Capture Page Screenshot` keyword, if a path is specified that is non-existent it will try to create the path, but raise an assert if it isn't able to create it. 

If writing the screenshot fails for whatever reason, a generic error will be raised. This error can't really be that specific because no details are passed back from the selenium api. 
