### PR TITLE
Provides fix to keep API for adding custom locator strategy

### DIFF
--- a/src/Selenium2Library/locators/elementfinder.py
+++ b/src/Selenium2Library/locators/elementfinder.py
@@ -1,3 +1,5 @@
+import copy
+
 from robot.api import logger
 from robot.utils import NormalizedDict
 from selenium.webdriver.remote.webelement import WebElement
@@ -29,6 +31,7 @@ class ElementFinder(ContextAware):
         self._strategies = NormalizedDict(initial=strategies, caseless=True,
                                           spaceless=True)
         self._default_strategies = list(strategies)
+        self._original_strategies = copy.deepcopy(self._default_strategies)
         self._key_attrs = {
             None: ['@id', '@name'],
             'a': ['@id', '@name', '@href',
@@ -48,7 +51,10 @@ class ElementFinder(ContextAware):
                              "is not supported." % prefix)
         strategy = self._strategies.get(prefix)
         tag, constraints = self._get_tag_and_constraints(tag)
-        elements = strategy(criteria, tag, constraints)
+        if prefix in self._original_strategies:
+            elements = strategy(criteria, tag, constraints)
+        else:
+            elements = strategy(self.browser, criteria, tag, constraints)
         if required and not elements:
             raise ValueError("Element locator '{}' did not match any "
                              "elements.".format(locator))

--- a/test/acceptance/locators/custom.robot
+++ b/test/acceptance/locators/custom.robot
@@ -40,15 +40,12 @@ Ensure Locators Can Persist
 *** Keywords ***
 Setup Custom Locator
     [Arguments]    ${persist}=${EMPTY}
-    [Documentation]    Setup Custom Locator
     Add Location Strategy    custom    Custom Locator Strategy    persist=${persist}
 
 Teardown Custom Locator
-    [Documentation]    Teardown Custom Locator
     Remove Location Strategy    custom
 
 Custom Locator Strategy
-    [Arguments]    ${criteria}    ${tag}    ${constraints}
-    [Documentation]    Custom Locator Strategy
+    [Arguments]    ${browser}    ${criteria}    ${tag}    ${constraints}
     ${retVal}=    Execute Javascript    return window.document.getElementById('${criteria}') || [];
     [Return]    ${retVal}


### PR DESCRIPTION
Provides idea how to support custom locator strategy API. In the API it has four arguments ((${browser}    ${criteria}    ${tag}    ${constraints})) as like the old `ElementFinder,find` method line `return strategy(browser, criteria, tag, constraints)` required.

Some unit test fails, which reveal bug in my PR, but this PR is more to discuss is to solution good one or should we do something else?