### PR TITLE
Unit Tests will not run on Fedora without this PR

### DIFF
--- a/test/run_unit_tests.py
+++ b/test/run_unit_tests.py
@@ -5,7 +5,7 @@ from Selenium2Library import utils
 
 def run_unit_tests(modules_to_run=[]):
     (test_module_names, test_modules) = utils.import_modules_under(
-        env.UNIT_TEST_DIR, include_root_package_name = False, pattern="test*.py")
+        env.UNIT_TEST_DIR, include_root_package_name = True, pattern="test*.py")
 
     bad_modules_to_run = [module_to_run for module_to_run in modules_to_run
         if module_to_run not in test_module_names]


### PR DESCRIPTION
Setting include_root_package_name to True, will allow running unit tests in Fedora 22, and all other O.S.
