### PR TITLE
Use is not instead of != to check for None

### DIFF
--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -757,7 +757,7 @@ return !element.dispatchEvent(evt);
         return (parts[0], parts[2])
 
     def _is_element_present(self, locator, tag=None):
-        return (self._element_find(locator, True, False, tag=tag) != None)
+        return (self._element_find(locator, True, False, tag=tag) is not None)
 
     def _page_contains(self, text):
         browser = self._current_browser()


### PR DESCRIPTION
Otherwise things blow up with selenium > 2.26 since they override `WebElement.__eq__`
