### PR TITLE
Support switching windows and getting some window information on browsers without javascript

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Release Notes
 1.8.1
 -----
 - Added 'Get Locations' keyword [thaffenden]
+- Fix getting window information and switching windows on browsers that do not
+  support javascript
 
 1.8.0
 -----

--- a/src/Selenium2Library/locators/windowmanager.py
+++ b/src/Selenium2Library/locators/windowmanager.py
@@ -140,7 +140,14 @@ class WindowManager(object):
         raise ValueError(error)
 
     def _get_current_window_info(self, browser):
-        id_, name = browser.execute_script("return [ window.id, window.name ];")
+        try:
+            id_, name = browser.execute_script("return [ window.id, window.name ];")
+        except WebDriverException:
+            # The webdriver implementation doesn't support Javascript so we
+            # can't get window id or name this way.
+            id_ = None
+            name = ''
+
         title = browser.title
         url = browser.current_url
 

--- a/src/Selenium2Library/locators/windowmanager.py
+++ b/src/Selenium2Library/locators/windowmanager.py
@@ -1,4 +1,5 @@
 from selenium.common.exceptions import NoSuchWindowException
+from selenium.common.exceptions import WebDriverException
 
 
 class WindowManager(object):
@@ -139,8 +140,10 @@ class WindowManager(object):
         raise ValueError(error)
 
     def _get_current_window_info(self, browser):
-        id_, name, title, url = browser.execute_script(
-            "return [ window.id, window.name, document.title, document.URL ];")
+        id_, name = browser.execute_script("return [ window.id, window.name ];")
+        title = browser.title
+        url = browser.current_url
+
         id_ = id_ if id_ is not None else 'undefined'
         name, title, url = (
             att if att else 'undefined' for att in (name, title, url)

--- a/test/unit/keywords/test_windowmananger_window_info.py
+++ b/test/unit/keywords/test_windowmananger_window_info.py
@@ -4,18 +4,21 @@ from mockito import mock, when, unstub
 
 from Selenium2Library.locators import WindowManager
 
-SCRIPT = "return [ window.id, window.name, document.title, document.URL ];"
+SCRIPT = "return [ window.id, window.name ];"
 HANDLE = "17c3dc18-0443-478b-aec6-ed7e2a5da7e1"
 
 
 class GetCurrentWindowInfoTest(unittest.TestCase):
 
+    def mock_window_info(self, driver, id_, name, title, url):
+        when(driver).execute_script(SCRIPT).thenReturn([id_, name])
+        driver.title = title
+        driver.current_url = url
+
     def test_window_info_values_are_strings(self):
         manager = WindowManager()
         driver = mock()
-        when(driver).execute_script(SCRIPT).thenReturn(
-            ['id', 'name', 'title', 'url']
-        )
+        self.mock_window_info(driver, 'id', 'name', 'title', 'url')
         driver.current_window_handle = HANDLE
         info = manager._get_current_window_info(driver)
         self.assertEqual(info, (HANDLE, 'id', 'name', 'title', 'url'))
@@ -24,7 +27,7 @@ class GetCurrentWindowInfoTest(unittest.TestCase):
     def test_window_info_values_are_none(self):
         manager = WindowManager()
         driver = mock()
-        when(driver).execute_script(SCRIPT).thenReturn([None] * 4)
+        self.mock_window_info(driver, None, None, None, None)
         driver.current_window_handle = HANDLE
         info = manager._get_current_window_info(driver)
         self.assertEqual(
@@ -35,7 +38,7 @@ class GetCurrentWindowInfoTest(unittest.TestCase):
     def test_window_info_values_are_empty_strings(self):
         manager = WindowManager()
         driver = mock()
-        when(driver).execute_script(SCRIPT).thenReturn([''] * 4)
+        self.mock_window_info(driver, '', '', '', '')
         driver.current_window_handle = HANDLE
         info = manager._get_current_window_info(driver)
         self.assertEqual(
@@ -46,11 +49,11 @@ class GetCurrentWindowInfoTest(unittest.TestCase):
     def test_window_id_is_bool(self):
         manager = WindowManager()
         driver = mock()
-        when(driver).execute_script(SCRIPT).thenReturn(
-            [True, '', '', '']).thenReturn([False, '', '', ''])
+        self.mock_window_info(driver, True, '', '', '')
         driver.current_window_handle = HANDLE
         info = manager._get_current_window_info(driver)
         self.assertEqual(info[1], True)
+        self.mock_window_info(driver, False, '', '', '')
         info = manager._get_current_window_info(driver)
         self.assertEqual(info[1], False)
         unstub()
@@ -59,7 +62,7 @@ class GetCurrentWindowInfoTest(unittest.TestCase):
         manager = WindowManager()
         driver = mock()
         elem = mock()
-        when(driver).execute_script(SCRIPT).thenReturn([elem, '', '', ''])
+        self.mock_window_info(driver, *[elem, '', '', ''])
         driver.current_window_handle = HANDLE
         info = manager._get_current_window_info(driver)
         self.assertEqual(info[1], elem)
@@ -68,11 +71,12 @@ class GetCurrentWindowInfoTest(unittest.TestCase):
     def test_window_id_is_container(self):
         manager = WindowManager()
         driver = mock()
-        when(driver).execute_script(SCRIPT).thenReturn(
-            [['1'], '', '', '']).thenReturn([{'a': 2}, '', '', ''])
+        self.mock_window_info(driver, *[['1'], '', '', ''])
         driver.current_window_handle = HANDLE
         info = manager._get_current_window_info(driver)
         self.assertEqual(info[1], ['1'])
+
+        self.mock_window_info(driver, *[{'a': 2}, '', '', ''])
         info = manager._get_current_window_info(driver)
         self.assertEqual(info[1], {'a': 2})
         unstub()
@@ -80,11 +84,11 @@ class GetCurrentWindowInfoTest(unittest.TestCase):
     def test_window_id_is_empty_container(self):
         manager = WindowManager()
         driver = mock()
-        when(driver).execute_script(SCRIPT).thenReturn(
-            [[], '', '', '']).thenReturn([{}, '', '', ''])
+        self.mock_window_info(driver, *[[], '', '', ''])
         driver.current_window_handle = HANDLE
         info = manager._get_current_window_info(driver)
         self.assertEqual(info[1], [])
+        self.mock_window_info(driver, *[{}, '', '', ''])
         info = manager._get_current_window_info(driver)
         self.assertEqual(info[1], {})
         unstub()

--- a/test/unit/keywords/test_windowmananger_window_info.py
+++ b/test/unit/keywords/test_windowmananger_window_info.py
@@ -3,6 +3,7 @@ import unittest
 from mockito import mock, when, unstub
 
 from Selenium2Library.locators import WindowManager
+from selenium.common.exceptions import WebDriverException
 
 SCRIPT = "return [ window.id, window.name ];"
 HANDLE = "17c3dc18-0443-478b-aec6-ed7e2a5da7e1"
@@ -91,4 +92,18 @@ class GetCurrentWindowInfoTest(unittest.TestCase):
         self.mock_window_info(driver, *[{}, '', '', ''])
         info = manager._get_current_window_info(driver)
         self.assertEqual(info[1], {})
+        unstub()
+
+    def test_no_javascript_support(self):
+        manager = WindowManager()
+        driver = mock()
+        elem = mock()
+        when(driver).execute_script(SCRIPT).thenRaise(WebDriverException)
+        driver.title = 'title'
+        driver.current_url = 'url'
+        driver.current_window_handle = HANDLE
+        info = manager._get_current_window_info(driver)
+        self.assertEqual(
+            info, (HANDLE, 'undefined', 'undefined', 'title', 'url')
+        )
         unstub()

--- a/test/unit/locators/test_windowmanager.py
+++ b/test/unit/locators/test_windowmanager.py
@@ -333,11 +333,13 @@ class WindowManagerTests(unittest.TestCase):
                 browser.session_id = handle_
                 current_window.name = window_infos[handle_][1]
                 browser.current_window = current_window
+                browser.title = window_infos[handle_][2]
+                browser.current_url = window_infos[handle_][3]
         browser.switch_to_window = switch_to_window
 
         def execute_script(script):
             handle_ = browser.session_id
             if handle_ in browser.window_handles:
-                return window_infos[handle_]
+                return window_infos[handle_][:2]
         browser.execute_script = execute_script
         return browser


### PR DESCRIPTION
I'm using this library with [QtWebDriver](https://github.com/cisco-open-source/qtwebdriver) to test Qt applications. Some of the windows in my application are not actually web-based, so they don't support the `execute_script` command. Currently this makes it impossible to switch between windows because a script is used to get the window title and url.

By using the web driver API instead of a custom `execute_script` we can implement the same functionality without javascript.