### PR TITLE
Clean up run_unit_tests.py.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-  - "2.6"
   - "2.7"
 install:
   #- pip install pep8 --use-mirrors

--- a/src/Selenium2Library/utils/__init__.py
+++ b/src/Selenium2Library/utils/__init__.py
@@ -1,47 +1,7 @@
-import os
-from fnmatch import fnmatch
 from browsercache import BrowserCache
 from librarylistener import LibraryListener
 import events
 
-__all__ = [
-    "get_child_packages_in",
-    "get_module_names_under",
-    "import_modules_under",
-    "escape_xpath_value",
-    "BrowserCache",
-    "LibraryListener",
-    "events"
-]
-
-# Public
-
-def get_child_packages_in(root_dir, include_root_package_name=True, exclusions=None):
-    packages = []
-    root_package_str = os.path.basename(root_dir) + '.' if include_root_package_name else ""
-    _discover_child_package_dirs(
-        root_dir,
-        _clean_exclusions(exclusions),
-        lambda abs_path, relative_path, name:
-            packages.append(root_package_str + relative_path.replace(os.sep, '.')))
-    return packages
-
-def get_module_names_under(root_dir, include_root_package_name=True, exclusions=None, pattern=None):
-    module_names = []
-    root_package_str = os.path.basename(root_dir) + '.' if include_root_package_name else ""
-    _discover_module_files_in(
-        root_dir,
-        _clean_exclusions(exclusions),
-        pattern if pattern is not None else "*.*",
-        lambda abs_path, relative_path, name:
-            module_names.append(root_package_str + os.path.splitext(relative_path)[0].replace(os.sep, '.')))
-    return module_names
-
-def import_modules_under(root_dir, include_root_package_name=True, exclusions=None, pattern=None):
-    module_names = get_module_names_under(root_dir, include_root_package_name, exclusions, pattern)
-    modules = [ __import__(module_name, globals(), locals(), ['*'], -1)
-        for module_name in module_names ]
-    return (module_names, modules)
 
 def escape_xpath_value(value):
     value = unicode(value)
@@ -51,42 +11,3 @@ def escape_xpath_value(value):
     if '\'' in value:
         return "\"%s\"" % value
     return "'%s'" % value
-
-# Private
-
-def _clean_exclusions(exclusions):
-    if exclusions is None: exclusions = []
-    if not isinstance(exclusions, list): exclusions = [ exclusions ]
-    exclusions = [ os.sep + exclusion.lower().strip(os.sep) + os.sep
-        for exclusion in exclusions ]
-    return exclusions
-
-def _discover_child_package_dirs(root_dir, exclusions, callback, relative_dir=None):
-    relative_dir = relative_dir if relative_dir is not None else ''
-    abs_dir = os.path.join(root_dir, relative_dir)
-    for item in os.listdir(abs_dir):
-        item_relative_path = os.path.join(relative_dir, item)
-        item_abs_path = os.path.join(root_dir, item_relative_path)
-        if os.path.isdir(item_abs_path):
-            if os.path.exists(os.path.join(item_abs_path, "__init__.py")):
-                exclusion_matches = [ exclusion for exclusion in exclusions
-                    if os.sep + item_relative_path.lower() + os.sep == exclusion ]
-                if not exclusion_matches:
-                    callback(item_abs_path, item_relative_path, item)
-                    _discover_child_package_dirs(root_dir, exclusions, callback, item_relative_path)
-
-def _discover_module_files_in(root_dir, exclusions, pattern, callback):
-    def find_matching_files(relative_dir):
-        abs_dir = os.path.join(root_dir, relative_dir)
-        for item in os.listdir(abs_dir):
-            item_relative_path = os.path.join(relative_dir, item)
-            item_abs_path = os.path.join(root_dir, item_relative_path)
-            if os.path.isfile(item_abs_path) and fnmatch(item, pattern):
-                callback(item_abs_path, item_relative_path, item)
-
-    find_matching_files('')
-
-    _discover_child_package_dirs(
-        root_dir,
-        _clean_exclusions(exclusions),
-        lambda abs_path, relative_path, name: find_matching_files(relative_path))

--- a/test/run_unit_tests.py
+++ b/test/run_unit_tests.py
@@ -1,29 +1,22 @@
-import env
-import os, sys
-import unittest
-from Selenium2Library import utils
+#!/usr/bin/env python
 
-def run_unit_tests(modules_to_run=[]):
-    (test_module_names, test_modules) = utils.import_modules_under(
-        env.UNIT_TEST_DIR, include_root_package_name = False, pattern="test*.py")
+from os.path import abspath, dirname, join
+from unittest import defaultTestLoader, TextTestRunner
+import sys
 
-    bad_modules_to_run = [module_to_run for module_to_run in modules_to_run
-        if module_to_run not in test_module_names]
-    if bad_modules_to_run:
-        print("Specified test module%s not exist: %s" % (
-            ' does' if len(bad_modules_to_run) == 1 else 's do',
-            ', '.join(bad_modules_to_run)))
-        return -1
 
-    tests = [unittest.defaultTestLoader.loadTestsFromModule(test_module) 
-        for test_module in test_modules]
+CURDIR = dirname(abspath(__file__))
 
-    runner = unittest.TextTestRunner()
-    result = runner.run(unittest.TestSuite(tests))
-    rc = len(result.failures) + len(result.errors)
-    if rc > 255: rc = 255
-    return rc
+
+def run_unit_tests():
+    sys.path.insert(0, join(CURDIR, '..', 'src'))
+    try:
+        suite = defaultTestLoader.discover(join(CURDIR, 'unit'), 'test_*.py')
+        result = TextTestRunner().run(suite)
+    finally:
+        sys.path.pop(0)
+    return min(len(result.failures) + len(result.errors), 255)
+
 
 if __name__ == '__main__':
-    sys.exit(run_unit_tests(sys.argv[1:]))
-
+    sys.exit(run_unit_tests())


### PR DESCRIPTION
Finding unit tests is rewritten by using test discovery functionality
provided by the unittest module in Python 2.7 and newer. This means
unit tests cannot be executed with Python 2.6 anymore, but we've
decided to drop its support anyway (#620). Tests won't be run with
Python 2.6 on Travis anymore either.

Also removed utils related to loading modules from S2L.utils. This
unit test related code didn't belong under the main project in the
first place.
