### PR TITLE
Add named keys to Press Key.

### DIFF
--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -483,10 +483,13 @@ return !element.dispatchEvent(evt);
         lead by '\\\\'.
 
         Examples:
-        | Press Key | text_field   | q |
-        | Press Key | login_button | \\\\13 | # ASCII code for enter key |
+        | Press Key | text_field   | q                |                                               |
+        | Press Key | login_button | \\\\13           | # ASCII code for enter key                    |
+        | Press Key | nav_console  | \\\\\\\\ARROW_UP | # selenium.webdriver.common.keys ARROW_UP KEY |
         """
-        if key.startswith('\\') and len(key) > 1:
+        if key.startswith('\\\\') and len(key) > 1:
+            key = getattr(Keys,key[2:])
+        elif key.startswith('\\') and len(key) > 1:
             key = self._map_ascii_key_code_to_key(int(key[1:]))
         #if len(key) > 1:
         #    raise ValueError("Key value '%s' is invalid.", key)

--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -480,12 +480,14 @@ return !element.dispatchEvent(evt);
         """Simulates user pressing key on element identified by `locator`.
 
         `key` is either a single character, a numerical ASCII code of the key lead by '\\\\',
-         or a NAMED KEY as described at https://selenium.googlecode.com/git/docs/api/py/webdriver/selenium.webdriver.common.keys.html
+         or a NAMED KEY as described in the [https://selenium.googlecode.com/git/docs/api/py/webdriver/selenium.webdriver.common.keys.html|Selenium docs].
 
         Examples:
         | Press Key | text_field   | q        | # The letter 'q'                              |
+        | Press Key | nav_console  | ARROW_UP | # Named ARROW_UP key                          |
         | Press Key | login_button | \\\\13   | # ASCII code for Enter key                    |
-        | Press Key | nav_console  | ARROW_UP | # selenium.webdriver.common.keys ARROW_UP KEY |
+
+        It's recommended to use named keys over ascii escapes (.i.e ``ENTER`` over ``\\\\13``)
 
         NAMED KEY value is new in Selenium2Library 1.7.3.
         """
@@ -759,7 +761,6 @@ return !element.dispatchEvent(evt);
            message = "Unknown key named '%s'." % (key_name)
            self._debug(message)
            raise ValueError(message)
-        return Keys.NULL
 
     def _parse_attribute_locator(self, attribute_locator):
         parts = attribute_locator.rpartition('@')

--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -479,29 +479,23 @@ return !element.dispatchEvent(evt);
     def press_key(self, locator, key):
         """Simulates user pressing key on element identified by `locator`.
 
-        `key` is either a single character, a numerical ASCII code of the key,\
+        `key` is either a single character, a numerical ASCII code of the key lead by '\\\\',
          or a NAMED KEY as described at https://selenium.googlecode.com/git/docs/api/py/webdriver/selenium.webdriver.common.keys.html
 
         Examples:
-        | Press Key | text_field   | q        |                                               |
-        | Press Key | login_button | \\\\13   | # ASCII code for Enter key (DEPRECATED)       |
-        | Press Key | login_button | 10       | # ASCII code for Return key                   |
+        | Press Key | text_field   | q        | # The letter 'q'                              |
+        | Press Key | login_button | \\\\13   | # ASCII code for Enter key                    |
         | Press Key | nav_console  | ARROW_UP | # selenium.webdriver.common.keys ARROW_UP KEY |
-        
+
         NAMED KEY value is new in Selenium2Library 1.7.3.
         """
         if len(key) > 1:
             if key.startswith('\\'):
-                self._warn("Press Key: Escaped ASCII codes are deprecated. Use plain numeric value: '%s'" % (key[1:]))
                 key = self._map_ascii_key_code_to_key(int(key[1:]))
             else:
-                try:
-                    key = (key.isdecimal() and self._map_ascii_key_code_to_key(int(key))) or\
-                          ((not key.isdecimal()) and self._map_named_key_code_to_special_key(key))
-                except:
-                    raise ValueError("Key value '%s' is invalid." % (key))
+                key = self._map_named_key_code_to_special_key(key)
         element = self._element_find(locator, True, True)
-        #select it
+        # select it
         element.send_keys(key)
 
     # Public, links
@@ -609,7 +603,7 @@ return !element.dispatchEvent(evt);
         """Returns number of elements matching `xpath`
 
         One should not use the xpath= prefix for 'xpath'. XPath is assumed.
-        
+
         Correct:
         | count = | Get Matching Xpath Count | //div[@id='sales-pop']
         Incorrect:
@@ -625,7 +619,7 @@ return !element.dispatchEvent(evt);
         """Verifies that the page contains the given number of elements located by the given `xpath`.
 
         One should not use the xpath= prefix for 'xpath'. XPath is assumed.
-        
+
         Correct:
         | Xpath Should Match X Times | //div[@id='sales-pop'] | 1
         Incorrect:
@@ -761,7 +755,7 @@ return !element.dispatchEvent(evt);
     def _map_named_key_code_to_special_key(self, key_name):
         try:
            return getattr(Keys, key_name)
-        except:
+        except AttributeError:
            message = "Unknown key named '%s'." % (key_name)
            self._debug(message)
            raise ValueError(message)

--- a/test/acceptance/keywords/textfields.robot
+++ b/test/acceptance/keywords/textfields.robot
@@ -1,40 +1,49 @@
-*Setting*
-Variables  variables.py
-Resource  ../resource.robot
-Test Setup  Go To Page "forms/prefilled_email_form.html"
+*** Setting ***
+Test Setup        Go To Page "forms/prefilled_email_form.html"
+Force Tags        txtfields
+Variables         variables.py
+Resource          ../resource.robot
 
-
-*Test Cases*
-
+*** Test Cases ***
 Get Value From Text Field
-  ${text} =  Get Value  name
-  Should Be Equal  ${text}  Prefilled Name
-  Clear Element Text  name
-  ${text} =  Get Value  name
-  Should Be Equal  ${text}  ${EMPTY}
+    ${text} =    Get Value    name
+    Should Be Equal    ${text}    Prefilled Name
+    Clear Element Text    name
+    ${text} =    Get Value    name
+    Should Be Equal    ${text}    ${EMPTY}
   
 
 Input Unicode In Text Field
-  Input Text  name  ${unic_text}
-  ${text} =  Get Value  name
-  Should Be Equal  ${text}  ${unic_text}
+    Input Text    name    ${unic_text}
+    ${text} =    Get Value    name
+    Should Be Equal    ${text}    ${unic_text}
 
 Input Password
-  [Documentation]  LOG 3 Typing password into text field 'password_field'
-  [Setup]  Go To Page "forms/login.html"
-  Input Text  username_field  username
-  Input Password  password_field  password
-  Submit Form
-  Verify Location Is "forms/submit.html"
+    [Documentation]    LOG 3 Typing password into text field 'password_field'
+    [Setup]    Go To Page "forms/login.html"
+    Input Text    username_field    username
+    Input Password    password_field    password
+    Submit Form
+    Verify Location Is "forms/submit.html"
 
 Press Key
-  [Setup]  Go To Page "forms/login.html"
-  Cannot Be Executed in IE
-  Input Text  username_field  James Bond
-  Press Key  password_field  f
-  Press Key  password_field   \\9
-  Press Key  login_button  \\10
-  Verify Location Is "forms/submit.html"
+    [Setup]    Go To Page "forms/login.html"
+    #Cannot Be Executed in IE
+    Input Text    username_field    James Bond
+    Press Key    username_field    \\\\HOME
+    Press Key    username_field    \\\\END
+    Press Key    username_field    \\\\ARROW_LEFT
+    Press Key    username_field    \\\\ARROW_LEFT
+    Press Key    username_field    \\\\ARROW_LEFT
+    Press Key    username_field    \\\\ARROW_LEFT
+    Press Key    username_field    \\\\ARROW_RIGHT
+    Press Key    username_field    \\108    #This is the 'l' char
+    ${text} =    Get Value    username_field
+    Should Be Equal    ${text}    James Blond
+    Press Key    password_field    f
+    Press Key    password_field    \\9
+    Press Key    login_button    \\10
+    Verify Location Is "forms/submit.html"
 
 Attempt Clear Element Text On Non-Editable Field
-  Run Keyword And Expect Error  *  Clear Element Text  can_send_email
+    Run Keyword And Expect Error    *    Clear Element Text    can_send_email

--- a/test/acceptance/keywords/textfields.robot
+++ b/test/acceptance/keywords/textfields.robot
@@ -30,19 +30,21 @@ Press Key
     [Setup]    Go To Page "forms/login.html"
     #Cannot Be Executed in IE
     Input Text    username_field    James Bond
-    Press Key    username_field    \\\\HOME
-    Press Key    username_field    \\\\END
-    Press Key    username_field    \\\\ARROW_LEFT
-    Press Key    username_field    \\\\ARROW_LEFT
-    Press Key    username_field    \\\\ARROW_LEFT
-    Press Key    username_field    \\\\ARROW_LEFT
-    Press Key    username_field    \\\\ARROW_RIGHT
-    Press Key    username_field    \\108    #This is the 'l' char
+    Press Key    username_field    HOME
+    Press Key    username_field    END
+    Press Key    username_field    ARROW_LEFT
+    Press Key    username_field    ARROW_LEFT
+    Press Key    username_field    ARROW_LEFT
+    Press Key    username_field    DELETE
+    Press Key    username_field    ARROW_LEFT
+    Press Key    username_field    ARROW_RIGHT
+    Press Key    username_field    \\108    #This is the 'l' char (deprecated style)
+    Press Key    username_field    111    #This is the 'o' char
     ${text} =    Get Value    username_field
     Should Be Equal    ${text}    James Blond
     Press Key    password_field    f
-    Press Key    password_field    \\9
-    Press Key    login_button    \\10
+    Press Key    password_field    9
+    Press Key    login_button    10
     Verify Location Is "forms/submit.html"
 
 Attempt Clear Element Text On Non-Editable Field

--- a/test/acceptance/keywords/textfields.robot
+++ b/test/acceptance/keywords/textfields.robot
@@ -11,7 +11,7 @@ Get Value From Text Field
     Clear Element Text    name
     ${text} =    Get Value    name
     Should Be Equal    ${text}    ${EMPTY}
-  
+
 
 Input Unicode In Text Field
     Input Text    name    ${unic_text}
@@ -38,13 +38,13 @@ Press Key
     Press Key    username_field    DELETE
     Press Key    username_field    ARROW_LEFT
     Press Key    username_field    ARROW_RIGHT
-    Press Key    username_field    \\108    #This is the 'l' char (deprecated style)
-    Press Key    username_field    111    #This is the 'o' char
+    Press Key    username_field    \\108    #This is the 'l' char
+    Press Key    username_field    o
     ${text} =    Get Value    username_field
     Should Be Equal    ${text}    James Blond
     Press Key    password_field    f
     Press Key    password_field    9
-    Press Key    login_button    10
+    Press Key    login_button    ENTER
     Verify Location Is "forms/submit.html"
 
 Attempt Clear Element Text On Non-Editable Field

--- a/test/acceptance/keywords/textfields.robot
+++ b/test/acceptance/keywords/textfields.robot
@@ -1,6 +1,5 @@
 *** Setting ***
 Test Setup        Go To Page "forms/prefilled_email_form.html"
-Force Tags        txtfields
 Variables         variables.py
 Resource          ../resource.robot
 


### PR DESCRIPTION
Adds named keys escaped with double backslash, for example \\ARROW_LEFT.
Also normalized test file.
Fixes #275 .
