### PR TITLE
Use packaged jquery

### DIFF
--- a/test/resources/html/jquery.html
+++ b/test/resources/html/jquery.html
@@ -2,7 +2,7 @@
   <head>
     <title>(root)/links.html</title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-    <script src="http://code.jquery.com/jquery-1.9.1.min.js" type="text/javascript"></script>
+    <script src="javascript/jquery.js" type="text/javascript"></script>
   </head>
   <body>
     <div id="div_id">
@@ -23,7 +23,7 @@
       	Link with whitespace
       </a><br/>
       <a href="target/third.html">
-      	Link with 
+      	Link with
       	whitespace   within
       </a><br/>
       <a href="target/first.html" id="bold_id"><b>Link with bolded text</b></a>


### PR DESCRIPTION
When testing locally for the 1.7 push, the sizzle test was failing because the jquery resource URL couldn't be reached (likely because of my work network). To avoid this, I just switch it to use the jquery instance that we already provide anyway. 
