### PR TITLE
Removing usage of switch_to_* methods and using switch_to.*

### DIFF
--- a/src/Selenium2Library/keywords/browsermanagement.py
+++ b/src/Selenium2Library/keywords/browsermanagement.py
@@ -304,7 +304,7 @@ class BrowserManagementKeywords(LibraryComponent):
         """
         self.info("Selecting frame '%s'." % locator)
         element = self.element_find(locator)
-        self.browser.switch_to_frame(element)
+        self.browser.switch_to.frame(element)
 
     @keyword
     def select_window(self, locator=None):
@@ -356,7 +356,7 @@ class BrowserManagementKeywords(LibraryComponent):
     @keyword
     def unselect_frame(self):
         """Sets the top frame as the current frame."""
-        self.browser.switch_to_default_content()
+        self.browser.switch_to.default_content()
 
     @keyword
     def get_location(self):

--- a/src/Selenium2Library/keywords/element.py
+++ b/src/Selenium2Library/keywords/element.py
@@ -755,10 +755,10 @@ return !element.dispatchEvent(evt);
 
     def _frame_contains(self, locator, text):
         element = self.element_find(locator)
-        self.browser.switch_to_frame(element)
+        self.browser.switch_to.frame(element)
         self.info("Searching for text from frame '%s'." % locator)
         found = self.is_text_present(text)
-        self.browser.switch_to_default_content()
+        self.browser.switch_to.default_content()
         return found
 
     def _get_text(self, locator):
@@ -836,7 +836,7 @@ return !element.dispatchEvent(evt);
         return parts[0], parts[2]
 
     def _page_contains(self, text):
-        self.browser.switch_to_default_content()
+        self.browser.switch_to.default_content()
 
         if self.is_text_present(text):
             return True
@@ -845,9 +845,9 @@ return !element.dispatchEvent(evt);
                                       first_only=False, required=False)
         self.debug('Current frame has %d subframes' % len(subframes))
         for frame in subframes:
-            self.browser.switch_to_frame(frame)
+            self.browser.switch_to.frame(frame)
             found_text = self.is_text_present(text)
-            self.browser.switch_to_default_content()
+            self.browser.switch_to.default_content()
             if found_text:
                 return True
         return False

--- a/src/Selenium2Library/locators/windowmanager.py
+++ b/src/Selenium2Library/locators/windowmanager.py
@@ -61,21 +61,21 @@ class WindowManager(object):
     def _select_by_default(self, browser, criteria):
         if criteria is None or len(criteria) == 0 or criteria.lower() == "null":
             handles = browser.window_handles
-            browser.switch_to_window(handles[0])
+            browser.switch_to.window(handles[0])
             return
         try:
             starting_handle = browser.current_window_handle
         except NoSuchWindowException:
             starting_handle = None
         for handle in browser.window_handles:
-            browser.switch_to_window(handle)
+            browser.switch_to.window(handle)
             if criteria == handle:
                 return
             for item in self._get_current_window_info(browser)[2:4]:
                 if item.strip().lower() == criteria.lower():
                     return
         if starting_handle:
-            browser.switch_to_window(starting_handle)
+            browser.switch_to.window(starting_handle)
         raise ValueError("Unable to locate window with handle or name or title or URL '" + criteria + "'")
 
     def _select_by_last_index(self, browser):
@@ -87,12 +87,12 @@ class WindowManager(object):
             raise AssertionError("No window found")
         except NoSuchWindowException:
             raise AssertionError("Currently no focus window. where are you making a popup window?")
-        browser.switch_to_window(handles[-1])
+        browser.switch_to.window(handles[-1])
 
     def _select_by_excludes(self, browser, excludes):
         for handle in browser.window_handles:
             if handle not in excludes:
-                browser.switch_to_window(handle)
+                browser.switch_to.window(handle)
                 return
         raise ValueError("Unable to locate new window")
 
@@ -119,11 +119,11 @@ class WindowManager(object):
             starting_handle = None
         try:
             for handle in browser.window_handles:
-                browser.switch_to_window(handle)
+                browser.switch_to.window(handle)
                 window_infos.append(self._get_current_window_info(browser))
         finally:
             if starting_handle:
-                browser.switch_to_window(starting_handle)
+                browser.switch_to.window(starting_handle)
         return window_infos
 
     def _select_matching(self, browser, matcher, error):
@@ -132,11 +132,11 @@ class WindowManager(object):
         except NoSuchWindowException:
             starting_handle = None
         for handle in browser.window_handles:
-            browser.switch_to_window(handle)
+            browser.switch_to.window(handle)
             if matcher(self._get_current_window_info(browser)):
                 return
         if starting_handle:
-            browser.switch_to_window(starting_handle)
+            browser.switch_to.window(starting_handle)
         raise ValueError(error)
 
     def _get_current_window_info(self, browser):

--- a/test/unit/locators/test_windowmanager.py
+++ b/test/unit/locators/test_windowmanager.py
@@ -327,14 +327,16 @@ class WindowManagerTests(unittest.TestCase):
             ]
             window_infos[handle] = window_info
 
-        def switch_to_window(handle_):
+        def window(handle_):
             if handle_ in browser.window_handles:
                 browser.session_id = handle_
                 current_window.name = window_infos[handle_][1]
                 browser.current_window = current_window
                 browser.title = window_infos[handle_][2]
                 browser.current_url = window_infos[handle_][3]
-        browser.switch_to_window = switch_to_window
+        switch_to = mock()
+        switch_to.window = window
+        browser.switch_to = switch_to
 
         def execute_script(script):
             handle_ = browser.session_id


### PR DESCRIPTION
Selenium has deprecated switch_to_* methods, like switch_to_window.
Instead we should use switch_to.* methods.

Fixes #592