### PR TITLE
Fixes `Unselect From List` due to Selenium changes.

### DIFF
--- a/src/Selenium2Library/keywords/_selectelement.py
+++ b/src/Selenium2Library/keywords/_selectelement.py
@@ -271,8 +271,17 @@ class _SelectElementKeywords(KeywordGroup):
 
         select, options = self._get_select_list_options(select)
         for item in items:
-            select.deselect_by_value(item)
-            select.deselect_by_visible_text(item)
+            try:
+                select.deselect_by_value(item)
+                # Code for selenium <= 2.52.0
+                select.deselect_by_visible_text(item)
+            except:  # Code for selenium > 2.52.0
+                try:
+                    select.deselect_by_visible_text(item)
+                except:
+                    self._warn("Tried to unselect missing selection item, \
+'%s' from locator '%s'." % (item, locator))
+                    continue
 
     def unselect_from_list_by_index(self, locator, *indexes):
         """Unselects `*indexes` from list identified by `locator`


### PR DESCRIPTION
Since Selenium version 2.53.0 deselect_by_value/label returns boolean, and
Exception if element is not found.
This fix keeps compatibility with versions <=2.52.0.
