### PR TITLE
Clarified `get_matching_xpath_count` returns str

### DIFF
--- a/src/Selenium2Library/keywords/_element.py
+++ b/src/Selenium2Library/keywords/_element.py
@@ -607,7 +607,7 @@ return !element.dispatchEvent(evt);
     # Public, xpath
 
     def get_matching_xpath_count(self, xpath):
-        """Returns number of elements matching `xpath`
+        """Returns number of elements matching `xpath` as a string.
 
         One should not use the xpath= prefix for 'xpath'. XPath is assumed.
 


### PR DESCRIPTION
Updated documentation to include the return type (string) of the XPath count.

Many users would assume that the "count" is an integer. However, since the count value is cast to a string upon return, this is not the case. Since this behavior has been in the code for quite awhile, likely as not users have coded around it. However, for accuracy's sake (as well as for those just learning RF).