### PR TITLE
Import cleanup: PEP-8 and Python 3

### DIFF
--- a/src/Selenium2Library/__init__.py
+++ b/src/Selenium2Library/__init__.py
@@ -1,9 +1,10 @@
-import os
-from keywords import *
-from version import VERSION
-from utils import LibraryListener
+from .keywords import *
+from .utils import LibraryListener
+from .version import VERSION
+
 
 __version__ = VERSION
+
 
 class Selenium2Library(
     _LoggingKeywords,

--- a/src/Selenium2Library/keywords/__init__.py
+++ b/src/Selenium2Library/keywords/__init__.py
@@ -1,15 +1,16 @@
-from _logging import _LoggingKeywords
-from _runonfailure import _RunOnFailureKeywords
-from _browsermanagement import _BrowserManagementKeywords
-from _element import _ElementKeywords
-from _tableelement import _TableElementKeywords
-from _formelement import _FormElementKeywords
-from _selectelement import _SelectElementKeywords
-from _javascript import _JavaScriptKeywords
-from _cookie import _CookieKeywords
-from _screenshot import _ScreenshotKeywords
-from _waiting import _WaitingKeywords
-from _alert import _AlertKeywords
+from ._logging import _LoggingKeywords
+from ._runonfailure import _RunOnFailureKeywords
+from ._browsermanagement import _BrowserManagementKeywords
+from ._element import _ElementKeywords
+from ._tableelement import _TableElementKeywords
+from ._formelement import _FormElementKeywords
+from ._selectelement import _SelectElementKeywords
+from ._javascript import _JavaScriptKeywords
+from ._cookie import _CookieKeywords
+from ._screenshot import _ScreenshotKeywords
+from ._waiting import _WaitingKeywords
+from ._alert import _AlertKeywords
+
 
 __all__ = [
     "_LoggingKeywords",

--- a/src/Selenium2Library/keywords/_alert.py
+++ b/src/Selenium2Library/keywords/_alert.py
@@ -2,7 +2,8 @@ import time
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-from keywordgroup import KeywordGroup
+
+from .keywordgroup import KeywordGroup
 
 
 class _AlertKeywords(KeywordGroup):

--- a/src/Selenium2Library/keywords/_browsermanagement.py
+++ b/src/Selenium2Library/keywords/_browsermanagement.py
@@ -1,12 +1,17 @@
-import os
-import robot
+import os.path
+
 from robot.errors import DataError
+from robot.utils import secs_to_timestr, timestr_to_secs
+
 from selenium import webdriver
+from selenium.common.exceptions import NoSuchWindowException
+
 from Selenium2Library import webdrivermonkeypatches
 from Selenium2Library.utils import BrowserCache
 from Selenium2Library.locators import WindowManager
-from keywordgroup import KeywordGroup
-from selenium.common.exceptions import NoSuchWindowException
+
+from .keywordgroup import KeywordGroup
+
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 FIREFOX_PROFILE_DIR = os.path.join(ROOT_DIR, 'resources', 'firefoxprofile')
@@ -26,6 +31,7 @@ BROWSER_NAMES = {'ff': "_make_ff",
                  'safari': "_make_safari",
                  'edge': "_make_edge"
                 }
+
 
 class _BrowserManagementKeywords(KeywordGroup):
 
@@ -428,19 +434,19 @@ class _BrowserManagementKeywords(KeywordGroup):
         """Gets the delay in seconds that is waited after each Selenium command.
 
         See `Set Selenium Speed` for an explanation."""
-        return robot.utils.secs_to_timestr(self._speed_in_secs)
+        return secs_to_timestr(self._speed_in_secs)
 
     def get_selenium_timeout(self):
         """Gets the timeout in seconds that is used by various keywords.
 
         See `Set Selenium Timeout` for an explanation."""
-        return robot.utils.secs_to_timestr(self._timeout_in_secs)
+        return secs_to_timestr(self._timeout_in_secs)
 
     def get_selenium_implicit_wait(self):
         """Gets the wait in seconds that is waited by Selenium.
 
         See `Set Selenium Implicit Wait` for an explanation."""
-        return robot.utils.secs_to_timestr(self._implicit_wait_in_secs)
+        return secs_to_timestr(self._implicit_wait_in_secs)
 
     def set_selenium_speed(self, seconds):
         """Sets the delay in seconds that is waited after each Selenium command.
@@ -453,7 +459,7 @@ class _BrowserManagementKeywords(KeywordGroup):
         | Set Selenium Speed | .5 seconds |
         """
         old_speed = self.get_selenium_speed()
-        self._speed_in_secs = robot.utils.timestr_to_secs(seconds)
+        self._speed_in_secs = timestr_to_secs(seconds)
         for browser in self._cache.browsers:
             browser.set_speed(self._speed_in_secs)
         return old_speed
@@ -476,7 +482,7 @@ class _BrowserManagementKeywords(KeywordGroup):
         | Set Selenium Timeout | ${orig timeout} |
         """
         old_timeout = self.get_selenium_timeout()
-        self._timeout_in_secs = robot.utils.timestr_to_secs(seconds)
+        self._timeout_in_secs = timestr_to_secs(seconds)
         for browser in self._cache.get_open_browsers():
             browser.set_script_timeout(self._timeout_in_secs)
         return old_timeout
@@ -495,7 +501,7 @@ class _BrowserManagementKeywords(KeywordGroup):
         | Set Selenium Implicit Wait | ${orig wait} |
         """
         old_wait = self.get_selenium_implicit_wait()
-        self._implicit_wait_in_secs = robot.utils.timestr_to_secs(seconds)
+        self._implicit_wait_in_secs = timestr_to_secs(seconds)
         for browser in self._cache.get_open_browsers():
             browser.implicitly_wait(self._implicit_wait_in_secs)
         return old_wait
@@ -513,7 +519,7 @@ class _BrowserManagementKeywords(KeywordGroup):
 
         See also `Set Selenium Implicit Wait`.
         """
-        implicit_wait_in_secs = robot.utils.timestr_to_secs(seconds)
+        implicit_wait_in_secs = timestr_to_secs(seconds)
         self._current_browser().implicitly_wait(implicit_wait_in_secs)
 
     # Private

--- a/src/Selenium2Library/keywords/_cookie.py
+++ b/src/Selenium2Library/keywords/_cookie.py
@@ -1,4 +1,5 @@
-from keywordgroup import KeywordGroup
+from .keywordgroup import KeywordGroup
+
 
 class _CookieKeywords(KeywordGroup):
 

--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -1,18 +1,13 @@
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.remote.webelement import WebElement
+
 from Selenium2Library import utils
 from Selenium2Library.locators import ElementFinder
 from Selenium2Library.locators import CustomLocator
-from keywordgroup import KeywordGroup
 
-try:
-    basestring  # attempt to evaluate basestring
-    def isstr(s):
-        return isinstance(s, basestring)
-except NameError:
-    def isstr(s):
-        return isinstance(s, str)
+from .keywordgroup import KeywordGroup
+
 
 class _ElementKeywords(KeywordGroup):
 
@@ -684,7 +679,7 @@ return !element.dispatchEvent(evt);
 
     def _element_find(self, locator, first_only, required, tag=None):
         browser = self._current_browser()
-        if isstr(locator):
+        if isinstance(locator, basestring):
             elements = self._element_finder.find(browser, locator, tag)
             if required and len(elements) == 0:
                 raise ValueError("Element locator '" + locator + "' did not match any elements.")

--- a/src/Selenium2Library/keywords/_formelement.py
+++ b/src/Selenium2Library/keywords/_formelement.py
@@ -1,6 +1,7 @@
 import os
-from keywordgroup import KeywordGroup
-from selenium.common.exceptions import WebDriverException
+
+from .keywordgroup import KeywordGroup
+
 
 class _FormElementKeywords(KeywordGroup):
 

--- a/src/Selenium2Library/keywords/_javascript.py
+++ b/src/Selenium2Library/keywords/_javascript.py
@@ -1,5 +1,6 @@
 import os
-from keywordgroup import KeywordGroup
+
+from .keywordgroup import KeywordGroup
 
 
 class _JavaScriptKeywords(KeywordGroup):

--- a/src/Selenium2Library/keywords/_logging.py
+++ b/src/Selenium2Library/keywords/_logging.py
@@ -1,13 +1,13 @@
 import os
-import sys
-from robot.api import logger
-from keywordgroup import KeywordGroup
-from robot.libraries.BuiltIn import BuiltIn
 
+from robot.api import logger
+from robot.libraries.BuiltIn import BuiltIn
 try:
     from robot.libraries.BuiltIn import RobotNotRunningError
-except ImportError:
+except ImportError:  # Support RF < 2.8.5
     RobotNotRunningError = AttributeError
+
+from .keywordgroup import KeywordGroup
 
 
 class _LoggingKeywords(KeywordGroup):

--- a/src/Selenium2Library/keywords/_runonfailure.py
+++ b/src/Selenium2Library/keywords/_runonfailure.py
@@ -1,7 +1,7 @@
-from robot.libraries import BuiltIn
-from keywordgroup import KeywordGroup
+from robot.libraries.BuiltIn import BuiltIn
 
-BUILTIN = BuiltIn.BuiltIn()
+from .keywordgroup import KeywordGroup
+
 
 class _RunOnFailureKeywords(KeywordGroup):
 
@@ -32,9 +32,6 @@ class _RunOnFailureKeywords(KeywordGroup):
         | Register Keyword To Run On Failure  | Log Source | # Run `Log Source` on failure. |
         | ${previous kw}= | Register Keyword To Run On Failure  | Nothing    | # Disables run-on-failure functionality and stores the previous kw name in a variable. |
         | Register Keyword To Run On Failure  | ${previous kw} | # Restore to the previous keyword. |
-
-        This run-on-failure functionality only works when running tests on Python/Jython 2.4
-        or newer and it does not work on IronPython at all.
         """
         old_keyword = self._run_on_failure_keyword
         old_keyword_text = old_keyword if old_keyword is not None else "No keyword"
@@ -56,7 +53,7 @@ class _RunOnFailureKeywords(KeywordGroup):
             return
         self._running_on_failure_routine = True
         try:
-            BUILTIN.run_keyword(self._run_on_failure_keyword)
+            BuiltIn().run_keyword(self._run_on_failure_keyword)
         except Exception as err:
             self._run_on_failure_error(err)
         finally:

--- a/src/Selenium2Library/keywords/_screenshot.py
+++ b/src/Selenium2Library/keywords/_screenshot.py
@@ -1,8 +1,11 @@
-import robot
-import os, errno
+import errno
+import os
 
-from Selenium2Library import utils
-from keywordgroup import KeywordGroup
+from robot.utils import get_link_path
+
+from Selenium2Library.utils import events
+
+from .keywordgroup import KeywordGroup
 
 
 class _ScreenshotKeywords(KeywordGroup):
@@ -28,9 +31,8 @@ class _ScreenshotKeywords(KeywordGroup):
         if persist is False:
             self._screenshot_path_stack.append(self.screenshot_root_directory)
             # Restore after current scope ends
-            utils.events.on('scope_end', 'current',
-                            self._restore_screenshot_directory)
-
+            events.on('scope_end', 'current',
+                      self._restore_screenshot_directory)
         self.screenshot_root_directory = path
 
     def capture_page_screenshot(self,
@@ -130,7 +132,7 @@ class _ScreenshotKeywords(KeywordGroup):
         screenshotdir = self._get_screenshot_directory()
         logdir = self._get_log_dir()
         path = os.path.join(screenshotdir, filename)
-        link = robot.utils.get_link_path(path, logdir)
+        link = get_link_path(path, logdir)
         return path, link
 
     def _get_screenshot_index(self, filename):

--- a/src/Selenium2Library/keywords/_selectelement.py
+++ b/src/Selenium2Library/keywords/_selectelement.py
@@ -1,6 +1,7 @@
-from selenium.webdriver.support.ui import Select
-from keywordgroup import KeywordGroup
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.support.ui import Select
+
+from .keywordgroup import KeywordGroup
 
 
 class _SelectElementKeywords(KeywordGroup):

--- a/src/Selenium2Library/keywords/_tableelement.py
+++ b/src/Selenium2Library/keywords/_tableelement.py
@@ -1,7 +1,7 @@
-import os
-import sys
 from Selenium2Library.locators import TableElementFinder
-from keywordgroup import KeywordGroup
+
+from .keywordgroup import KeywordGroup
+
 
 class _TableElementKeywords(KeywordGroup):
 

--- a/src/Selenium2Library/keywords/_waiting.py
+++ b/src/Selenium2Library/keywords/_waiting.py
@@ -1,6 +1,9 @@
 import time
-import robot
-from keywordgroup import KeywordGroup
+
+from robot.utils import secs_to_timestr, timestr_to_secs
+
+from .keywordgroup import KeywordGroup
+
 
 class _WaitingKeywords(KeywordGroup):
 
@@ -231,7 +234,7 @@ class _WaitingKeywords(KeywordGroup):
         self._wait_until_no_error(timeout, wait_func)
 
     def _wait_until_no_error(self, timeout, wait_func, *args):
-        timeout = robot.utils.timestr_to_secs(timeout) if timeout is not None else self._timeout_in_secs
+        timeout = timestr_to_secs(timeout) if timeout is not None else self._timeout_in_secs
         maxtime = time.time() + timeout
         while True:
             timeout_error = wait_func(*args)
@@ -241,5 +244,5 @@ class _WaitingKeywords(KeywordGroup):
             time.sleep(0.2)
 
     def _format_timeout(self, timeout):
-        timeout = robot.utils.timestr_to_secs(timeout) if timeout is not None else self._timeout_in_secs
-        return robot.utils.secs_to_timestr(timeout)
+        timeout = timestr_to_secs(timeout) if timeout is not None else self._timeout_in_secs
+        return secs_to_timestr(timeout)

--- a/src/Selenium2Library/keywords/keywordgroup.py
+++ b/src/Selenium2Library/keywords/keywordgroup.py
@@ -1,11 +1,8 @@
 import sys
 import inspect
-try:
-    from decorator import decorator
-except SyntaxError: # decorator module requires Python/Jython 2.4+
-    decorator = None
-if sys.platform == 'cli':
-    decorator = None # decorator module doesn't work with IronPython 2.6
+
+from decorator import decorator
+
 
 def _run_on_failure_decorator(method, *args, **kwargs):
     self = args[0]
@@ -25,13 +22,16 @@ def _run_on_failure_decorator(method, *args, **kwargs):
             self._already_in_keyword = False
             self._has_run_on_failure = False
 
+
 class KeywordGroupMetaClass(type):
+
     def __new__(cls, clsname, bases, dict):
         if decorator:
             for name, method in list(dict.items()):
                 if not name.startswith('_') and inspect.isroutine(method):
                     dict[name] = decorator(_run_on_failure_decorator, method)
         return type.__new__(cls, clsname, bases, dict)
+
 
 class KeywordGroup(object):
     __metaclass__ = KeywordGroupMetaClass

--- a/src/Selenium2Library/locators/__init__.py
+++ b/src/Selenium2Library/locators/__init__.py
@@ -1,7 +1,8 @@
-from elementfinder import ElementFinder
-from tableelementfinder import TableElementFinder
-from windowmanager import WindowManager
-from customlocator import CustomLocator
+from .elementfinder import ElementFinder
+from .customlocator import CustomLocator
+from .tableelementfinder import TableElementFinder
+from .windowmanager import WindowManager
+
 
 __all__ = [
     "ElementFinder",

--- a/src/Selenium2Library/locators/customlocator.py
+++ b/src/Selenium2Library/locators/customlocator.py
@@ -1,9 +1,5 @@
 from robot.libraries.BuiltIn import BuiltIn
 
-try:
-    string_type = basestring
-except NameError:
-    string_type = str
 
 class CustomLocator(object):
 
@@ -12,9 +8,8 @@ class CustomLocator(object):
         self.finder = finder
 
     def find(self, *args):
-
         # Allow custom locators to be keywords or normal methods
-        if isinstance(self.finder, string_type):
+        if isinstance(self.finder, basestring):
             element = BuiltIn().run_keyword(self.finder, *args)
         elif hasattr(self.finder, '__call__'):
             element = self.finder(*args)
@@ -22,7 +17,7 @@ class CustomLocator(object):
             raise AttributeError('Invalid type provided for Custom Locator %s' % self.name)
 
         # Always return an array
-        if hasattr(element, '__len__') and (not isinstance(element, string_type)):
+        if hasattr(element, '__len__') and (not isinstance(element, basestring)):
             return element
         else:
             return [element]

--- a/src/Selenium2Library/locators/elementfinder.py
+++ b/src/Selenium2Library/locators/elementfinder.py
@@ -1,6 +1,7 @@
-from Selenium2Library import utils
 from robot.api import logger
 from robot.utils import NormalizedDict
+
+from Selenium2Library.utils import escape_xpath_value, events
 
 
 class ElementFinder(object):
@@ -45,7 +46,7 @@ class ElementFinder(object):
 
         if not persist:
             # Unregister after current scope ends
-            utils.events.on('scope_end', 'current', self.unregister, strategy.name)
+            events.on('scope_end', 'current', self.unregister, strategy.name)
 
     def unregister(self, strategy_name):
         if strategy_name in self._default_strategies:
@@ -133,7 +134,7 @@ class ElementFinder(object):
         if tag is not None:
             key_attrs = self._key_attrs.get(tag, key_attrs)
 
-        xpath_criteria = utils.escape_xpath_value(criteria)
+        xpath_criteria = escape_xpath_value(criteria)
         xpath_tag = tag if tag is not None else '*'
         xpath_constraints = ["@%s='%s'" % (name, constraints[name]) for name in constraints]
         xpath_searchers = ["%s=%s" % (attr, xpath_criteria) for attr in key_attrs]
@@ -206,7 +207,7 @@ class ElementFinder(object):
             if attr in key_attrs:
                 if url is None or xpath_url is None:
                     url = self._get_base_url(browser) + "/" + criteria
-                    xpath_url = utils.escape_xpath_value(url)
+                    xpath_url = escape_xpath_value(url)
                 attrs.append("%s=%s" % (attr, xpath_url))
         return attrs
 
@@ -224,7 +225,7 @@ class ElementFinder(object):
             if len(locator_parts[1]) > 0:
                 prefix = locator_parts[0]
                 criteria = locator_parts[2].strip()
-        return (prefix, criteria)
+        return prefix, criteria
 
     def _normalize_result(self, elements):
         if not isinstance(elements, list):

--- a/src/Selenium2Library/locators/tableelementfinder.py
+++ b/src/Selenium2Library/locators/tableelementfinder.py
@@ -1,6 +1,5 @@
-from selenium.common.exceptions import NoSuchElementException
-from Selenium2Library import utils
-from elementfinder import ElementFinder
+from .elementfinder import ElementFinder
+
 
 class TableElementFinder(object):
 

--- a/src/Selenium2Library/locators/windowmanager.py
+++ b/src/Selenium2Library/locators/windowmanager.py
@@ -1,7 +1,5 @@
-from types import *
-from robot import utils
-from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.common.exceptions import NoSuchWindowException
+
 
 class WindowManager(object):
 

--- a/src/Selenium2Library/utils/__init__.py
+++ b/src/Selenium2Library/utils/__init__.py
@@ -1,6 +1,6 @@
-from browsercache import BrowserCache
-from librarylistener import LibraryListener
-import events
+from . import events
+from .browsercache import BrowserCache
+from .librarylistener import LibraryListener
 
 
 def escape_xpath_value(value):

--- a/src/Selenium2Library/utils/browsercache.py
+++ b/src/Selenium2Library/utils/browsercache.py
@@ -1,5 +1,6 @@
 from robot.utils import ConnectionCache
 
+
 class BrowserCache(ConnectionCache):
 
     def __init__(self):

--- a/src/Selenium2Library/utils/events/__init__.py
+++ b/src/Selenium2Library/utils/events/__init__.py
@@ -1,7 +1,5 @@
-from scope_event import ScopeStart, ScopeEnd
+from .scope_event import ScopeStart, ScopeEnd
 
-_registered_events = [ ScopeStart, ScopeEnd ]
-_events = []
 
 __all__ = [
     "on",
@@ -9,16 +7,22 @@ __all__ = [
     "register_event"
 ]
 
+_registered_events = [ScopeStart, ScopeEnd]
+_events = []
+
+
 def on(event_name, *args, **kwargs):
     for event in _registered_events:
         if event.name == event_name:
             _events.append(event(*args, **kwargs))
             return
 
+
 def dispatch(event_name, *args, **kwargs):
     for event in _events:
         if event.name == event_name:
             event.trigger(*args, **kwargs)
+
 
 def register_event(event):
     for registered_event in _registered_events:

--- a/src/Selenium2Library/utils/events/event.py
+++ b/src/Selenium2Library/utils/events/event.py
@@ -1,5 +1,6 @@
 import abc
 
+
 class Event(object):
 
     @abc.abstractmethod

--- a/src/Selenium2Library/utils/events/scope_event.py
+++ b/src/Selenium2Library/utils/events/scope_event.py
@@ -1,7 +1,10 @@
-from event import Event
 from robot.libraries.BuiltIn import BuiltIn
 
+from .event import Event
+
+
 class ScopeEvent(Event):
+
     def __init__(self, scope, action, *args, **kwargs):
         self.scope = scope
         self.action = action
@@ -17,8 +20,10 @@ class ScopeEvent(Event):
         if args[0] == self.scope:
             self.action(*self.action_args, **self.action_kwargs)
 
+
 class ScopeStart(ScopeEvent):
     name = 'scope_start'
+
 
 class ScopeEnd(ScopeEvent):
     name = 'scope_end'

--- a/src/Selenium2Library/utils/librarylistener.py
+++ b/src/Selenium2Library/utils/librarylistener.py
@@ -1,18 +1,17 @@
-import events as event
-from robot.api import logger
+from .events import dispatch
+
 
 class LibraryListener(object):
-
     ROBOT_LISTENER_API_VERSION = 2
 
     def start_suite(self, name, attrs):
-        event.dispatch( 'scope_start', attrs['longname'] )
+        dispatch('scope_start', attrs['longname'])
 
     def end_suite(self, name, attrs):
-        event.dispatch( 'scope_end', attrs['longname'] )
+        dispatch('scope_end', attrs['longname'])
 
     def start_test(self, name, attrs):
-        event.dispatch( 'scope_start', attrs['longname'] )
+        dispatch('scope_start', attrs['longname'])
 
     def end_test(self, name, attrs):
-        event.dispatch( 'scope_end', attrs['longname'] )
+        dispatch('scope_end', attrs['longname'])

--- a/src/Selenium2Library/webdrivermonkeypatches.py
+++ b/src/Selenium2Library/webdrivermonkeypatches.py
@@ -1,7 +1,7 @@
 import time
-from robot import utils
+
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
-from locators import WindowManager
+
 
 class WebDriverMonkeyPatches:
 

--- a/test/unit/keywords/test_browsermanagement.py
+++ b/test/unit/keywords/test_browsermanagement.py
@@ -1,7 +1,10 @@
 import unittest
-from Selenium2Library.keywords._browsermanagement import _BrowserManagementKeywords
+
+from mockito import mock, verify, verifyNoMoreInteractions
 from selenium import webdriver
-from mockito import *
+
+from Selenium2Library.keywords._browsermanagement import _BrowserManagementKeywords
+
 
 class BrowserManagementTests(unittest.TestCase): 
 

--- a/test/unit/locators/test_elementfinder.py
+++ b/test/unit/locators/test_elementfinder.py
@@ -1,8 +1,10 @@
 import unittest
-import os
-from Selenium2Library.locators import ElementFinder
-from mockito import *
+
+from mockito import any, mock, verify, when
 from robot.utils.asserts import assert_raises_with_msg
+
+from Selenium2Library.locators import ElementFinder
+
 
 class ElementFinderTests(unittest.TestCase):
 

--- a/test/unit/locators/test_tableelementfinder.py
+++ b/test/unit/locators/test_tableelementfinder.py
@@ -1,6 +1,9 @@
 import unittest
+
+from mockito import mock, verify, when
+
 from Selenium2Library.locators import TableElementFinder
-from mockito import *
+
 
 class ElementFinderTests(unittest.TestCase):
 

--- a/test/unit/locators/test_windowmanager.py
+++ b/test/unit/locators/test_windowmanager.py
@@ -1,9 +1,11 @@
 import unittest
-import os
-from Selenium2Library.locators import WindowManager
-from mockito import *
 import uuid
+
+from mockito import mock
+
+from Selenium2Library.locators import WindowManager
 from selenium.common.exceptions import NoSuchWindowException
+
 
 class WindowManagerTests(unittest.TestCase):
 
@@ -220,11 +222,7 @@ class WindowManagerTests(unittest.TestCase):
             { 'name': 'win1', 'title': "Title 1", 'url': 'http://localhost/page1.html' },
             { 'name': 'win2', 'title': "Title 2", 'url': 'http://localhost/page2.html' },
             { 'name': 'win3', 'title': "Title 3", 'url': 'http://localhost/page3.html' })
-
-        try:
-            self.assertRaises(ValueError, manager.select, browser, "win-1")
-        except ValueError as e:
-            self.assertEqual(context.exception.message, "Unable to locate window with name or title 'win-1'")
+        self.assertRaises(ValueError, manager.select, browser, "win-1")
 
     def test_select_with_sloppy_prefix(self):
         manager = WindowManager()

--- a/test/unit/test_webdrivermonkeypatches.py
+++ b/test/unit/test_webdrivermonkeypatches.py
@@ -1,7 +1,10 @@
 import unittest
+
+from mockito import when
+
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
-from mockito import *
+
 
 SCRIPT = "return [ window.id, window.name, document.title, document.URL ];"
 HANDLE = "17c3dc18-0443-478b-aec6-ed7e2a5da7e1"

--- a/test/unit/utils/test_browsercache.py
+++ b/test/unit/utils/test_browsercache.py
@@ -1,7 +1,9 @@
 import unittest
-import os
+
+from mockito import mock, verify
+
 from Selenium2Library.utils import BrowserCache
-from mockito import *
+
 
 class BrowserCacheTests(unittest.TestCase): 
 

--- a/test/unit/utils/test_package.py
+++ b/test/unit/utils/test_package.py
@@ -1,19 +1,18 @@
 import unittest
-from Selenium2Library import utils
+
+from Selenium2Library.utils import escape_xpath_value
+
 
 class UtilsPackageTests(unittest.TestCase):
 
     def test_escape_xpath_value_with_apos(self):
-        self.assertEqual(
-            utils.escape_xpath_value("test '1'"),
-            "\"test '1'\"")
+        self.assertEqual(escape_xpath_value("test '1'"),
+                         "\"test '1'\"")
 
     def test_escape_xpath_value_with_quote(self):
-        self.assertEqual(
-            utils.escape_xpath_value("test \"1\""),
-            "'test \"1\"'")
+        self.assertEqual(escape_xpath_value("test \"1\""),
+                         "'test \"1\"'")
 
     def test_escape_xpath_value_with_quote_and_apos(self):
-        self.assertEqual(
-            utils.escape_xpath_value("test \"1\" and '2'"),
-            "concat('test \"1\" and ', \"'\", '2', \"'\", '')")
+        self.assertEqual(escape_xpath_value("test \"1\" and '2'"),
+                         "concat('test \"1\" and ', \"'\", '2', \"'\", '')")


### PR DESCRIPTION
- Order imports as recommended by PEP-8
- Use relative imports to support Python 3
- Some other PEP-8 compatibility fixes (e.g. empty rows)