### PR TITLE
Enhancement for selecting new or any opened window

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,14 @@ Release Notes
 
 1.7 (unreleased)
 ----------------
+- Added 'Close Window And Select' to simplify 'Close Window' + 'Select Window'.
+  Added 'List Windows' to return a list of all current handles.
+  Enhanced 'Select Window' to select new window by excluding a list of window handles
+  (the strict way), or by special locator 'new' (the simplified but less strict way)
+  Enhanced 'Select Window' to accept window handle as locator, and special locator
+  'self' to return current window handle.
+  [divfor]
+
 - Corrected error message in new keyword 'Wait Until Element Is Not
   Visible' to reflect element being visible instead of not visible.
   [joepurdy]

--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -290,6 +290,7 @@ class _BrowserManagementKeywords(KeywordGroup):
 
     def select_window(self, locator=None):
         """Selects the window found with `locator` as the context of actions.
+        Return value is ether current window handle before select action or None.
 
         If the window is found, all subsequent commands use that window, until
         this keyword is used again. If the window is not found, this keyword fails.
@@ -299,7 +300,10 @@ class _BrowserManagementKeywords(KeywordGroup):
         javascript name of the window. If multiple windows with
         same identifier are found, the first one is selected.
 
-        Special locator `main` (default) can be used to select the main window.
+        Special locator `main` (default) used to select the main window and returns from-window handle.
+        Special locator `new` switches to new opened window and returns old window handle.
+        Special locator `current` does not switch window but return current window handle.
+        The returned window handle could be used as locator to switch back to that window.
 
         It is also possible to specify the approach Selenium2Library should take
         to find a window by specifying a locator strategy:
@@ -315,7 +319,11 @@ class _BrowserManagementKeywords(KeywordGroup):
         | Title Should Be | Popup Title |
         | Select Window |  | | # Chooses the main window again |
         """
+        try:
+            from_handle = self._current_browser().get_current_window_handle()
+        except NoSuchWindowException: pass 
         self._window_manager.select(self._current_browser(), locator)
+        return from_handle if from_handle else None
 
     def unselect_frame(self):
         """Sets the top frame as the current frame."""

--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -290,8 +290,10 @@ class _BrowserManagementKeywords(KeywordGroup):
 
     def select_window(self, locator=None):
         """Selects the window found with `locator` as the context of actions.
-        Return value is ether current window handle before select action or None.
-
+        locator value may be name, title, special string or window handle(s).
+        return value is current window handle if it exists before select else None.
+        The returned window handle could be used as locator to switch back to that window.
+        
         If the window is found, all subsequent commands use that window, until
         this keyword is used again. If the window is not found, this keyword fails.
         
@@ -300,10 +302,13 @@ class _BrowserManagementKeywords(KeywordGroup):
         javascript name of the window. If multiple windows with
         same identifier are found, the first one is selected.
 
-        Special locator `main` (default) used to select the main window and returns from-window handle.
-        Special locator `new` switches to new opened window and returns old window handle.
-        Special locator `current` does not switch window but return current window handle.
-        The returned window handle could be used as locator to switch back to that window.
+        There are some special locators for searching target window:
+        string 'main' (default): select the main window;
+        string 'current': just return current window handle;
+        a single window handle: directly select window by handle;
+        string 'new': select new opened window assuming it is last-position indexed (no iframe)
+        a past list of window handles: select new window by excluding past window handle list
+        See 'Get Window Handles' to get the past list of window handles 
 
         It is also possible to specify the approach Selenium2Library should take
         to find a window by specifying a locator strategy:
@@ -324,6 +329,9 @@ class _BrowserManagementKeywords(KeywordGroup):
         except NoSuchWindowException: pass 
         self._window_manager.select(self._current_browser(), locator)
         return from_handle if from_handle else None
+
+    def get_window_handles():
+        return self._current_browser().get_window_handles()
 
     def unselect_frame(self):
         """Sets the top frame as the current frame."""

--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -338,7 +338,7 @@ class _BrowserManagementKeywords(KeywordGroup):
         self._current_browser().close()
         self.select_window(locator)
 
-    def list_windows():
+    def list_windows(self):
         """Return all current window handles as a list"""
         return self._current_browser().get_window_handles()
 

--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -325,18 +325,18 @@ class _BrowserManagementKeywords(KeywordGroup):
         | Select Window |  | | # Chooses the main window again |
         """
         try:
-            from_handle = self._current_browser().get_current_window_handle()
+            return self._current_browser().get_current_window_handle()
         except NoSuchWindowException:
-            from_handle = None
-        self._window_manager.select(self._current_browser(), locator)
-        return from_handle
+            pass
+        finally:
+            self._window_manager.select(self._current_browser(), locator)
 
     def close_window_and_select(self, locator=None):
         """Closes current window and then switch to the window matching given locator.
         See 'Select Window' keyword for same locator requirement
         """
         self._current_browser().close()
-        self.select_window(locator)
+        return self.select_window(locator)
 
     def list_windows(self):
         """Return all current window handles as a list"""

--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -305,9 +305,9 @@ class _BrowserManagementKeywords(KeywordGroup):
 
         There are some special locators for searching target window:
         string 'main' (default): select the main window;
-        string 'current': only return current window handle;
-        string 'new': select new opened window assuming it is last-position indexed (no iframe)
-        excluded handle's list: select the first window not in the list
+        string 'self': only return current window handle;
+        string 'new': select the last-indexed window assuming it is the newest opened window
+        list of window handle: select the first window not in the list
         See 'List Windows' to get window handle list 
 
         It is also possible to specify the approach Selenium2Library should take
@@ -331,7 +331,7 @@ class _BrowserManagementKeywords(KeywordGroup):
         self._window_manager.select(self._current_browser(), locator)
         return from_handle
 
-    def close_window_and_switch_to(self, locator=None):
+    def close_window_and_select(self, locator=None):
         """Closes current window and then switch to the window matching given locator.
         See 'Select Window' keyword for same locator requirement
         """

--- a/src/Selenium2Library/locators/windowmanager.py
+++ b/src/Selenium2Library/locators/windowmanager.py
@@ -52,21 +52,29 @@ class WindowManager(object):
             "Unable to locate window with URL '" + criteria + "'")
 
     def _select_by_default(self, browser, criteria):
+        if criteria.lower() == "current":
+            return
+        handles = browser.get_window_handles()
         if criteria is None or len(criteria) == 0 or criteria.lower() == "null":
-            browser.switch_to_window('')
+            browser.switch_to_window(handles[0])
             return
-
-        try:
-            self._select_by_name(browser, criteria)
+        if criteria.lower() == "new" or criteria.lower() == "popup":
+            try:
+                start_handle = browser.get_current_window_handle()
+            except NoSuchWindowException:
+                 raise AssertionError("No current window. where are you to make a popup window?")
+            if len(handles) < 2 or handles[-1] == start_handle:
+               raise AssertionError("No new window found to switch to")
+            browser.switch_to_window(handles[-1])
             return
-        except ValueError: pass
-
-        try:
-            self._select_by_title(browser, criteria)
-            return
-        except ValueError: pass
-
-        raise ValueError("Unable to locate window with name or title '" + criteria + "'")
+        for handle in handles:
+            browser.switch_to_window(handle)
+            if criteria == handle:
+                return
+            for item in browser.get_current_window_info()[2:4]:
+                if item.strip().lower() == criteria.lower():
+                    return
+        raise ValueError("Unable to locate window with handle or name or title or URL '" + criteria + "'")
 
     # Private
 

--- a/src/Selenium2Library/locators/windowmanager.py
+++ b/src/Selenium2Library/locators/windowmanager.py
@@ -87,7 +87,7 @@ class WindowManager(object):
     def _parse_locator(self, locator):
         prefix = None
         criteria = locator
-        if type(locator) == list:
+        if isinstance(locator, list):
             return (prefix, criteria)
         if locator is not None and len(locator) > 0:
             locator_parts = locator.partition('=')        

--- a/src/Selenium2Library/locators/windowmanager.py
+++ b/src/Selenium2Library/locators/windowmanager.py
@@ -68,7 +68,7 @@ class WindowManager(object):
             try:
                 start_handle = browser.get_current_window_handle()
             except NoSuchWindowException:
-                 raise AssertionError("No current window. where are you to make a popup window?")
+                 raise AssertionError("No current window. where are you making a popup window?")
             if len(handles) < 2 or handles[-1] == start_handle:
                raise AssertionError("No new window found to switch to")
             browser.switch_to_window(handles[-1])
@@ -111,10 +111,13 @@ class WindowManager(object):
         return window_infos
 
     def _select_matching(self, browser, matcher, error):
-        starting_handle = browser.get_current_window_handle()
+        try:
+            starting_handle = browser.get_current_window_handle()
+        except NoSuchWindowException: pass
         for handle in browser.get_window_handles():
             browser.switch_to_window(handle)
             if matcher(browser.get_current_window_info()):
                 return
-        browser.switch_to_window(starting_handle)
+        if starting_handle:
+            browser.switch_to_window(starting_handle)
         raise ValueError(error)

--- a/src/Selenium2Library/locators/windowmanager.py
+++ b/src/Selenium2Library/locators/windowmanager.py
@@ -52,7 +52,7 @@ class WindowManager(object):
             "Unable to locate window with URL '" + criteria + "'")
 
     def _select_by_default(self, browser, criteria):
-        if criteria.lower() == "current":
+        if criteria.lower() == "self":
             return
         handles = browser.get_window_handles()
         if type(criteria) == list:
@@ -101,19 +101,20 @@ class WindowManager(object):
 
     def _get_window_infos(self, browser):
         window_infos = []
-        starting_handle = browser.get_current_window_handle()
+        start_handle = browser.get_current_window_handle()
         try:
             for handle in browser.get_window_handles():
                 browser.switch_to_window(handle)
                 window_infos.append(browser.get_current_window_info())
         finally:
-            browser.switch_to_window(starting_handle)
+            browser.switch_to_window(start_handle)
         return window_infos
 
     def _select_matching(self, browser, matcher, error):
         try:
             starting_handle = browser.get_current_window_handle()
-        except NoSuchWindowException: pass
+        except NoSuchWindowException:
+            starting_handle = None
         for handle in browser.get_window_handles():
             browser.switch_to_window(handle)
             if matcher(browser.get_current_window_info()):

--- a/src/Selenium2Library/locators/windowmanager.py
+++ b/src/Selenium2Library/locators/windowmanager.py
@@ -55,6 +55,12 @@ class WindowManager(object):
         if criteria.lower() == "current":
             return
         handles = browser.get_window_handles()
+        if type(criteria) == list:
+            for handle in handles:
+                if handle not in criteria:
+                    browser.switch_to_window(handle)
+                    return
+            raise ValueError("Unable to locate new window")
         if criteria is None or len(criteria) == 0 or criteria.lower() == "null":
             browser.switch_to_window(handles[0])
             return
@@ -81,6 +87,8 @@ class WindowManager(object):
     def _parse_locator(self, locator):
         prefix = None
         criteria = locator
+        if type(locator) == list:
+            return (prefix, criteria)
         if locator is not None and len(locator) > 0:
             locator_parts = locator.partition('=')        
             if len(locator_parts[1]) > 0:

--- a/src/Selenium2Library/locators/windowmanager.py
+++ b/src/Selenium2Library/locators/windowmanager.py
@@ -52,28 +52,28 @@ class WindowManager(object):
             "Unable to locate window with URL '" + criteria + "'")
 
     def _select_by_default(self, browser, criteria):
-        if criteria.lower() == "self":
-            return
-        handles = browser.get_window_handles()
         if type(criteria) == list:
-            for handle in handles:
+            for handle in browser.get_window_handles():
                 if handle not in criteria:
                     browser.switch_to_window(handle)
                     return
             raise ValueError("Unable to locate new window")
+        if criteria.lower() == "self":
+            return
         if criteria is None or len(criteria) == 0 or criteria.lower() == "null":
-            browser.switch_to_window(handles[0])
+            browser.switch_to_window(browser.get_window_handles()[0])
             return
         if criteria.lower() == "new" or criteria.lower() == "popup":
             try:
                 start_handle = browser.get_current_window_handle()
             except NoSuchWindowException:
                  raise AssertionError("No current window. where are you making a popup window?")
+            handles = browser.get_window_handles()
             if len(handles) < 2 or handles[-1] == start_handle:
-               raise AssertionError("No new window found to switch to")
+               raise AssertionError("No new window found to select")
             browser.switch_to_window(handles[-1])
             return
-        for handle in handles:
+        for handle in browser.get_window_handles():
             browser.switch_to_window(handle)
             if criteria == handle:
                 return
@@ -101,24 +101,20 @@ class WindowManager(object):
 
     def _get_window_infos(self, browser):
         window_infos = []
-        start_handle = browser.get_current_window_handle()
+        starting_handle = browser.get_current_window_handle()
         try:
             for handle in browser.get_window_handles():
                 browser.switch_to_window(handle)
                 window_infos.append(browser.get_current_window_info())
         finally:
-            browser.switch_to_window(start_handle)
+            browser.switch_to_window(starting_handle)
         return window_infos
 
     def _select_matching(self, browser, matcher, error):
-        try:
-            starting_handle = browser.get_current_window_handle()
-        except NoSuchWindowException:
-            starting_handle = None
+        starting_handle = browser.get_current_window_handle()
         for handle in browser.get_window_handles():
             browser.switch_to_window(handle)
             if matcher(browser.get_current_window_info()):
                 return
-        if starting_handle:
-            browser.switch_to_window(starting_handle)
+        browser.switch_to_window(starting_handle)
         raise ValueError(error)

--- a/src/Selenium2Library/locators/windowmanager.py
+++ b/src/Selenium2Library/locators/windowmanager.py
@@ -52,7 +52,7 @@ class WindowManager(object):
             "Unable to locate window with URL '" + criteria + "'")
 
     def _select_by_default(self, browser, criteria):
-        if type(criteria) == list:
+        if isinstance(criteria, list):
             for handle in browser.get_window_handles():
                 if handle not in criteria:
                     browser.switch_to_window(handle)
@@ -67,7 +67,7 @@ class WindowManager(object):
             try:
                 start_handle = browser.get_current_window_handle()
             except NoSuchWindowException:
-                 raise AssertionError("No current window. where are you making a popup window?")
+                 raise AssertionError("Currently no window focus. where are you making a popup window?")
             handles = browser.get_window_handles()
             if len(handles) < 2 or handles[-1] == start_handle:
                raise AssertionError("No new window found to select")

--- a/test/acceptance/windows.txt
+++ b/test/acceptance/windows.txt
@@ -41,7 +41,6 @@ Get and Set Window Size
   Should Be Equal  ${returned_width}  ${win_width}
   Should Be Equal  ${returned_height}  ${win_height}
 
-
 Get and Set Window Position
   ${position_x}=  Set Variable  ${100}
   ${position_y}=  Set Variable  ${100}
@@ -49,6 +48,39 @@ Get and Set Window Position
   ${returned_x}  ${returned_y}=  Get Window Position
   Should Be Equal  ${position_x}  ${returned_x}
   Should Be Equal  ${position_y}  ${returned_y}
+
+Select Window By Handle
+  Cannot Be Executed in IE
+  Click Link  my popup
+  ${parent}=  Select Window  Original
+  Title Should Be  Original
+  ${child}=  Select Window  ${parent}
+  Title Should Be  Click link to show a popup window
+  Select Window  ${child}
+  Close Window
+  ${FromWindow}=  Select Window  ${parent}
+  Title Should Be  Click link to show a popup window
+  Should Be True  ${FromWindow} == None
+
+Select Popup Window By Excluded List
+  Cannot Be Executed in IE
+  @{excluded_handle_list}=  List Windows
+  Click Link  my popup
+  ${parent}=  Select Window  ${excluded_handle_list}
+  Title Should Be  Original
+  Close Window
+  Select Window  ${parent}
+  Title Should Be  Click link to show a popup window
+
+Select Window By Special Locator
+  Cannot Be Executed in IE
+  ${start}=  Select Window  self
+  Click Link  my popup
+  ${parent}=  Select Window  new
+  Title Should Be  Original
+  Should Be True  '${start}' == '${parent}'
+  Close Window And Select  main
+  Title Should Be  Click link to show a popup window
 
 
 *Keywords*


### PR DESCRIPTION
Code changes:
added 'Close Window And Select' to simplify two steps of 'Close Window' + 'Select Window'
added 'List Windows' to return all current handles;
enable 'Select Window' to always return the handle of window it is selecting from, and only return handle if 'self' as locator;
enriched 'Select Window' to select any opened window by a window handle;
enriched 'Select Window' to select new window by excluding a list of earlier window handles;

Background:
It is very useful to surface window handle to users that want to have the 'correct way' - comparing window handle sets, to switch window. If we do this way, the fix here for 'Close Window' is not required. instead, my new proposal is to update 'Select Window' and add 2 keywords:

``` robotframework
Close Window And Select | locator=None
```

This will close current window and then switch to window if locator is given. locator can be name, title, url, handle, ..., the same as 'Select Window' requires.

``` robotframework
${previous_window}= | Select Window | locator=None
```

This will switch to window matching locator and return previous window's handle. locator can be name, title, url, handle of target window, or a handle list to exclude in order to find new window. If locator is 'self', only return current window handle. 

``` robotframework
${window_list}= | List Windows
```

This will return a list of all opened window handles in same session not assuming its order. 

Above changes should not impact existing usage of 'Close Window' and 'Select Window', and can offer the strict 'correct way' for using handle to switch window.

example 1:
A user should save main window handle in the beginning if required:

``` robotframework
Open Browser 
${main_window}= | Select Window | self
```

A user can switch to correct window like below:

``` robotframework
${all_old_windows}= | List Windows
Click Link | xxx | # or any other action that generates a child window
${parent_window}= | Select Window | ${all_old_windows}
Other Actions Against The Child Window
Close Window And Select | ${parent_window}
```

One more consideration:
should we also offer the additional simplified way to select the last-position indexed window as new window without the need to comparing with old window handles? The doc can prompt user to use strict way to select new window if the simplified way does not work for him/her. From my experiences the simplified way will be correct in 99% cases. 

``` robotframework
${parent_window}= | Select Window | new
```
