### PR TITLE
Mockito version 1.0.0 or greater does not anymore work with unit tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-mockito
+mockito == 0.7.1
 robotstatuschecker


### PR DESCRIPTION
New releases of mockito do not anymore work with Selenium2Library
units test. This is a quick work a round to use older version of
mockito until we fix the unit test to work with new version of
mockito.