### PR TITLE
Add RF 3.0.1, 2.9.2 and 2.8.7 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,6 @@ before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - pip install selenium==$SELENIUM
-  - pip install selenium==$ROBOTFRAMEWORK
+  - pip install robotframework==$ROBOTFRAMEWORK
 script:
   - python test/run_tests.py $BROWSER

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,21 +23,31 @@ matrix:
       env:
         - BROWSER=chrome
         - SELENIUM=2.53.6
-    - python: "3.3" # For PR and cron
+        - ROBOTFRAMEWORK=3.0.1
+    - python: "2.7" # For PR and cron
       env:
         - BROWSER=chrome
         - SELENIUM=2.53.6
+        - ROBOTFRAMEWORK=2.9.2
     - python: "2.7" # For PR and cron
       env:
         - BROWSER=chrome
         - SELENIUM=3.0.2
+        - ROBOTFRAMEWORK=2.8.7
+    - python: "3.3" # For PR and cron
+      env:
+        - BROWSER=chrome
+        - SELENIUM=2.53.6
+        - ROBOTFRAMEWORK=3.0.1
     - python: "3.3" # For cron only
       env:
         - BROWSER=firefox
         - SELENIUM=2.53.6
+        - ROBOTFRAMEWORK=3.0.1
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - pip install selenium==$SELENIUM
+  - pip install selenium==$ROBOTFRAMEWORK
 script:
   - python test/run_tests.py $BROWSER


### PR DESCRIPTION
We must also test with RF version we support. Updated Travis to
run test for different Robot Framework versions.