### PR TITLE
Added Keyword 'Capture Screenshot Only On Failure'

### DIFF
--- a/src/Selenium2Library/keywords/_screenshot.py
+++ b/src/Selenium2Library/keywords/_screenshot.py
@@ -63,7 +63,7 @@ class _ScreenshotKeywords(KeywordGroup):
 
     def capture_screenshot_only_on_failure(self,keyword,*args):
         """Takes a screenshot of the current page and embeds it into the log
-        when the given ``keyword``  fails. If the given ``keyword`` can run miltiple times
+        when the given ``keyword``  fails. If the given ``keyword`` can run multiple times
         prior to timing out, the screenshot will only be captured on the very
         last failure.
 

--- a/src/Selenium2Library/keywords/_screenshot.py
+++ b/src/Selenium2Library/keywords/_screenshot.py
@@ -63,15 +63,14 @@ class _ScreenshotKeywords(KeywordGroup):
 
     def capture_screenshot_only_on_failure(self,keyword,*args):
         """Takes a screenshot of the current page and embeds it into the log
-        only when a specific keyword fails. If a keyword can run miltiple times
+        when the given ``keyword``  fails. If the given ``keyword`` can run miltiple times
         prior to timing out, the screenshot will only be captured on the very
         last failure.
 
         Example:
         |  Capture Screenshot Only On Failure  |  Wait Until Keyword Succeeds  |  5 min  1 sec  | On Page  |  ${page name}  | """
 
-        nothing = lambda *args: None
-        old_keyword = self.register_keyword_to_run_on_failure(nothing)
+        old_keyword = self.register_keyword_to_run_on_failure('nothing')
         status, value = BuiltIn().run_keyword_and_ignore_error(keyword,*args)
         self.register_keyword_to_run_on_failure(old_keyword)
         if (status=='FAIL'):

--- a/src/Selenium2Library/keywords/_screenshot.py
+++ b/src/Selenium2Library/keywords/_screenshot.py
@@ -61,6 +61,24 @@ class _ScreenshotKeywords(KeywordGroup):
         self._html('</td></tr><tr><td colspan="3"><a href="%s">'
                    '<img src="%s" width="800px"></a>' % (link, link))
 
+    def capture_screenshot_only_on_failure(self,keyword,*args):
+        """Takes a screenshot of the current page and embeds it into the log
+        only when a specific keyword fails. If a keyword can run miltiple times
+        prior to timing out, the screenshot will only be captured on the very
+        last failure.
+
+        Example:
+        |  Capture Screenshot Only On Failure  |  Wait Until Keyword Succeeds  |  5 min  1 sec  | On Page  |  ${page name}  | """
+
+        nothing = lambda *args: None
+        old_keyword = self.register_keyword_to_run_on_failure(nothing)
+        status, value = BuiltIn().run_keyword_and_ignore_error(keyword,*args)
+        self.register_keyword_to_run_on_failure(old_keyword)
+        if (status=='FAIL'):
+            self.capture_page_screenshot()
+            BuiltIn().fail(msg=value)
+        return value
+
     # Private
     def _create_directory(self, path):
         target_dir = os.path.dirname(path)


### PR DESCRIPTION
This keyword is very useful when looking back into the logs to see exactly why something failed. It also does not clutter up the logs with a large amount of unnecessary screenshots when you are waiting for a given keyword to succeed, it will simply capture a single screenshot if the keyword does fail.
