### PR TITLE
Refector ElementFinder to better support ctx object.

### DIFF
--- a/src/Selenium2Library/locators/elementfinder.py
+++ b/src/Selenium2Library/locators/elementfinder.py
@@ -4,10 +4,10 @@ from robot.utils import NormalizedDict
 from Selenium2Library.utils import escape_xpath_value, events
 
 
-class ParserLocator(object):
+class LocatorParser(object):
 
     @classmethod
-    def parse_locator(cls, locator):
+    def parse(cls, locator):
         prefix = None
         criteria = locator
         if locator.startswith('//') or locator.startswith('(//'):
@@ -63,7 +63,7 @@ class ElementFinder(object):
         assert browser is not None
         assert locator is not None and len(locator) > 0
 
-        prefix, criteria = ParserLocator.parse_locator(locator)
+        prefix, criteria = LocatorParser.parse(locator)
         strategy = self._strategies.get(prefix)
         if strategy is None:
             raise ValueError('Element locator with prefix \'{}\' '

--- a/src/Selenium2Library/locators/elementfinder.py
+++ b/src/Selenium2Library/locators/elementfinder.py
@@ -10,7 +10,7 @@ class LocatorParser(object):
     def parse(cls, locator):
         prefix = None
         criteria = locator
-        if locator.startswith('//') or locator.startswith('(//'):
+        if locator.startswith(('//', '(//')):
             prefix = 'xpath'
         else:
             locator_parts = locator.split('=', 1)

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -72,7 +72,8 @@ ROBOT_OPTIONS = [
     '--report', 'NONE',
     '--log', 'NONE',
     '--loglevel', 'DEBUG',
-    '--pythonpath', os.pathsep.join([SRC_DIR, TEST_LIBS_DIR]),
+    '--pythonpath', SRC_DIR,
+    '--pythonpath', TEST_LIBS_DIR
 ]
 REBOT_OPTIONS = [
     '--outputdir', RESULTS_DIR,

--- a/test/unit/locators/test_elementfinder.py
+++ b/test/unit/locators/test_elementfinder.py
@@ -11,27 +11,14 @@ class ElementFinderTests(unittest.TestCase):
     def test_find_with_invalid_prefix(self):
         finder = ElementFinder()
         browser = mock()
-        assert_raises_with_msg(ValueError, "Element locator with prefix 'something' is not supported",
+        assert_raises_with_msg(ValueError, "Element locator with prefix 'something' is not supported.",
                                finder.find, browser, "something=test1")
-        assert_raises_with_msg(ValueError, "Element locator with prefix ' by ID ' is not supported",
+        assert_raises_with_msg(ValueError, "Element locator with prefix 'by ID' is not supported.",
                                finder.find, browser, " by ID =test1")
 
     def test_find_with_null_browser(self):
         finder = ElementFinder()
-        self.assertRaises(AssertionError,
-            finder.find, None, "id=test1")
-
-    def test_find_with_null_locator(self):
-        finder = ElementFinder()
-        browser = mock()
-        self.assertRaises(AssertionError,
-            finder.find, browser, None)
-
-    def test_find_with_empty_locator(self):
-        finder = ElementFinder()
-        browser = mock()
-        self.assertRaises(AssertionError,
-            finder.find, browser, "")
+        self.assertRaises(AttributeError, finder.find, None, "id=test1")
 
     def test_find_with_no_tag(self):
         finder = ElementFinder()
@@ -335,7 +322,7 @@ class ElementFinderTests(unittest.TestCase):
         browser = mock()
 
         elements = self._make_mock_elements('div', 'a', 'span', 'a')
-        when(browser).find_elements_by_id("test1").thenReturn(elements)
+        when(browser).find_elements_by_id("test1  ").thenReturn(elements)
 
         result = finder.find(browser, "id= test1  ")
         self.assertEqual(result, elements)

--- a/test/unit/locators/test_locator_parser.py
+++ b/test/unit/locators/test_locator_parser.py
@@ -1,67 +1,76 @@
 import unittest
 
-from Selenium2Library.locators.elementfinder import LocatorParser
+from Selenium2Library.locators.elementfinder import ElementFinder
 
 
 class LocatorParserTests(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        cls.parse = ElementFinder()._parse_locator
+
     def test_parse_xpath(self):
-        prefix, criteria = LocatorParser.parse('//foo/bar')
+        prefix, criteria = self.parse('//foo/bar')
         self.assertEqual(prefix, 'xpath')
         self.assertEqual(criteria, '//foo/bar')
 
-        prefix, criteria = LocatorParser.parse('(//foo/bar)[2]')
+        prefix, criteria = self.parse('(//foo/bar)[2]')
         self.assertEqual(prefix, 'xpath')
         self.assertEqual(criteria, '(//foo/bar)[2]')
 
-        prefix, criteria = LocatorParser.parse(
-            'xpath=//foo[@attr=value]')
+        prefix, criteria = self.parse('xpath=//foo[@attr=value]')
         self.assertEqual(prefix, 'xpath')
         self.assertEqual(criteria, '//foo[@attr=value]')
 
-        prefix, criteria = LocatorParser.parse('//foo/bar  ')
-        self.assertEqual(prefix, 'xpath')
-        self.assertEqual(criteria, '//foo/bar')
-
     def test_parse_dom(self):
-        prefix, criteria = LocatorParser.parse(
+        prefix, criteria = self.parse(
             'dom=document.images[56]')
         self.assertEqual(prefix, 'dom')
         self.assertEqual(criteria, 'document.images[56]')
 
     def test_parse_link(self):
-        prefix, criteria = LocatorParser.parse('link=My Link')
+        prefix, criteria = self.parse('link=My Link')
         self.assertEqual(prefix, 'link')
         self.assertEqual(criteria, 'My Link')
 
-        prefix, criteria = LocatorParser.parse('partial link=y Lin')
+        prefix, criteria = self.parse('partial link=y Lin')
         self.assertEqual(prefix, 'partial link')
         self.assertEqual(criteria, 'y Lin')
 
     def test_parse_id(self):
-        prefix, criteria = LocatorParser.parse('id=my_element')
+        prefix, criteria = self.parse('id=my_element')
         self.assertEqual(prefix, 'id')
         self.assertEqual(criteria, 'my_element')
 
-        prefix, criteria = LocatorParser.parse('my_element')
+        prefix, criteria = self.parse('my_element')
         self.assertEqual(prefix, 'default')
         self.assertEqual(criteria, 'my_element')
 
-        prefix, criteria = LocatorParser.parse('id= test1  ')
+    def test_parse_leave_trailing_spaces(self):
+        prefix, criteria = self.parse('id= test1  ')
         self.assertEqual(prefix, 'id')
-        self.assertEqual(criteria, 'test1')
+        self.assertEqual(criteria, 'test1  ')
+
+        prefix, criteria = self.parse('//foo/bar  ')
+        self.assertEqual(prefix, 'xpath')
+        self.assertEqual(criteria, '//foo/bar  ')
 
     def test_parse_identifier(self):
-        prefix, criteria = LocatorParser.parse('identifier=my_element')
+        prefix, criteria = self.parse('identifier=my_element')
         self.assertEqual(prefix, 'identifier')
         self.assertEqual(criteria, 'my_element')
 
     def test_parse_default(self):
-        prefix, criteria = LocatorParser.parse('default=page?a=b')
+        prefix, criteria = self.parse('default=page?a=b')
         self.assertEqual(prefix, 'default')
         self.assertEqual(criteria, 'page?a=b')
 
     def test_parse_invalid(self):
-        prefix, criteria = LocatorParser.parse('foo=bar')
+        prefix, criteria = self.parse('foo=bar')
         self.assertEqual(prefix, 'foo')
         self.assertEqual(criteria, 'bar')
+
+    def test_parse_empty(self):
+        prefix, criteria = self.parse('')
+        self.assertEqual(prefix, 'default')
+        self.assertEqual(criteria, '')

--- a/test/unit/locators/test_locator_parser.py
+++ b/test/unit/locators/test_locator_parser.py
@@ -1,0 +1,58 @@
+import unittest
+
+from Selenium2Library.locators.elementfinder import ParserLocator
+
+
+class ParserLocatorTests(unittest.TestCase):
+
+    def test_parse_xpath(self):
+        prefix, criteria = ParserLocator.parse_locator('//foo/bar')
+        self.assertEqual(prefix, 'xpath')
+        self.assertEqual(criteria, '//foo/bar')
+
+        prefix, criteria = ParserLocator.parse_locator('(//foo/bar)[2]')
+        self.assertEqual(prefix, 'xpath')
+        self.assertEqual(criteria, '(//foo/bar)[2]')
+
+        prefix, criteria = ParserLocator.parse_locator(
+            'xpath=//foo[@attr=value]')
+        self.assertEqual(prefix, 'xpath')
+        self.assertEqual(criteria, '//foo[@attr=value]')
+
+    def test_parse_dom(self):
+        prefix, criteria = ParserLocator.parse_locator(
+            'dom=document.images[56]')
+        self.assertEqual(prefix, 'dom')
+        self.assertEqual(criteria, 'document.images[56]')
+
+    def test_parse_link(self):
+        prefix, criteria = ParserLocator.parse_locator('link=My Link')
+        self.assertEqual(prefix, 'link')
+        self.assertEqual(criteria, 'My Link')
+
+        prefix, criteria = ParserLocator.parse_locator('partial link=y Lin')
+        self.assertEqual(prefix, 'partial link')
+        self.assertEqual(criteria, 'y Lin')
+
+    def test_parse_id(self):
+        prefix, criteria = ParserLocator.parse_locator('id=my_element')
+        self.assertEqual(prefix, 'id')
+        self.assertEqual(criteria, 'my_element')
+
+        prefix, criteria = ParserLocator.parse_locator('my_element')
+        self.assertEqual(prefix, 'default')
+        self.assertEqual(criteria, 'my_element')
+
+        prefix, criteria = ParserLocator.parse_locator('id= test1  ')
+        self.assertEqual(prefix, 'id')
+        self.assertEqual(criteria, 'test1')
+
+    def test_parse_identifier(self):
+        prefix, criteria = ParserLocator.parse_locator('identifier=my_element')
+        self.assertEqual(prefix, 'identifier')
+        self.assertEqual(criteria, 'my_element')
+
+    def test_parse_default(self):
+        prefix, criteria = ParserLocator.parse_locator('default=page?a=b')
+        self.assertEqual(prefix, 'default')
+        self.assertEqual(criteria, 'page?a=b')

--- a/test/unit/locators/test_locator_parser.py
+++ b/test/unit/locators/test_locator_parser.py
@@ -1,58 +1,58 @@
 import unittest
 
-from Selenium2Library.locators.elementfinder import ParserLocator
+from Selenium2Library.locators.elementfinder import LocatorParser
 
 
-class ParserLocatorTests(unittest.TestCase):
+class LocatorParserTests(unittest.TestCase):
 
     def test_parse_xpath(self):
-        prefix, criteria = ParserLocator.parse_locator('//foo/bar')
+        prefix, criteria = LocatorParser.parse('//foo/bar')
         self.assertEqual(prefix, 'xpath')
         self.assertEqual(criteria, '//foo/bar')
 
-        prefix, criteria = ParserLocator.parse_locator('(//foo/bar)[2]')
+        prefix, criteria = LocatorParser.parse('(//foo/bar)[2]')
         self.assertEqual(prefix, 'xpath')
         self.assertEqual(criteria, '(//foo/bar)[2]')
 
-        prefix, criteria = ParserLocator.parse_locator(
+        prefix, criteria = LocatorParser.parse(
             'xpath=//foo[@attr=value]')
         self.assertEqual(prefix, 'xpath')
         self.assertEqual(criteria, '//foo[@attr=value]')
 
     def test_parse_dom(self):
-        prefix, criteria = ParserLocator.parse_locator(
+        prefix, criteria = LocatorParser.parse(
             'dom=document.images[56]')
         self.assertEqual(prefix, 'dom')
         self.assertEqual(criteria, 'document.images[56]')
 
     def test_parse_link(self):
-        prefix, criteria = ParserLocator.parse_locator('link=My Link')
+        prefix, criteria = LocatorParser.parse('link=My Link')
         self.assertEqual(prefix, 'link')
         self.assertEqual(criteria, 'My Link')
 
-        prefix, criteria = ParserLocator.parse_locator('partial link=y Lin')
+        prefix, criteria = LocatorParser.parse('partial link=y Lin')
         self.assertEqual(prefix, 'partial link')
         self.assertEqual(criteria, 'y Lin')
 
     def test_parse_id(self):
-        prefix, criteria = ParserLocator.parse_locator('id=my_element')
+        prefix, criteria = LocatorParser.parse('id=my_element')
         self.assertEqual(prefix, 'id')
         self.assertEqual(criteria, 'my_element')
 
-        prefix, criteria = ParserLocator.parse_locator('my_element')
+        prefix, criteria = LocatorParser.parse('my_element')
         self.assertEqual(prefix, 'default')
         self.assertEqual(criteria, 'my_element')
 
-        prefix, criteria = ParserLocator.parse_locator('id= test1  ')
+        prefix, criteria = LocatorParser.parse('id= test1  ')
         self.assertEqual(prefix, 'id')
         self.assertEqual(criteria, 'test1')
 
     def test_parse_identifier(self):
-        prefix, criteria = ParserLocator.parse_locator('identifier=my_element')
+        prefix, criteria = LocatorParser.parse('identifier=my_element')
         self.assertEqual(prefix, 'identifier')
         self.assertEqual(criteria, 'my_element')
 
     def test_parse_default(self):
-        prefix, criteria = ParserLocator.parse_locator('default=page?a=b')
+        prefix, criteria = LocatorParser.parse('default=page?a=b')
         self.assertEqual(prefix, 'default')
         self.assertEqual(criteria, 'page?a=b')

--- a/test/unit/locators/test_locator_parser.py
+++ b/test/unit/locators/test_locator_parser.py
@@ -19,6 +19,10 @@ class LocatorParserTests(unittest.TestCase):
         self.assertEqual(prefix, 'xpath')
         self.assertEqual(criteria, '//foo[@attr=value]')
 
+        prefix, criteria = LocatorParser.parse('//foo/bar  ')
+        self.assertEqual(prefix, 'xpath')
+        self.assertEqual(criteria, '//foo/bar')
+
     def test_parse_dom(self):
         prefix, criteria = LocatorParser.parse(
             'dom=document.images[56]')
@@ -56,3 +60,8 @@ class LocatorParserTests(unittest.TestCase):
         prefix, criteria = LocatorParser.parse('default=page?a=b')
         self.assertEqual(prefix, 'default')
         self.assertEqual(criteria, 'page?a=b')
+
+    def test_parse_invalid(self):
+        prefix, criteria = LocatorParser.parse('foo=bar')
+        self.assertEqual(prefix, 'foo')
+        self.assertEqual(criteria, 'bar')


### PR DESCRIPTION
Also also simplifies where the prefix is determined and which
selenium method is used to find elements

In past //div was defaulted to xpath prefix, because it starts "//".
Now also (// defaults to xpath prefix, because example (//div)[1] is
valid xpath.