### PR TITLE
Ensure RobotRunningError exists before using it

### DIFF
--- a/src/Selenium2Library/keywords/_logging.py
+++ b/src/Selenium2Library/keywords/_logging.py
@@ -3,7 +3,12 @@ import sys
 from robot.api import logger
 from keywordgroup import KeywordGroup
 from robot.libraries.BuiltIn import BuiltIn
-from robot.libraries.BuiltIn import RobotNotRunningError
+
+try:
+    from robot.libraries.BuiltIn import RobotNotRunningError
+except ImportError:
+    RobotNotRunningError = AttributeError
+
 
 class _LoggingKeywords(KeywordGroup):
 


### PR DESCRIPTION
@emanlove informed me that the `RobotNotRunningError` which was added to support the [PageObjects](https://github.com/ncbi/robotframework-pageobjects/issues/54) library was breaking some older versions of S2L. 

This fix was suggested by @pekkaklarck in our [conversation](https://github.com/rtomac/robotframework-selenium2library/commit/e43e782a5a0173a4dce2d60ce5f46e6ce3b78f78)

Hopefully this addresses any issues people were having with compatibility. 
