### PR TITLE
Added Python 3.6 to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - pip install -r requirements-dev.txt
 matrix:
   include:
-    - python: "2.7" # For PR and cron
+    - python: "3.6" # For PR and cron
       env:
         - BROWSER=chrome
         - SELENIUM=3.4.2


### PR DESCRIPTION
This removes one of the Python 2.7 runs from travis.yml