### PR TITLE
Improve behavior of setting desired_capabilities

### DIFF
--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -540,10 +540,9 @@ class _BrowserManagementKeywords(KeywordGroup):
 
         if profile_dir:
             if profile_dir != "":
-            profile = webdriver.FirefoxProfile(profile_dir)
+                profile = webdriver.FirefoxProfile(profile_dir)
         else:
-            profile_dir = FIREFOX_PROFILE_DIR
-            profile = webdriver.FirefoxProfile(profile_dir)
+            profile = webdriver.FirefoxProfile(FIREFOX_PROFILE_DIR)
 
         if remote:
             browser = self._create_remote_web_driver(webdriver.DesiredCapabilities.FIREFOX  ,

--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -539,7 +539,12 @@ class _BrowserManagementKeywords(KeywordGroup):
     def _make_ff(self , remote , desired_capabilites , profile_dir):
 
         if profile_dir:
+            if profile_dir != "":
             profile = webdriver.FirefoxProfile(profile_dir)
+        else:
+            profile_dir = FIREFOX_PROFILE_DIR
+            profile = webdriver.FirefoxProfile(profile_dir)
+
         if remote:
             browser = self._create_remote_web_driver(webdriver.DesiredCapabilities.FIREFOX  ,
                         remote , desired_capabilites , profile)

--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -628,5 +628,7 @@ class _BrowserManagementKeywords(KeywordGroup):
                     desired_capabilities_object.pop(key.strip(), None)
             else:
                 desired_capabilities[key.strip()] = value.strip()
-
-        return desired_capabilities_object.update(desired_capabilities)
+        
+        desired_capabilities_object.update(desired_capabilities)
+        
+        return desired_capabilities_object

--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -623,10 +623,10 @@ class _BrowserManagementKeywords(KeywordGroup):
         for cap in capabilities_string.split(","):
             (key, value) = cap.split(":", 1)
             
-            if key.strip() in desired_capabilities_object:
-                if value.strip() == "":
-                        desired_capabilities_object.pop(key.strip(), None)
-                else:
-                    desired_capabilities[key.strip()] = value.strip()
+            if value.strip() == "":
+                if key.strip() in desired_capabilities_object:
+                    desired_capabilities_object.pop(key.strip(), None)
+            else:
+                desired_capabilities[key.strip()] = value.strip()
 
         return desired_capabilities_object.update(desired_capabilities)

--- a/test/unit/keywords/test_browsermanagement.py
+++ b/test/unit/keywords/test_browsermanagement.py
@@ -47,7 +47,7 @@ class BrowserManagementTests(unittest.TestCase):
     def test_parse_capabilities_string(self):
         bm = _BrowserManagementKeywords()
         expected_caps = "key1:val1,key2:val2"
-        capabilities = bm._parse_capabilities_string(expected_caps)
+        capabilities = bm._parse_capabilities_string({}, expected_caps)
         self.assertTrue("val1", capabilities["key1"])
         self.assertTrue("val2", capabilities["key2"])
         self.assertTrue(2, len(capabilities))
@@ -55,7 +55,7 @@ class BrowserManagementTests(unittest.TestCase):
     def test_parse_complex_capabilities_string(self):
         bm = _BrowserManagementKeywords()
         expected_caps = "proxyType:manual,httpProxy:IP:port"
-        capabilities = bm._parse_capabilities_string(expected_caps)
+        capabilities = bm._parse_capabilities_string({}, expected_caps)
         self.assertTrue("manual", capabilities["proxyType"])
         self.assertTrue("IP:port", capabilities["httpProxy"])
         self.assertTrue(2, len(capabilities))


### PR DESCRIPTION
Remove forceful Firefox profile definition.
Add ability to remove default desired_capabilities definitions.

Signed-off-by: Matthew Valimaki matthew.valimaki@gmail.com
