### PR TITLE
Allows custom locators to be regular methods

### DIFF
--- a/src/Selenium2Library/locators/customlocator.py
+++ b/src/Selenium2Library/locators/customlocator.py
@@ -7,12 +7,21 @@ except NameError:
 
 class CustomLocator(object):
 
-    def __init__(self, name, keyword):
+    def __init__(self, name, finder):
         self.name = name
-        self.keyword = keyword
+        self.finder = finder
 
     def find(self, *args):
-        element = BuiltIn().run_keyword(self.keyword, *args)
+
+        # Allow custom locators to be keywords or normal methods
+        if isinstance(self.finder, string_type):
+            element = BuiltIn().run_keyword(self.finder, *args)
+        elif hasattr(self.finder, '__caller__'):
+            element = self.finder(*args)
+        else:
+            raise AttributeError('Invalid type provided as a Custom Locator')
+
+        # Always return an array
         if hasattr(element, '__len__') and (not isinstance(element, string_type)):
             return element
         else:

--- a/src/Selenium2Library/locators/customlocator.py
+++ b/src/Selenium2Library/locators/customlocator.py
@@ -19,7 +19,7 @@ class CustomLocator(object):
         elif hasattr(self.finder, '__caller__'):
             element = self.finder(*args)
         else:
-            raise AttributeError('Invalid type provided as a Custom Locator')
+            raise AttributeError('Invalid type provided for Custom Locator %s' % self.name)
 
         # Always return an array
         if hasattr(element, '__len__') and (not isinstance(element, string_type)):


### PR DESCRIPTION
This was always intended, but a slight oversight on my part. 

Custom locators should be addable as a regular python function. It should allow a situation something like the following

``` python
from robot.libraries.BuiltIn import BuiltIn

selenium = BuiltIn.get_library_instance('Selenium2Library')
selector = lambda query: selenium.execute_javascript("return document.querySelectorAll('%s')" % query)
selenium.add_location_strategy('query', selector)
```
