### PR TITLE
Added keyword 'Get WebElement'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+1.7.3 (unreleased)
+-------------------
+- Added 'Get WebElement' [zephraph][emanlove]
+
 1.7.2
 ----------------
 - Added an argument called screenshot_root_directory that can be passed into S2L's

--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -21,6 +21,13 @@ class _ElementKeywords(KeywordGroup):
 
     # Public, get element(s)
 
+    def get_webelement(self, locator):
+        """Returns the first WebElement matching the given locator.
+
+        See `introduction` for details about locating elements.
+        """
+        return self.get_webelements(locator)[0]
+
     def get_webelements(self, locator):
         """Returns list of WebElement objects matching locator.
 
@@ -599,7 +606,7 @@ return !element.dispatchEvent(evt);
         """Returns number of elements matching `xpath`
 
         One should not use the xpath= prefix for 'xpath'. XPath is assumed.
-        
+
         Correct:
         | count = | Get Matching Xpath Count | //div[@id='sales-pop']
         Incorrect:
@@ -615,7 +622,7 @@ return !element.dispatchEvent(evt);
         """Verifies that the page contains the given number of elements located by the given `xpath`.
 
         One should not use the xpath= prefix for 'xpath'. XPath is assumed.
-        
+
         Correct:
         | Xpath Should Match X Times | //div[@id='sales-pop'] | 1
         Incorrect:

--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -26,7 +26,7 @@ class _ElementKeywords(KeywordGroup):
 
         See `introduction` for details about locating elements.
         """
-        return self.get_webelements(locator)[0]
+        return self._element_find(locator, True, True)
 
     def get_webelements(self, locator):
         """Returns list of WebElement objects matching locator.

--- a/test/acceptance/keywords/elements.robot
+++ b/test/acceptance/keywords/elements.robot
@@ -7,6 +7,13 @@ Get Elements
     @{links}=  Get WebElements  //div[@id="div_id"]/a
     Length Should Be  ${links}  11
 
+Get First Matching Element
+    @{links}=  Get WebElements  //div[@id="div_id"]/a
+    ${link}=  Get WebElement  //div[@id="div_id"]/a
+    LOG  @{links}[0]
+    LOG  ${link}
+    Should Be Equal  @{links}[0]  ${link}
+
 More Get Elements
     [Setup]  Go To Page "forms/prefilled_email_form.html"
     @{checkboxes}=  Get WebElements  //input[@type="checkbox"]
@@ -51,4 +58,3 @@ Get Vertical Position
     ${pos}=  Get Vertical Position  link=Link
     Should Be True  ${pos} > ${0}
     Run Keyword And Expect Error  Could not determine position for 'non-existent'  Get Horizontal Position  non-existent
-

--- a/test/acceptance/keywords/elements.robot
+++ b/test/acceptance/keywords/elements.robot
@@ -10,8 +10,6 @@ Get Elements
 Get Web Element
     @{links}=  Get WebElements  //div[@id="div_id"]/a
     ${link}=  Get WebElement  //div[@id="div_id"]/a
-    LOG  @{links}[0]
-    LOG  ${link}
     Should Be Equal  @{links}[0]  ${link}
     Run Keyword and Expect Error  ValueError: Element locator 'id=non_existing_elem' did not match any elements.
     ...  Get WebElement  id=non_existing_elem

--- a/test/acceptance/keywords/elements.robot
+++ b/test/acceptance/keywords/elements.robot
@@ -7,12 +7,14 @@ Get Elements
     @{links}=  Get WebElements  //div[@id="div_id"]/a
     Length Should Be  ${links}  11
 
-Get First Matching Element
+Get Web Element
     @{links}=  Get WebElements  //div[@id="div_id"]/a
     ${link}=  Get WebElement  //div[@id="div_id"]/a
     LOG  @{links}[0]
     LOG  ${link}
     Should Be Equal  @{links}[0]  ${link}
+    Run Keyword and Expect Error  ValueError: Element locator 'id=non_existing_elem' did not match any elements.
+    ...  Get WebElement  id=non_existing_elem
 
 More Get Elements
     [Setup]  Go To Page "forms/prefilled_email_form.html"


### PR DESCRIPTION
This may or may not be merged. 

@emanlove, we briefly discussed this in #356 and I just wanted to broach the issue again. It was raised in #469 that the documentation using `Get WebElements` was wrong. I've corrected it in #472, but I'm using `Get WebElement` which obviously doesn't exist. 

We could of course just correct the documentation and only keep `Get WebElements`. 

It would be this

``` robotframework
@{elements}=   Get WebElements  id=my_element
Click Element  @{elements}[0]
```

versus

``` robotframework
${element}=  Get WebElement  id=my_element
Click Element  ${element}
```

@pekkaklarck, feel free to jump in on this conversation too.
