### PR TITLE
Add requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+decorator >= 3.3.2
+selenium >= 2.32.0
+robotframework >= 2.6.0

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python
 
-from os.path import join, dirname
+from os.path import abspath, dirname, join
 
 from setuptools import setup
 
-execfile(join(dirname(__file__), 'src', 'Selenium2Library', 'version.py'))
+
+CURDIR = dirname(abspath(__file__))
+
+execfile(join(CURDIR, 'src', 'Selenium2Library', 'version.py'))
 
 DESCRIPTION = """
 Selenium2Library is a web testing library for Robot Framework
 that leverages the Selenium 2 (WebDriver) libraries.
 """[1:-1]
+
+with open(join(CURDIR, 'requirements.txt')) as f:
+    REQUIREMENTS = f.read().splitlines()
 
 setup(name         = 'robotframework-selenium2library',
       version      = VERSION,
@@ -28,11 +34,7 @@ setup(name         = 'robotframework-selenium2library',
                         "Programming Language :: Python",
                         "Topic :: Software Development :: Testing"
                      ],
-      install_requires = [
-							'decorator >= 3.3.2',
-							'selenium >= 2.32.0',
-							'robotframework >= 2.6.0'
-						 ],
+      install_requires = REQUIREMENTS,
       package_dir  = {'' : 'src'},
       packages     = ['Selenium2Library','Selenium2Library.keywords','Selenium2Library.locators',
                       'Selenium2Library.utils'],


### PR DESCRIPTION
Eases installing project requirements e.g. when doing development. To avoid listing
requirements twice, changed setup.py to read install_requires content from
requirements.txt directly.
