### PR TITLE
Updated mockito to 1.0.0 in dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-mockito == 0.7.1
+mockito >= 1.0.0
 robotstatuschecker


### PR DESCRIPTION
mockito 1.0.0 did not anymore work with the BrowserManagementKeywords
unit tests. Changed unit test to work with mockito 1.0.0. Unit test
do not anymore work with older mockito versions.

Fixes #738 