### PR TITLE
Add py3.4 to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 python:
   - "2.6"
   - "2.7"
+  - "3.4"
 install:
   #- pip install pep8 --use-mirrors
   #- pip install pyflakes --use-mirrors


### PR DESCRIPTION
@aaltat This is basically all you have to do to get the tests to run with python 3.4 as discussed in #497. 

**[This PR is for demonstration, please don't merge]**
