### PR TITLE
Fixes #257 by removing the docutils dependency

### DIFF
--- a/doc/buildhtml.py
+++ b/doc/buildhtml.py
@@ -26,13 +26,16 @@ import os
 import os.path
 import copy
 from fnmatch import fnmatch
-import docutils
-from docutils import ApplicationError
-from docutils import core, frontend, utils
-from docutils.error_reporting import ErrorOutput, ErrorString
-from docutils.parsers import rst
-from docutils.readers import standalone, pep
-from docutils.writers import html4css1, pep_html
+try:
+    import docutils
+    from docutils import ApplicationError
+    from docutils import core, frontend, utils
+    from docutils.error_reporting import ErrorOutput, ErrorString
+    from docutils.parsers import rst
+    from docutils.readers import standalone, pep
+    from docutils.writers import html4css1, pep_html
+except ImportError:
+  raise ImportError('Importing `docutils` failed. Install it with `pip install docutils`.')
 
 
 usage = '%prog [options] [<directory> ...]'

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,7 @@ setup(name         = 'robotframework-selenium2library',
       install_requires = [
 							'decorator >= 3.3.2',
 							'selenium >= 2.32.0',
-							'robotframework >= 2.6.0',
-							'docutils >= 0.8.1'
+							'robotframework >= 2.6.0'
 						 ],
       py_modules=['ez_setup'],
       package_dir  = {'' : 'src'},


### PR DESCRIPTION
The docutils is only needed for Selenium2Library development,
therefore removed the dependency from setup.py. Also added meaningfull
error message to development tools, if the docutils is not installed.
