### PR TITLE
Adds 'Get Parent WebElement' and 'Get Child WebElement' keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Release Notes
 1.8.1
 -----
 - Added 'Get Locations' keyword [thaffenden]
+- Added 'Get Parent Webelement' keyword [thaffenden]
+- Added 'Get Child Webelement' keyword [thaffenden]
 
 1.8.0
 -----

--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -35,6 +35,22 @@ class _ElementKeywords(KeywordGroup):
         """
         return self._element_find(locator, False, True)
 
+    def get_parent_webelement(self, locator):
+        """Returns the parent WebElement for the given locator.
+
+        See `introduction` for details about locating elements.
+        """
+        locator_element = self.get_webelement(locator)
+        return locator_element.find_element(by="xpath", value="parent::*")
+
+    def get_child_webelements(self, locator):
+        """Returns the child WebElements for the given locator.
+
+        See `introduction` for details about locating elements.
+        """
+        locator_element = self.get_webelement(locator)
+        return locator_element.find_elements(by="xpath", value="child::*")
+
     # Public, element lookups
 
     def current_frame_contains(self, text, loglevel='INFO'):

--- a/test/acceptance/keywords/elements.robot
+++ b/test/acceptance/keywords/elements.robot
@@ -32,6 +32,32 @@ More Get Elements
     : FOR    ${checkbox}    IN    @{checkboxes}
     \    Checkbox Should Be Selected    ${checkbox}
 
+Get Parent Web Element Passing Element
+    [Documentation]  Get parent web element of the element passed
+    ${expected_parent}=     Get WebElement  //div[@id="div_id"]
+    ${element}=    Get WebElement    //div[@id="div_id"]/a
+    ${parent}=  Get Parent Webelement   ${element}
+    Should be equal     ${parent}   ${expected_parent}
+
+Get Parent Web Element Passing Locator
+    [Documentation]  Get parent web element of the locator passed
+    ${expected_parent}=     Get WebElement  //div[@id="div_id"]
+    ${parent}=  Get Parent Webelement   //div[@id="div_id"]/a
+    Should be equal     ${parent}   ${expected_parent}
+
+Get Child Web Element Passing Element
+    [Documentation]  Get parent web element of the element passed
+    @{expected_children}=     Get WebElements  //div[@id="first_div"]/a
+    ${element}=    Get WebElement    //div[@id="first_div"]
+    @{children}=  Get Child Webelements   ${element}
+    Lists should be equal   ${children}     ${expected_children}
+
+Get Child Web Element Passing Locator
+    [Documentation]  Get parent web element of the locator passed
+    @{expected_children}=     Get WebElements  //div[@id="first_div"]/a
+    @{children}=  Get Child Webelements   //div[@id="first_div"]
+    Lists should be equal   ${children}     ${expected_children}
+
 Assign Id To Element
     [Documentation]    Tests also Reload Page keyword.
     Page Should Not Contain Element    my id


### PR DESCRIPTION
Adds keyword to get the parent of the specified element. 
Accepts passing of a web element or a locator to find the web element, so I have added a test for each of those scenarios. 

Raised under issue #699 which was closed as a duplicate of #672 (but that deals with element children not parents). 
As #672 was asking for a `get child webelement` keyword I thought I'd add that in as well as they work in the same way. 

