### PR TITLE
Fixed an invalid attribute reference

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+1.7.2
+----------------
+- Fixed an error where regular functions were not able to be used as a custom locator
+  [zephraph]
+
+- Changed all test files to have a '.robot' extension
+  [zephraph]
+
 1.7.1 (hotfix)
 ----------------
 - Remove references to GLOBAL_VARIABLES for RF 2.9 compatibility

--- a/src/Selenium2Library/locators/customlocator.py
+++ b/src/Selenium2Library/locators/customlocator.py
@@ -12,11 +12,13 @@ class CustomLocator(object):
         self.finder = finder
 
     def find(self, *args):
+        print 'finder', self.finder
+        print 'name', self.name
 
         # Allow custom locators to be keywords or normal methods
         if isinstance(self.finder, string_type):
             element = BuiltIn().run_keyword(self.finder, *args)
-        elif hasattr(self.finder, '__caller__'):
+        elif hasattr(self.finder, '__call__'):
             element = self.finder(*args)
         else:
             raise AttributeError('Invalid type provided for Custom Locator %s' % self.name)

--- a/src/Selenium2Library/locators/customlocator.py
+++ b/src/Selenium2Library/locators/customlocator.py
@@ -12,8 +12,6 @@ class CustomLocator(object):
         self.finder = finder
 
     def find(self, *args):
-        print 'finder', self.finder
-        print 'name', self.name
 
         # Allow custom locators to be keywords or normal methods
         if isinstance(self.finder, string_type):


### PR DESCRIPTION
A custom locator should allow for functions to be used as locators. There was a typo preventing this functionality. 
