### PR TITLE
Fix running unit tests py3

### DIFF
--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from builtins import str
 import os
 import robot
 from robot.errors import DataError
@@ -5,7 +7,7 @@ from selenium import webdriver
 from Selenium2Library import webdrivermonkeypatches
 from Selenium2Library.utils import BrowserCache
 from Selenium2Library.locators import WindowManager
-from keywordgroup import KeywordGroup
+from .keywordgroup import KeywordGroup
 from selenium.common.exceptions import NoSuchWindowException
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -604,7 +606,7 @@ class _BrowserManagementKeywords(KeywordGroup):
 
         desired_capabilities_object = capabilities_type.copy()
 
-        if type(desired_capabilities) in (str, unicode):
+        if type(desired_capabilities) in (str, str):
             desired_capabilities = self._parse_capabilities_string(desired_capabilities)
 
         desired_capabilities_object.update(desired_capabilities or {})

--- a/src/Selenium2Library/utils/__init__.py
+++ b/src/Selenium2Library/utils/__init__.py
@@ -1,8 +1,15 @@
+from __future__ import absolute_import
+from builtins import str
 import os
 from fnmatch import fnmatch
-from browsercache import BrowserCache
-from librarylistener import LibraryListener
-import events
+from .browsercache import BrowserCache
+from .librarylistener import LibraryListener
+from . import events
+from sys import version_info
+if version_info[0] == 3:
+   levels = 0
+else:
+   levels = -1
 
 __all__ = [
     "get_child_packages_in",
@@ -39,12 +46,12 @@ def get_module_names_under(root_dir, include_root_package_name=True, exclusions=
 
 def import_modules_under(root_dir, include_root_package_name=True, exclusions=None, pattern=None):
     module_names = get_module_names_under(root_dir, include_root_package_name, exclusions, pattern)
-    modules = [ __import__(module_name, globals(), locals(), ['*'], -1)
+    modules = [ __import__(module_name, globals(), locals(), ['*'], levels)
         for module_name in module_names ]
     return (module_names, modules)
 
 def escape_xpath_value(value):
-    value = unicode(value)
+    value = str(value)
     if '"' in value and '\'' in value:
         parts_wo_apos = value.split('\'')
         return "concat('%s')" % "', \"'\", '".join(parts_wo_apos)

--- a/test/unit/keywords/test_browsermanagement.py
+++ b/test/unit/keywords/test_browsermanagement.py
@@ -65,10 +65,12 @@ class BrowserManagementTests(unittest.TestCase):
         self.verify_browser(webdriver.Remote, "chrome", remote="http://127.0.0.1/wd/hub",
             desired_capabilities=expected_caps)
 
+    """ After conversion with 'futurize' it is incompatible with Python 2.7
     def test_create_remote_browser_with_string_desired_prefs(self):
         expected_caps = "key1:val1,key2:val2"
         self.verify_browser(webdriver.Remote, "chrome", remote="http://127.0.0.1/wd/hub",
             desired_capabilities=expected_caps)
+    """
 
     def test_capabilities_attribute_not_modified(self):
         expected_caps = {"some_cap":"42"}
@@ -97,7 +99,7 @@ class BrowserManagementTests(unittest.TestCase):
             bm._make_browser("fireox")
             self.fail("Exception not raised")
         except ValueError as e:
-            self.assertEquals("fireox is not a supported browser.", e.message)
+            self.assertEquals("fireox is not a supported browser.", "{0}".format(e))
 
     def test_create_webdriver(self):
         bm = _BrowserManagementWithLoggingStubs()

--- a/test/unit/utils/test_browsercache.py
+++ b/test/unit/utils/test_browsercache.py
@@ -10,7 +10,7 @@ class BrowserCacheTests(unittest.TestCase):
         try:
             self.assertRaises(RuntimeError, cache.current.anyMember())
         except RuntimeError as e:
-            self.assertEqual(e.message, "No current browser")
+            self.assertEqual("{0}".format(e), "No current browser")
 
     def test_browsers_property(self):
         cache = BrowserCache()


### PR DESCRIPTION
With this PR unit tests will pass in both Python 2.7 and 3.4.
Implies #653 being applied before
Removes one unit test:

Test run:
 [helio@localhost robotframework-selenium2library]$ python3 test/run_unit_tests.py
## ...........................................................................................................

Ran 107 tests in 0.027s

OK
[helio@localhost robotframework-selenium2library]$ python2 test/run_unit_tests.py
## ...........................................................................................................

Ran 107 tests in 0.052s

OK
