### PR TITLE
Quick fix for #489.

### DIFF
--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -490,9 +490,10 @@ return !element.dispatchEvent(evt);
          or a NAMED KEY as described in the [https://selenium.googlecode.com/git/docs/api/py/webdriver/selenium.webdriver.common.keys.html|Selenium docs].
 
         Examples:
-        | Press Key | text_field   | q        | # The letter 'q'                              |
-        | Press Key | nav_console  | ARROW_UP | # Named ARROW_UP key                          |
-        | Press Key | login_button | \\\\13   | # ASCII code for Enter key                    |
+        | Press Key | text_field   | q        | # The letter 'q'                                |
+        | Press Key | nav_console  | ARROW_UP | # Named ARROW_UP key                            |
+        | Press Key | login_button | \\\\13   | # ASCII code for Enter key                      |
+        | Press Key | custom_input | mystring | # String to be entered different from named key |
 
         It's recommended to use named keys over ascii escapes (.i.e ``ENTER`` over ``\\\\13``)
 
@@ -767,7 +768,7 @@ return !element.dispatchEvent(evt);
         except AttributeError:
            message = "Unknown key named '%s'." % (key_name)
            self._debug(message)
-           raise ValueError(message)
+           return(key_name)  # raise ValueError(message)
 
     def _parse_attribute_locator(self, attribute_locator):
         parts = attribute_locator.rpartition('@')

--- a/test/acceptance/keywords/textfields.robot
+++ b/test/acceptance/keywords/textfields.robot
@@ -49,6 +49,27 @@ Press Key
     Press Key    login_button    ENTER
     Verify Location Is "forms/submit.html"
 
+Press Key Words
+    [Documentation]    Press Key with words
+    [Setup]    Go To Page "forms/login.html"
+    #Cannot Be Executed in IE
+    Press Key    username_field    James Bond
+    Press Key    username_field    HOME
+    Press Key    username_field    END
+    Press Key    username_field    ARROW_LEFT
+    Press Key    username_field    ARROW_LEFT
+    Press Key    username_field    ARROW_LEFT
+    Press Key    username_field    DELETE
+    Press Key    username_field    ARROW_LEFT
+    Press Key    username_field    ARROW_RIGHT
+    Press Key    username_field    \\108    #This is the 'l' char
+    Press Key    username_field    o
+    ${text} =    Get Value    username_field
+    Should Be Equal    ${text}    James Blond
+    Press Key    password_field    f9
+    Press Key    login_button    ENTER
+    Verify Location Is "forms/submit.html"
+
 Attempt Clear Element Text On Non-Editable Field
     [Documentation]    Attempt Clear Element Text On Non-Editable Field
     Run Keyword And Expect Error    *    Clear Element Text    can_send_email


### PR DESCRIPTION
Press Key can send strings (if they do not match named keys).
With this PR, you can send strings of texts if they do not match exactly a named key.
