### PR TITLE
Adds 'Get Locations' keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+1.8.1
+-----
+- Added 'Get Locations' keyword [thaffenden]
+
 1.8.0
 -----
 - Moved keyword documentation to:

--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -346,6 +346,13 @@ class _BrowserManagementKeywords(KeywordGroup):
         """Returns the current location."""
         return self._current_browser().get_current_url()
 
+    def get_locations(self):
+        """Returns and logs current locations of all windows known to the browser."""
+        return self._log_list(
+            [window_info[4] for window_info in
+             self._window_manager._get_window_infos(self._current_browser())]
+        )
+
     def get_source(self):
         """Returns the entire html source of the current page or frame."""
         return self._current_browser().get_page_source()

--- a/src/Selenium2Library/version.py
+++ b/src/Selenium2Library/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.8.0'
+VERSION = '1.8.1'

--- a/test/acceptance/windows.robot
+++ b/test/acceptance/windows.robot
@@ -23,6 +23,19 @@ Get Window Titles
     ${titles}=    Get Window Titles
     Should Be Equal    ${titles}    ${exp_titles}
 
+Get Location
+    [Documentation]  Get current location
+    ${current_url}=     Get Location
+    Should Be Equal  ${current_url}    ${ROOT}/javascript/popupwindow.html
+
+Get Locations
+    [Documentation]  Get all window locations
+    ${expected_urls}=   Create List     ${ROOT}/javascript/dynamic_content.html     ${ROOT}/javascript/popupwindow.html
+    ${urls}=    Get Locations
+    Sort List  ${expected_urls}
+    Sort List  ${urls}
+    Lists Should Be Equal   ${urls}     ${expected_urls}
+
 Get Window Names
     [Documentation]    Get Window Names
     ${exp_names}=    Create List    selenium_main_app_window    myName


### PR DESCRIPTION
As a keyword to return a list for all of the currently opened urls (in the same way titles works).

The urls are exposed by `WebDriverMonkeyPatches.get_current_window_info` so I'm not sure if there was a reason this functionality has been left out previously (I had a look through the issues on here and in the google group but couldn't see anything) or if it just wasn't needed.

I'm using it for testing on a site where the url is the most reliable/consistent information so its really useful for switch window command to make sure you're in the right place. 

I've added an acceptance test and a unit test in line with the other `get_window...` keywords.

Let me know if there's any issues with any of this.