### PR TITLE
add fix for 'No Such Window' error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ Release Notes
 
 1.7 (unreleased)
 ----------------
+- Fixed ‘NoSuchWindowException' issue. Running keyword 'Select Window' after 'Close Window'
+  will trigger this issue if locator has prefix 'name=','title=' or 'url='. Also fixed same
+  issue for keywords 'Get Window Ids', 'Get Window Titles' and 'Get Window Names'.
+  [divfor]
+  
 - Corrected error message in new keyword 'Wait Until Element Is Not
   Visible' to reflect element being visible instead of not visible.
   [joepurdy]

--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -212,8 +212,15 @@ class _BrowserManagementKeywords(KeywordGroup):
     # Public, window management
 
     def close_window(self):
-        """Closes currently opened pop-up window."""
+        """Closes currently opened pop-up window and switch back to previous window.
+        It assumes the last opened window is in the last index of window list.
+        However, as opened windows are list-returned from tree-order in remote end,
+        please use 'Select Window' if automatic switching does not work as expected.
+        """
         self._current_browser().close()
+        handles = self._current_browser().get_window_handles()
+        if len(handles) >= 1:
+            self._current_browser().switch_to_window(handles[-1])
 
     def get_window_identifiers(self):
         """Returns and logs id attributes of all windows known to the browser."""

--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -212,15 +212,8 @@ class _BrowserManagementKeywords(KeywordGroup):
     # Public, window management
 
     def close_window(self):
-        """Closes currently opened pop-up window and switch back to previous window.
-        It assumes the last opened window is in the last index of window list.
-        However, as opened windows are list-returned from tree-order in remote end,
-        please use 'Select Window' if automatic switching does not work as expected.
-        """
+        """Closes currently opened pop-up window."""
         self._current_browser().close()
-        handles = self._current_browser().get_window_handles()
-        if len(handles) >= 1:
-            self._current_browser().switch_to_window(handles[-1])
 
     def get_window_identifiers(self):
         """Returns and logs id attributes of all windows known to the browser."""

--- a/src/Selenium2Library/locators/windowmanager.py
+++ b/src/Selenium2Library/locators/windowmanager.py
@@ -95,10 +95,13 @@ class WindowManager(object):
         return window_infos
 
     def _select_matching(self, browser, matcher, error):
-        starting_handle = browser.get_current_window_handle()
+        try:
+            starting_handle = browser.get_current_window_handle()
+        except NoSuchWindowException: pass
         for handle in browser.get_window_handles():
             browser.switch_to_window(handle)
             if matcher(browser.get_current_window_info()):
                 return
-        browser.switch_to_window(starting_handle)
+        if starting_handle:
+            browser.switch_to_window(starting_handle)
         raise ValueError(error)

--- a/src/Selenium2Library/locators/windowmanager.py
+++ b/src/Selenium2Library/locators/windowmanager.py
@@ -85,19 +85,24 @@ class WindowManager(object):
 
     def _get_window_infos(self, browser):
         window_infos = []
-        starting_handle = browser.get_current_window_handle()
+        try:
+            starting_handle = browser.get_current_window_handle()
+        except NoSuchWindowException:
+            starting_handle = None
         try:
             for handle in browser.get_window_handles():
                 browser.switch_to_window(handle)
                 window_infos.append(browser.get_current_window_info())
         finally:
-            browser.switch_to_window(starting_handle)
+            if starting_handle:
+                browser.switch_to_window(starting_handle)
         return window_infos
 
     def _select_matching(self, browser, matcher, error):
         try:
             starting_handle = browser.get_current_window_handle()
-        except NoSuchWindowException: pass
+        except NoSuchWindowException:
+            starting_handle = None
         for handle in browser.get_window_handles():
             browser.switch_to_window(handle)
             if matcher(browser.get_current_window_info()):

--- a/test/acceptance/windows.txt
+++ b/test/acceptance/windows.txt
@@ -50,6 +50,17 @@ Get and Set Window Position
   Should Be Equal  ${position_x}  ${returned_x}
   Should Be Equal  ${position_y}  ${returned_y}
 
+Select Window By Title After Close Window
+    Cannot Be Executed in IE
+    Open Popup Window, Select It And Verify    myName
+    Close Popup Window And Select Main Window By Title
+
+Get Window Titles After Close Window
+    [Tags]    Known Issue - TravisCI
+    Cannot Be Executed in IE
+    Open Popup Window, Select It And Verify    myName
+    Close Window
+    ${titles}=    Get Window Titles
 
 *Keywords*
 Open Popup Window, Select It And Verify
@@ -66,3 +77,7 @@ Select Main Window And Verify
 Do Action In Popup Window And Verify
   Click Link  change title
   Title Should Be  Changed
+
+Close Popup Window And Select Main Window By Title
+    Close Window
+    Select Window    title=Click link to show a popup window


### PR DESCRIPTION
reason:
from 6.4 secotion in http://www.w3.org/TR/webdriver/, it says:
Once the window has closed, future commands must return a status code of
no such window until a new window is selected for receiving commands.
how to fix:
1. let close_window() automaticly switches to prevoius window;
2. capture NoSuchWindowException when select_window() /
_select_matching()/get_current_window_handle()
