### PR TITLE
fixes #502 - prevent `capture page screenshot` from overwriting files

### DIFF
--- a/src/Selenium2Library/keywords/screenshot.py
+++ b/src/Selenium2Library/keywords/screenshot.py
@@ -145,9 +145,8 @@ class ScreenshotKeywords(LibraryComponent):
         filename = filename_template.format(
             index=self._get_screenshot_index(filename_template))
 
-        # Sorry for the gnarley regular expression.  it attempts to
-        # match python formatter syntax such as {index} or {index:...}
-        # but not {{index}} or # {{index:...}}
+        # try to match {index} but not {{index}} (plus handle
+        # other variants like {index!r})
         if re.search(r'(?<!{){index(![rs])?(:.*?)?}(?!})', filename_template):
             # make sure the computed filename doesn't exist. We only
             # do this if the template had the {index} formatting

--- a/test/acceptance/keywords/screenshots.robot
+++ b/test/acceptance/keywords/screenshots.robot
@@ -79,3 +79,72 @@ Capture page screenshot with escaped braces
     Should Be Equal    ${file}    ${OUTPUTDIR}${/}screenshot-and-index${/}brackets-{index}-name.png
     ${file} =    Capture Page Screenshot    ${OUTPUTDIR}${/}screenshot-and-index${/}brackets-{{index-name.png
     File Should Exist    ${OUTPUTDIR}${/}screenshot-and-index${/}brackets-{index-name.png
+
+Capture page screenshot computed name is unique
+    [Documentation]  verify that computed filenames are unique
+    [Tags]     issue-502
+    [Setup]    run keywords
+    ...  Remove files  ${OUTPUTDIR}/unique-screenshot-*.png
+    ...  AND  Touch    ${OUTPUTDIR}/unique-screenshot-1.png
+    ...  AND  Touch    ${OUTPUTDIR}/unique-screenshot-2.png
+    ...  # unique-screenshot-3 is purposely left out
+    ...  AND  Touch    ${OUTPUTDIR}/unique-screenshot-4.png
+
+
+    # number 3.
+    ${expected}=  set variable    ${OUTPUTDIR}/unique-screenshot-3.png
+    ${actual}=    Capture page screenshot  ${OUTPUTDIR}/unique-screenshot-{index}.png
+    Should be equal  ${actual}  ${expected}  values=False
+    ...  msg=Expected screenshot to be named '${expected}' but it was '${actual}'
+    File Should Exist    ${expected}
+
+    # since screenshot 4 exists, the next should be screenshot 5.
+    ${expected}=  set variable    ${OUTPUTDIR}/unique-screenshot-5.png
+    ${actual}=  Capture page screenshot  ${OUTPUTDIR}/unique-screenshot-{index}.png
+    Should be equal  ${actual}  ${expected}  values=False
+    ...  msg=Expected screenshot to be named '${expected}' but it was '${actual}'
+    File Should Exist    ${expected}
+
+Capture page screenshot advanced formatting name is unique
+    [Documentation]  verify that computed filenames are unique
+    [Tags]     issue-502
+    [Setup]    run keywords
+    ...  Remove files  ${OUTPUTDIR}/advanced-screenshot-*.png
+    ...  AND  Touch    ${OUTPUTDIR}/advanced-screenshot-002.png
+    ...  AND  Touch    ${OUTPUTDIR}/advanced-screenshot-003.png
+    ...  # advanced-screenshot-4 is purposely left out
+    ...  AND  Touch    ${OUTPUTDIR}/advanced-screenshot-005.png
+
+    ${expected}=  set variable    ${OUTPUTDIR}/advanced-screenshot-001.png
+    ${actual}=    Capture page screenshot  ${OUTPUTDIR}/advanced-screenshot-{index:03}.png
+    Should be equal  ${actual}  ${expected}  values=False
+    ...  msg=Expected screenshot to be named '${expected}' but it was '${actual}'
+    File Should Exist    ${expected}
+
+    # since screenshot 3 exists, the next should be screenshot 4.
+    ${expected}=  set variable    ${OUTPUTDIR}/advanced-screenshot-004.png
+    ${actual}=  Capture page screenshot  ${OUTPUTDIR}/advanced-screenshot-{index:03}.png
+    Should be equal  ${actual}  ${expected}  values=False
+    ...  msg=Expected screenshot to be named '${expected}' but it was '${actual}'
+    File Should Exist    ${expected}
+
+Capture page screenshot explicit name will overwrite
+    [Documentation]  Verify that existing filenames get overwritten if explicitly named
+    [Tags]     issue-502
+    [Setup]    run keywords
+    ...  Remove files  ${OUTPUTDIR}/explicit-screenshot-*.png
+    ...  AND  Touch  ${OUTPUTDIR}/explicit-screenshot-1.png
+
+    # make sure we are starting out with a single file in the output directory
+    ${count} =    Count Files In Directory    ${OUTPUTDIR}    explicit-screenshot-*.png
+    Should be equal as numbers  ${count}  1  values=False
+    ...  msg=Expected to find one screenshot file, found ${count}
+
+    # Give an explicit filename that doesn't include the counter placeholder {index}
+    Capture page screenshot    ${OUTPUTDIR}/explicit-screenshot-1.png
+
+    # we expect the above to overwrite the existing file
+    ${count} =    Count Files In Directory    ${OUTPUTDIR}    explicit-screenshot-*.png
+    Should be equal as numbers  ${count}  1  values=False
+    ...  msg=Expected to find one screenshot file, found ${count}
+    File Should Exist    ${OUTPUTDIR}/explicit-screenshot-1.png

--- a/test/acceptance/keywords/screenshots.robot
+++ b/test/acceptance/keywords/screenshots.robot
@@ -82,7 +82,6 @@ Capture page screenshot with escaped braces
 
 Capture page screenshot computed name is unique
     [Documentation]  verify that computed filenames are unique
-    [Tags]     issue-502
     [Setup]    run keywords
     ...  Remove files  ${OUTPUTDIR}/unique-screenshot-*.png
     ...  AND  Touch    ${OUTPUTDIR}/unique-screenshot-1.png
@@ -91,14 +90,14 @@ Capture page screenshot computed name is unique
     ...  AND  Touch    ${OUTPUTDIR}/unique-screenshot-4.png
 
 
-    # number 3.
+    # we expect this to be screenshot 3
     ${expected}=  set variable    ${OUTPUTDIR}/unique-screenshot-3.png
     ${actual}=    Capture page screenshot  ${OUTPUTDIR}/unique-screenshot-{index}.png
     Should be equal  ${actual}  ${expected}  values=False
     ...  msg=Expected screenshot to be named '${expected}' but it was '${actual}'
     File Should Exist    ${expected}
 
-    # since screenshot 4 exists, the next should be screenshot 5.
+    # since screenshot 4 exists, we expect this to be screenshot 5.
     ${expected}=  set variable    ${OUTPUTDIR}/unique-screenshot-5.png
     ${actual}=  Capture page screenshot  ${OUTPUTDIR}/unique-screenshot-{index}.png
     Should be equal  ${actual}  ${expected}  values=False
@@ -107,7 +106,6 @@ Capture page screenshot computed name is unique
 
 Capture page screenshot advanced formatting name is unique
     [Documentation]  verify that computed filenames are unique
-    [Tags]     issue-502
     [Setup]    run keywords
     ...  Remove files  ${OUTPUTDIR}/advanced-screenshot-*.png
     ...  AND  Touch    ${OUTPUTDIR}/advanced-screenshot-002.png
@@ -115,13 +113,14 @@ Capture page screenshot advanced formatting name is unique
     ...  # advanced-screenshot-4 is purposely left out
     ...  AND  Touch    ${OUTPUTDIR}/advanced-screenshot-005.png
 
+    # this should be screenshot 1, since it doesn't exist
     ${expected}=  set variable    ${OUTPUTDIR}/advanced-screenshot-001.png
     ${actual}=    Capture page screenshot  ${OUTPUTDIR}/advanced-screenshot-{index:03}.png
     Should be equal  ${actual}  ${expected}  values=False
     ...  msg=Expected screenshot to be named '${expected}' but it was '${actual}'
     File Should Exist    ${expected}
 
-    # since screenshot 3 exists, the next should be screenshot 4.
+    # since screenshot 1, 2, and 3 exists, the next should be screenshot 4.
     ${expected}=  set variable    ${OUTPUTDIR}/advanced-screenshot-004.png
     ${actual}=  Capture page screenshot  ${OUTPUTDIR}/advanced-screenshot-{index:03}.png
     Should be equal  ${actual}  ${expected}  values=False
@@ -130,7 +129,6 @@ Capture page screenshot advanced formatting name is unique
 
 Capture page screenshot explicit name will overwrite
     [Documentation]  Verify that existing filenames get overwritten if explicitly named
-    [Tags]     issue-502
     [Setup]    run keywords
     ...  Remove files  ${OUTPUTDIR}/explicit-screenshot-*.png
     ...  AND  Touch  ${OUTPUTDIR}/explicit-screenshot-1.png


### PR DESCRIPTION
When computing a number to add to a screenshot filename, it will use a
number that doesn't cause an existing file to be overwritten.