### PR TITLE
Modified .gitignore to ignore virtualenv dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ chromedriver.log
 
 dist
 build
+env


### PR DESCRIPTION
I use 'env' as my virtualenv directory so I added it to the .gitignore. 
