### PR TITLE
Fixed screenshot linking in logs

### DIFF
--- a/src/Selenium2Library/keywords/_logging.py
+++ b/src/Selenium2Library/keywords/_logging.py
@@ -3,6 +3,7 @@ import sys
 from robot.api import logger
 from keywordgroup import KeywordGroup
 from robot.libraries.BuiltIn import BuiltIn
+from robot.libraries.BuiltIn import RobotNotRunningError
 
 class _LoggingKeywords(KeywordGroup):
 
@@ -12,12 +13,16 @@ class _LoggingKeywords(KeywordGroup):
         logger.debug(message)
 
     def _get_log_dir(self):
-        variables = BuiltIn().get_variables()
+        try:
+            variables = BuiltIn().get_variables()
 
-        logfile = variables['${LOG FILE}']
-        if logfile != 'NONE':
-            return os.path.dirname(logfile)
-        return variables['${OUTPUTDIR}']
+            logfile = variables['${LOG FILE}']
+            if logfile != 'NONE':
+                return os.path.dirname(logfile)
+            return variables['${OUTPUTDIR}']
+
+        except RobotNotRunningError:
+            return os.getcwd()
 
     def _html(self, message):
         logger.info(message, True, False)

--- a/src/Selenium2Library/keywords/_screenshot.py
+++ b/src/Selenium2Library/keywords/_screenshot.py
@@ -3,7 +3,6 @@ import os, errno
 
 from Selenium2Library import utils
 from keywordgroup import KeywordGroup
-from robot.libraries.BuiltIn import RobotNotRunningError
 
 
 class _ScreenshotKeywords(KeywordGroup):
@@ -18,12 +17,13 @@ class _ScreenshotKeywords(KeywordGroup):
     def set_screenshot_directory(self, path, persist=False):
         """Sets the root output directory for captured screenshots.
 
-        ``path`` argument specifies the location to where the screenshots should
+        ``path`` argument specifies the absolute path where the screenshots should
         be written to. If the specified ``path`` does not exist, it will be created.
         Setting ``persist`` specifies that the given ``path`` should
         be used for the rest of the test execution, otherwise the path will be restored
         at the end of the currently executing scope.
         """
+        path = os.path.abspath(path)
         self._create_directory(path)
         if persist is False:
             self._screenshot_path_stack.append(self.screenshot_root_directory)
@@ -80,12 +80,7 @@ class _ScreenshotKeywords(KeywordGroup):
             return self.screenshot_root_directory
 
         # Otherwise use RF's log directory
-        try:
-            return self._get_log_dir()
-
-        # Unless robotframework isn't running, then use working directory
-        except RobotNotRunningError:
-            return os.getcwd()
+        return self._get_log_dir()
 
     # should only be called by set_screenshot_directory
     def _restore_screenshot_directory(self):
@@ -97,7 +92,9 @@ class _ScreenshotKeywords(KeywordGroup):
             filename = 'selenium-screenshot-%d.png' % self._screenshot_index
         else:
             filename = filename.replace('/', os.sep)
+
         screenshotDir = self._get_screenshot_directory()
+        logDir = self._get_log_dir()
         path = os.path.join(screenshotDir, filename)
-        link = robot.utils.get_link_path(path, screenshotDir)
+        link = robot.utils.get_link_path(path, logDir)
         return path, link

--- a/test/acceptance/keywords/screenshots.robot
+++ b/test/acceptance/keywords/screenshots.robot
@@ -33,10 +33,10 @@ Capture page screenshot to non-existing directory
   File Should Exist  ${OUTPUTDIR}/screenshot/test-screenshot.png
 
 Capture page screenshot to custom root directory
-  [Setup]  Remove Directory  ${OUTPUTDIR}/screenshot  recursive
-  Set Screenshot Directory  ${OUTPUTDIR}/screenshot
+  [Setup]  Remove Directory  ${OUTPUTDIR}/custom-root  recursive
+  Set Screenshot Directory  ${OUTPUTDIR}/custom-root
   Capture Page Screenshot  custom-root-screenshot.png
-  File Should Exist  ${OUTPUTDIR}/screenshot/custom-root-screenshot.png
+  File Should Exist  ${OUTPUTDIR}/custom-root/custom-root-screenshot.png
 
 Ensure screenshot captures revert to default root directory
   [Setup]  Remove Files  ${OUTPUTDIR}/default-root-screenshot.png


### PR DESCRIPTION
I noticed that the links to screenshots in the logs were linking to the correct locations in some situations. This PR fixes that. 
