### PR TITLE
Fixes phantomjs and safari webdriver creation

### DIFF
--- a/test/acceptance/create_webdriver.robot
+++ b/test/acceptance/create_webdriver.robot
@@ -34,7 +34,7 @@ Set Driver Variables
     [Documentation]    Selects proper driver
     ${drivers}=    Create Dictionary    ff=Firefox    firefox=Firefox    ie=Ie
     ...    internetexplorer=Ie    googlechrome=Chrome    gc=Chrome
-    ...    chrome=Chrome    opera=Opera    phantomjs=PhantomJS safari=Safari
+    ...    chrome=Chrome    opera=Opera    phantomjs=PhantomJS    safari=Safari
     ${name}=    Evaluate    "Remote" if "${REMOTE_URL}"!="None" else ${drivers}["${BROWSER.lower().replace(' ', '')}"]
     Set Test Variable    ${DRIVER_NAME}    ${name}
     ${dc names}=    Create Dictionary    ff=FIREFOX    firefox=FIREFOX    ie=INTERNETEXPLORER


### PR DESCRIPTION
Fixes spacing at `phantomjs=PhantomJS    safari=Safari`. This error was introduced when cleaning up tests by me.
