### PR TITLE
Add 'Wait Until Element Text Is' -keyword

### DIFF
--- a/src/Selenium2Library/keywords/_waiting.py
+++ b/src/Selenium2Library/keywords/_waiting.py
@@ -155,6 +155,29 @@ class _WaitingKeywords(KeywordGroup):
 
         self._wait_until_no_error(timeout, check_enabled)
 
+    def wait_until_element_text_is(self, locator, text, timeout=None, error=None):
+        """Waits until `text` appears on given element.
+
+        Fails if `timeout` expires before the text appears on given element. See
+        `introduction` for more information about `timeout` and its
+        default value.
+
+        `error` can be used to override the default error message.
+
+        See also `Wait Until Page Contains`, `Wait Until Page Contains Element`, `Wait For Condition`,
+        `Wait Until Element Is Visible` and BuiltIn keyword `Wait Until
+        Keyword Succeeds`.
+        """
+        element = self._element_find(locator, True, True)
+        def check_text():
+            actual = element.text
+            if text == actual:
+                return
+            else:
+                return error or "Text '%s' did not appear in %s to element '%s' " \
+                                "in fact it was '%s'." % (text, self._format_timeout(timeout), locator, actual)
+        self._wait_until_no_error(timeout, check_text)
+
     # Private
 
     def _wait_until(self, timeout, error, function, *args):

--- a/test/acceptance/keywords/waiting.txt
+++ b/test/acceptance/keywords/waiting.txt
@@ -38,4 +38,4 @@ Wait Until Element Text Is
     Run Keyword And Expect Error  Text 'Text that doesn't exists in source code' did not appear in 100 milliseconds to element 'content' in fact it was 'This is content'.  Wait Until Element Text Is  content  Text that doesn't exists in source code  0.1
     Wait Until Element Text Is  content  New Content  2 s
     Run Keyword And Expect Error  User error message  Wait Until Element Text Is  content  Error  0.1  User error message
-    Run Keyword And Expect Error  ValueError: Element locator 'id=invalid' did not match any elements.  Wait Until Element Text Is  id=invalid  0.1
+    Run Keyword And Expect Error  ValueError: Element locator 'id=invalid' did not match any elements.  Wait Until Element Text Is  id=invalid  Another error  0.1

--- a/test/acceptance/keywords/waiting.txt
+++ b/test/acceptance/keywords/waiting.txt
@@ -34,3 +34,8 @@ Wait Until Element Is Enabled
     Run Keyword And Expect Error  Element locator 'id=invalid' did not match any elements after 100 milliseconds  Wait Until Element Is Enabled  id=invalid  0.1
     Run Keyword And Expect Error  User error message  Wait Until Element Is Enabled  id=invalid  0.1  User error message
 
+Wait Until Element Text Is
+    Run Keyword And Expect Error  Text 'Text that doesn't exists in source code' did not appear in 100 milliseconds to element 'content' in fact it was 'This is content'.  Wait Until Element Text Is  content  Text that doesn't exists in source code  0.1
+    Wait Until Element Text Is  content  New Content  2 s
+    Run Keyword And Expect Error  User error message  Wait Until Element Text Is  content  Error  0.1  User error message
+    Run Keyword And Expect Error  ValueError: Element locator 'id=invalid' did not match any elements.  Wait Until Element Text Is  id=invalid  0.1


### PR DESCRIPTION
I have found some use for this kind of keyword when verifying text content in error message elements on forms (Text is too short -> Text is too long -> Text contains characters that are now allowed etc. when doing input field checks with Javascript).
