### PR TITLE
Selenium2Library keywords to use human readable text instead of locator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+1.8.1
+-------------------
+- Enhanced 'Add Location Strategy' to read locators stored in dictionary or remote database.
+  [divfor]
+
 1.8.0
 -----
 - Moved keyword documentation to:

--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -650,36 +650,51 @@ return !element.dispatchEvent(evt);
 
     # Public, custom
     def add_location_strategy(self, strategy_name, strategy_keyword=None, location=None, persist=False):
-        """Adds a custom location strategy based on a user keyword. Location strategies are
-        automatically removed after leaving the current scope by default. Setting `persist`
-        to any non-empty string will cause the location strategy to stay registered throughout
-        the life of the test.
+        """Adds a custom location strategy based on a user keyword.
+        
+        strategy_name: give an unique shortname as a customized prefix, such as 'myid', so that you can
+        use 'myid=User Name' instead of a legency locator '//div[text()="User Name"]/../input' in test cases.
+        strategy_name will be removed automatically after leaving the current scope if persist=False. 
 
-        Trying to add a custom location strategy with the same name as one that already exists will
-        cause the keyword to fail.
-
-        stragegy_name:
-            User defined short name as prefix of custom locator and used in format of
-            'Any Keyword | ${stragegy_name}=${criteria}'. 
-
-        strategy_keyword:
-            User defined keyword resgistered for hook call by any keywords.
-            If not defined, use location.get() when ${location} is a dictionary.
-            
-            Arguments:
-            
-                ${location}: where to get locator by ${criteria}, such as a dictionary or a database.
-                
-                ${criteria}: meaningful text with good readability, such as element's GUI text.
-                
-            Return: 
-            
-                return web element(s) if ${location} is None, or 
-                return legency locator string like 'xpath=xxx'.
+        strategy_keyword: an user_keyword(location, criteria) to be registered for converting string ${criteria}
+        to a legency locator like 'id=xxx', 'css=xxx', 'xpath=//xxx' or '//div/button[1]'. ${criteria} should be
+        meaningful text to add good readability to test cases, such as element's GUI text. This keyword will be
+        called internally and automatically when any Selenium2Library keyword is called, and should
+        return a legency locator string or web element(s) if ${location} is None.
+        
+        location: the source that stores the mapping from ${criteria} to legency locator, such as a dictionary,
+        page objects, or database.
+        
+        Examples A ( ${location} is a database ):
+        | # *** define strategy keyword *** |
+        | Get Locator From DB | ${location} | ${criteria} |
+        |   | ${index}= | Convert To Integer | ${criteria} |
+        |   | ${locator}= | Read MySQL | ${location} | ${index} |
+        |   | [Return] | ${locator} |
+        | # *** register strategy keyword *** |
+        | Add Location Strategy | db | Get Locator From DB | ${MySQL} |
+        | # *** In Use *** |
+        | Page Should Contain Element | db=${item_index} |
+        
+         
+        Examples B ( ${location} is a python dictionary):
+        # Define python file and import:
+        div_blocks = '//form'
+        # ${index} defined in user keyword
+        page = '${div_blocks}/div[${index}]'
+        dict_page = {
+            'Add Button': '${page}/div/button[1]',
+            'Delete Button': '${page}/div/button[2]
+        }
+        | # *** Register strategy keyword *** |
+        | Add Location Strategy | pg | | ${dict_page} |
+        | # *** Use *** |
+        | ${index}= | Set Variable | 1
+        | Click Button | pg=Add Button |
         
         
-        Examples ( ${location} is None ):
-        | #***Strategy Keyword examples*** |
+        Examples C ( ${location} is None ):
+        | #*** Define Strategy Keyword *** |
         | Return Web Element By Javascript | [Arguments] | ${browser} | ${criteria} | ${tag} | ${constraints} |
         |   | ${element_object}= | Execute Javascript | return window.document.getElementById('${criteria}'); |
         |   | [Return] | ${element_object} |
@@ -691,40 +706,6 @@ return !element.dispatchEvent(evt);
         | Add Location Strategy | byui | Return Web Element By Element Prompt Text |
         | Page Should Contain Element | byjs=${an_element_id} |
         | Page Should Contain Element | byui=User Name |
-        
-        Examples ( ${location} is a python dictionary ):
- 
-        # Step 1, define the dictionary:
-
-        all_blocks = '//form'
-
-        # ${index} to be defined in user keyword
-
-        login_block = '//${all_blocks}[@id="login"]/div[${index}]'
-
-        dict_users = {
-
-           'User Name': 'id=input_0',
-
-           'Password': 'id=input_1',
-
-            'Add Button': '${login_block}/div/button[1]',
-
-            'Delete Button': '${login_block}/div/button[2]
-
-        }
-
-        
-        Examples ( ${location} is a database ):
-        | # Step 1, define strategy keyword: |
-        | Read Locator String From DB | [Arguments] | ${location} | ${criteria} |
-        |   | ${locator_string}= | Read From Your Database | ${location} | ${criteria} |
-        |   | [Return] | ${locator_string} |
-        | # Step 2, register: |
-        | ${location}= | Set Variable | ${certain_database} |
-        | Add Location Strategy | db | Read Locator String From DB | ${location} |
-        | # Step 3, use custom locators: |
-        | Page Should Contain Element | db=${an_element_index} |
 
         See `Remove Location Strategy` for details about removing a custom location strategy.
         """

--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -649,7 +649,7 @@ return !element.dispatchEvent(evt);
                    % (actual_xpath_count, xpath))
 
     # Public, custom
-    def add_location_strategy(self, strategy_name, strategy_keyword=None, location=None, persist=False):
+    def add_location_strategy(self, strategy_name, strategy_keyword=None, persist=False, location=None):
         """Add a custom location strategy based on given user keyword
         
         < strategy_name > an unique short name as a customized prefix, such as 'myid', so that you can
@@ -673,7 +673,7 @@ return !element.dispatchEvent(evt);
         |   | ${locator}= | Read MySQL | ${location} | ${index} |
         |   | [Return] | ${locator} |
         | # *** Register and use *** |
-        | Add Location Strategy | db | Get Locator From DB | ${MySQL} |
+        | Add Location Strategy | db | Get Locator From DB | ${False} | ${MySQL} |
         | Page Should Contain Element | db=${obj_index} |
 
 

--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -650,62 +650,57 @@ return !element.dispatchEvent(evt);
 
     # Public, custom
     def add_location_strategy(self, strategy_name, strategy_keyword=None, location=None, persist=False):
-        """Adds a custom location strategy based on a user keyword.
+        """Add a custom location strategy based on given user keyword
         
-        strategy_name: give an unique shortname as a customized prefix, such as 'myid', so that you can
-        use 'myid=User Name' instead of a legency locator '//div[text()="User Name"]/../input' in test cases.
-        strategy_name will be removed automatically after leaving the current scope if persist=False. 
+        < strategy_name > an unique short name as a customized prefix, such as 'myid', so that you can
+        use 'myid=User Name' instead of a legacy locator '//div[text()="User Name"]/../input' when using
+        Selenium2Library keywords. Scoped locally if persist=False, or the whole test if persist=True.
 
-        strategy_keyword: an user_keyword(location, criteria) to be registered for converting string ${criteria}
-        to a legency locator like 'id=xxx', 'css=xxx', 'xpath=//xxx' or '//div/button[1]'. ${criteria} should be
-        meaningful text to add good readability to test cases, such as element's GUI text. This keyword will be
-        called internally and automatically when any Selenium2Library keyword is called, and should
-        return a legency locator string or web element(s) if ${location} is None.
+        < strategy_keyword > an user keyword with arguments (location, criteria) to be registered.
+        It should return a legacy locator (string like 'id=xxx', 'css=xxx', 'xpath=//xxx', '//div/button[1]')
+        retrieved from ${location} by given ${criteria}, or the matched web element if ${location} is None.
+        ${criteria} could be meaningful text to increase test case's readability, such as element's GUI text.
+        Once registered, this keyword will be hook-called internally when Selenium2Library keyword is called.
         
-        location: the source that stores the mapping from ${criteria} to legency locator, such as a dictionary,
+        < location > the source that stores the mapping from ${criteria} to legacy locator, such as a dictionary,
         page objects, or database.
         
-        Examples A ( ${location} is a database ):
-        | # *** define strategy keyword *** |
+        Examples A ( location is a database ):
+        | # *** Define strategy keyword *** |
         | Get Locator From DB | ${location} | ${criteria} |
         |   | ${index}= | Convert To Integer | ${criteria} |
         |   | ${locator}= | Read MySQL | ${location} | ${index} |
         |   | [Return] | ${locator} |
-        | # *** register strategy keyword *** |
+        | # *** Register and use *** |
         | Add Location Strategy | db | Get Locator From DB | ${MySQL} |
-        | # *** In Use *** |
-        | Page Should Contain Element | db=${item_index} |
-        
-         
-        Examples B ( ${location} is a python dictionary):
-        # Define python file and import:
-        div_blocks = '//form'
-        # ${index} defined in user keyword
-        page = '${div_blocks}/div[${index}]'
-        dict_page = {
-            'Add Button': '${page}/div/button[1]',
-            'Delete Button': '${page}/div/button[2]
-        }
-        | # *** Register strategy keyword *** |
-        | Add Location Strategy | pg | | ${dict_page} |
-        | # *** Use *** |
-        | ${index}= | Set Variable | 1
+        | Page Should Contain Element | db=${obj_index} |
+
+
+        Examples B ( location is a python dictionary, strategy keyword could be omitted ):
+        | # *** Define python file and import *** |
+        | div_blocks = '//form' |
+        | page = '${div_blocks}/div[${index}]' | # ${index} defined in user keyword |
+        | dict_page = {'Add Button': '${page}/div/button[1]', 'Delete Button': '${page}/div/button[2]} |
+        | # *** Register and use *** |
+        | Add Location Strategy | pg | | location=${dict_page} |
+        | ${index}= | Set Variable | 1 |
         | Click Button | pg=Add Button |
         
-        
-        Examples C ( ${location} is None ):
-        | #*** Define Strategy Keyword *** |
-        | Return Web Element By Javascript | [Arguments] | ${browser} | ${criteria} | ${tag} | ${constraints} |
+
+        Examples C ( location is None, strategy keyword must return web element object ):
+        | # *** Define Strategy Keyword, 4 args needed *** |
+        | Return Web Element By Javascript | ${browser} | ${criteria} | ${tag} | ${constraints} |
         |   | ${element_object}= | Execute Javascript | return window.document.getElementById('${criteria}'); |
         |   | [Return] | ${element_object} |
-        | Return Web Element By Element Prompt Text | [Arguments] | ${browser} | ${criteria} | ${tag} | ${constraints} |
+        | Return Web Element By Element Text | ${browser} | ${criteria} | ${tag} | ${constraints} |
         |   | ${element_object}= | Get Webelement | &${myPageDict}[${criteria}] |
         |   | [Return] | ${element_object} |
-        | #***Register and Usage:*** |
+        | # *** Register and use *** |
         | Add Location Strategy | byjs | Return Web Element By Javascript |
-        | Add Location Strategy | byui | Return Web Element By Element Prompt Text |
+        | Add Location Strategy | byui | Return Web Element By Element Text |
         | Page Should Contain Element | byjs=${an_element_id} |
         | Page Should Contain Element | byui=User Name |
+
 
         See `Remove Location Strategy` for details about removing a custom location strategy.
         """

--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -664,7 +664,8 @@ return !element.dispatchEvent(evt);
         
         < location > the source that stores the mapping from ${criteria} to legacy locator, such as a dictionary,
         page objects, or database.
-        
+
+
         Examples A ( location is a database ):
         | # *** Define strategy keyword *** |
         | Get Locator From DB | ${location} | ${criteria} |
@@ -701,12 +702,10 @@ return !element.dispatchEvent(evt);
         | Page Should Contain Element | byjs=${an_element_id} |
         | Page Should Contain Element | byui=User Name |
 
-
         See `Remove Location Strategy` for details about removing a custom location strategy.
         """
         strategy = CustomLocator(strategy_name, strategy_keyword)
         self._element_finder.register(strategy, persist, location)
-
 
     def remove_location_strategy(self, strategy_name):
         """Removes a previously added custom location strategy.

--- a/src/Selenium2Library/locators/elementfinder.py
+++ b/src/Selenium2Library/locators/elementfinder.py
@@ -1,6 +1,7 @@
 from Selenium2Library import utils
 from robot.api import logger
 from robot.utils import NormalizedDict
+from robot.libraries.BuiltIn import BuiltIn
 
 
 class ElementFinder(object):
@@ -24,6 +25,7 @@ class ElementFinder(object):
         }
         self._strategies = NormalizedDict(initial=strategies, caseless=True, spaceless=True)
         self._default_strategies = list(strategies.keys())
+        self._locations = {}
 
     def find(self, browser, locator, tag=None):
         assert browser is not None
@@ -32,16 +34,36 @@ class ElementFinder(object):
         (prefix, criteria) = self._parse_locator(locator)
         prefix = 'default' if prefix is None else prefix
         strategy = self._strategies.get(prefix)
+        location = self._locations.get(prefix)
+        if location is not None:
+            if hasattr(strategy, '__call__'):
+                locator = strategy(location, criteria)
+            elif isinstance(strategy, basestring) and len(strategy) > 0:
+                locator = BuiltIn().run_keyword(strategy, location, criteria)
+                logger.debug("Get locator via keyword '" + strategy + "': '" + criteria + "' -> '" + locator + "'")
+            elif isinstance(location, dict):
+                locator = location.get(criteria, criteria)
+                logger.debug("Get locator via dictionary: '" + criteria + "' -> '" + locator + "'")
+            else:
+                raise ValueError("Invaild strategy '" + str(strategy) + "' with location '"+ str(location) + "'")
+            if isinstance(locator, basestring):
+                while locator.find('${') >= 0:
+                    locator = BuiltIn().run_keyword('Replace Variables', locator)
+                    logger.debug("Locator replaced variables: " + locator)
+            (prefix, criteria) = self._parse_locator(locator)
+            prefix = 'default' if prefix is None else prefix
+            strategy = self._strategies.get(prefix)
         if strategy is None:
             raise ValueError("Element locator with prefix '" + prefix + "' is not supported")
         (tag, constraints) = self._get_tag_and_constraints(tag)
         return strategy(browser, criteria, tag, constraints)
 
-    def register(self, strategy, persist):
+    def register(self, strategy, persist, location):
         if strategy.name in self._strategies:
             raise AttributeError("The custom locator '" + strategy.name +
             "' cannot be registered. A locator of that name already exists.")
-        self._strategies[strategy.name] = strategy.find
+        self._strategies[strategy.name] = strategy.find if location is None else strategy.finder
+        self._locations[strategy.name] = location
 
         if not persist:
             # Unregister after current scope ends
@@ -54,6 +76,7 @@ class ElementFinder(object):
             logger.info("Cannot unregister the non-registered strategy '" + strategy_name + "'")
         else:
             del self._strategies[strategy_name]
+            del self._locations[strategy_name]
 
     def has_strategy(self, strategy_name):
         return strategy_name in self.strategies

--- a/test/acceptance/locators/custom_with_location.robot
+++ b/test/acceptance/locators/custom_with_location.robot
@@ -8,10 +8,10 @@ Resource          ../resource.robot
 
 *** Test Cases ***
 Test Custom Locator With Location
-    Add Location Strategy    custom1    Keyword To Get Locator By Location And Criteria    ${dt_page_index}    #keyword + location to get locator from dict or remote database
+    Add Location Strategy    custom1    Keyword To Get Locator By Location And Criteria    location=${dt_page_index}    #keyword + location to get locator from dict or database
     Page Should Contain Element    custom1=This is the haystack
     Page Should Contain Element    custom1=This is more text
-    Add Location Strategy    custom2    \    ${dt_page_index}    #dict[criteria] as locator
+    Add Location Strategy    custom2    \    location=${dt_page_index}    #dict[criteria] as locator
     Page Should Contain Element    custom2=This is the haystack
     Page Should Contain Element    custom2=This is more text
     Add Location Strategy    custom3    location=${dt_page_index}    #alernative dict[criteria] as locator

--- a/test/acceptance/locators/custom_with_location.robot
+++ b/test/acceptance/locators/custom_with_location.robot
@@ -1,0 +1,39 @@
+*** Settings ***
+Documentation     Test custom locators
+Suite Setup       Go To Page "index.html"
+Resource          ../resource.robot
+
+*** Variables ***
+&{dt_page_index}    This is more text=css=body > p:nth-child(2)    This is the haystack=xpath=/html/body/p[1]
+
+*** Test Cases ***
+Test Custom Locator With Location
+    Add Location Strategy    custom1    Keyword To Get Locator By Location And Criteria    ${dt_page_index}    #keyword + location to get locator from dict or remote database
+    Page Should Contain Element    custom1=This is the haystack
+    Page Should Contain Element    custom1=This is more text
+    Add Location Strategy    custom2    \    ${dt_page_index}    #dict[criteria] as locator
+    Page Should Contain Element    custom2=This is the haystack
+    Page Should Contain Element    custom2=This is more text
+    Add Location Strategy    custom3    location=${dt_page_index}    #alernative dict[criteria] as locator
+    Page Should Contain Element    custom3=This is the haystack
+    Page Should Contain Element    custom3=This is more text
+    Remove Location Strategy    custom1
+    Remove Location Strategy    custom2
+    Remove Location Strategy    custom3
+
+Test Custom Locator Without Location
+    Add Location Strategy    uitext    Keyword To Get Web Element By Criteria
+    Page Should Contain Element    uitext=This is the haystack
+    Page Should Contain Element    uitext=This is more text
+    Remove Location Strategy    uitext
+
+*** Keywords ***
+Keyword To Get Web Element By Criteria
+    [Arguments]    ${browser}    ${criteria}    ${tag}    ${constraints}
+    ${webelement_object}    Get Webelement    &{dt_page_index}[${criteria}]
+    [Return]    ${webelement_object}
+
+Keyword To Get Locator By Location And Criteria
+    [Arguments]    ${location}    ${criteria}
+    ${locator}    Set Variable    &{location}[${criteria}]    #location is dict here. could be db source
+    [Return]    ${locator}


### PR DESCRIPTION
This feature is enabled by improving 'Add Location Strategy':
Arguments: [ strategy_name | strategy_keyword=None | location=None | persist=False ]

Add a custom location strategy based on given user keyword

**strategy_name**
an unique short name as a customized prefix, such as 'myid', so that you can use 'myid=User Name' instead of a legacy locator '//div[text()="User Name"]/../input' when using Selenium2Library keywords. Scoped locally if persist=False, or the whole test if persist=True.

**strategy_keyword**
an user keyword with arguments (location, criteria) to be registered. It should return a legacy locator (string like 'id=xxx', 'css=xxx', 'xpath=//xxx', '//div/button[1]') retrieved from ${location} by given ${criteria}, or the matched web element if ${location} is None. ${criteria} could be meaningful text to increase test case's readability, such as element's GUI text. Once registered, this keyword will be hook-called internally when Selenium2Library keyword is called.

**location**
the source that stores the mapping from ${criteria} to legacy locator, such as a dictionary, page objects, or database.

**Examples A** ( location is a database ):

``` robotframework
        | # *** Define strategy keyword *** |
        | Get Locator From DB | ${location} | ${criteria} |
        |   | ${index}= | Convert To Integer | ${criteria} |
        |   | ${locator}= | Read MySQL | ${location} | ${index} |
        |   | [Return] | ${locator} |
        | # *** Register and use *** |
        | Add Location Strategy | db | Get Locator From DB | ${False} | ${MySQL} |
        | Page Should Contain Element | db=${obj_index} |
```

**Examples B** ( location is a python dictionary, strategy keyword could be omitted ):

``` python
        # Define python file and import as robotframework *Variables*:
        div_blocks = '//form'
        page = '${div_blocks}/div[2]'
        dict_page_login = {
            'User Name': '${page}/input[1]',
            'User Password': '${page}/input[2]',
            'Login Button': '${page}/div/button[1]',
            'Cancel Button': '${page}/div/button[2]
        }
```

``` robotframework
        | # *** Register and use *** |
        | Add Location Strategy | pg | location=${dict_page_login} |
        | Input Text | pg=User Name | antz |
        | Input Password | pg=User Password | xxxxx |
        | Click Button | pg=Login Button |
```

**Examples C** ( location is None, strategy keyword returns a web element object ):

``` robotframework
        | # *** Define Strategy Keyword, 4 args needed *** |
        | Return Web Element By Javascript | ${browser} | ${criteria} | ${tag} | ${constraints} |
        |   | ${element_object}= | Execute Javascript | return window.document.getElementById('${criteria}'); |
        |   | [Return] | ${element_object} |
        | Return Web Element By Element Text | ${browser} | ${criteria} | ${tag} | ${constraints} |
        |   | ${element_object}= | Get Webelement | &${myPageDict}[${criteria}] |
        |   | [Return] | ${element_object} |
        | # *** Register and use *** |
        | Add Location Strategy | byjs | Return Web Element By Javascript |
        | Add Location Strategy | byui | Return Web Element By Element Text |
        | Page Should Contain Element | byjs=${an_element_id} |
        | Page Should Contain Element | byui=User Name |
```
