### PR TITLE
New keyword `Should Be Focused`

### DIFF
--- a/src/Selenium2Library/keywords/element.py
+++ b/src/Selenium2Library/keywords/element.py
@@ -223,15 +223,15 @@ class ElementKeywords(LibraryComponent):
         Key attributes for arbitrary elements are `id` and `name`. See
         `introduction` for details about locating elements.
 
-        New in SeleniumLibrary 2.0.1.
+        New in SeleniumLibrary 3.0.0.
         """
         element = self.find_element(locator)
-        try:
+        if self.browser.capabilities['browserName'] != "firefox":
+            focused = self.browser.switch_to.active_element
+        else:
             focused = self.browser.execute_script('return document.activeElement;')
-        except (IOError, RuntimeError) as err:
-            raise AssertionError("Internal Error: '%s'" % (err))
-        if not element == focused:
-            raise AssertionError("ERROR: Element '%s' is not with focus." % (locator))
+        if element != focused:
+            raise AssertionError("Element '%s' is not with focus." % (locator))
 
     @keyword
     def element_should_be_visible(self, locator, message=''):

--- a/src/Selenium2Library/keywords/element.py
+++ b/src/Selenium2Library/keywords/element.py
@@ -217,6 +217,23 @@ class ElementKeywords(LibraryComponent):
             raise AssertionError("Element '%s' is disabled." % (locator))
 
     @keyword
+    def element_should_be_focused(self, locator):
+        """Verifies that element identified with `locator` is focused.
+
+        Key attributes for arbitrary elements are `id` and `name`. See
+        `introduction` for details about locating elements.
+
+        New in SeleniumLibrary 2.0.1.
+        """
+        element = self.find_element(locator)
+        try:
+            focused = self.browser.execute_script('return document.activeElement;')
+        except (IOError, RuntimeError) as err:
+            raise AssertionError("Internal Error: '%s'" % (err))
+        if not element == focused:
+            raise AssertionError("ERROR: Element '%s' is not with focus." % (locator))
+
+    @keyword
     def element_should_be_visible(self, locator, message=''):
         """Verifies that the element identified by `locator` is visible.
 

--- a/test/acceptance/keywords/element_focus.robot
+++ b/test/acceptance/keywords/element_focus.robot
@@ -14,7 +14,7 @@ Should Be Focused
 Should Not Be Focused
     [Documentation]    Verify that element is not Focused
     Click Element    el_for_focus
-    Run Keyword And Expect Error    ERROR: Element 'el_for_blur' is not with focus.    Element Should Be Focused    el_for_blur
+    Run Keyword And Expect Error    Element 'el_for_blur' is not with focus.    Element Should Be Focused    el_for_blur
 
 Unexistent Element Not Focused
     [Documentation]    Missing element returns locator error
@@ -25,11 +25,10 @@ Span Element Not Focused
     [Documentation]    Focus on not Focusable Span
     Go To Page "/"
     Click Element    some_id
-    Run Keyword And Expect Error    ERROR: Element 'some_id' is not with focus.    Element Should Be Focused    some_id
+    Run Keyword And Expect Error    Element 'some_id' is not with focus.    Element Should Be Focused    some_id
 
 Table Element Not Focused
     [Documentation]    Focus on not Focusable Table
     Go To Page "tables/tables.html"
     Click Element    simpleTable
-    Run Keyword And Expect Error    ERROR: Element 'simpleTable' is not with focus.    Element Should Be Focused    simpleTable
-
+    Run Keyword And Expect Error    Element 'simpleTable' is not with focus.    Element Should Be Focused    simpleTable

--- a/test/acceptance/keywords/element_focus.robot
+++ b/test/acceptance/keywords/element_focus.robot
@@ -1,0 +1,35 @@
+*** Settings ***
+Documentation     Tests Focus Verification and Wait for Focus
+Suite Setup       Open Browser To Start Page
+Test Setup        Go To Page "mouse/index.html"
+# Suite Teardown    Close All Browsers
+Resource          ../resource.robot
+
+*** Test Cases ***
+Should Be Focused
+    [Documentation]    Verify that element is Focused
+    Click Element    el_for_focus
+    Element Should Be Focused    el_for_focus
+
+Should Not Be Focused
+    [Documentation]    Verify that element is not Focused
+    Click Element    el_for_focus
+    Run Keyword And Expect Error    ERROR: Element 'el_for_blur' is not with focus.    Element Should Be Focused    el_for_blur
+
+Unexistent Element Not Focused
+    [Documentation]    Missing element returns locator error
+    Click Element    el_for_focus
+    Run Keyword And Expect Error    ValueError: Element locator 'Unexistent_element' did not match any elements.    Element Should Be Focused    Unexistent_element
+
+Span Element Not Focused
+    [Documentation]    Focus on not Focusable Span
+    Go To Page "/"
+    Click Element    some_id
+    Run Keyword And Expect Error    ERROR: Element 'some_id' is not with focus.    Element Should Be Focused    some_id
+
+Table Element Not Focused
+    [Documentation]    Focus on not Focusable Table
+    Go To Page "tables/tables.html"
+    Click Element    simpleTable
+    Run Keyword And Expect Error    ERROR: Element 'simpleTable' is not with focus.    Element Should Be Focused    simpleTable
+

--- a/test/acceptance/keywords/element_focus.robot
+++ b/test/acceptance/keywords/element_focus.robot
@@ -1,34 +1,69 @@
 *** Settings ***
 Documentation     Tests Focus Verification and Wait for Focus
 Suite Setup       Open Browser To Start Page
-Test Setup        Go To Page "mouse/index.html"
-# Suite Teardown    Close All Browsers
 Resource          ../resource.robot
 
 *** Test Cases ***
 Should Be Focused
     [Documentation]    Verify that element is Focused
+    [Setup]    Go To Page "mouse/index.html"
     Click Element    el_for_focus
     Element Should Be Focused    el_for_focus
 
 Should Not Be Focused
     [Documentation]    Verify that element is not Focused
+    [Setup]    Go To Page "mouse/index.html"
     Click Element    el_for_focus
     Run Keyword And Expect Error    Element 'el_for_blur' is not with focus.    Element Should Be Focused    el_for_blur
+    Element Should Be Focused    el_for_focus
 
 Unexistent Element Not Focused
     [Documentation]    Missing element returns locator error
+    [Setup]    Go To Page "mouse/index.html"
     Click Element    el_for_focus
     Run Keyword And Expect Error    ValueError: Element locator 'Unexistent_element' did not match any elements.    Element Should Be Focused    Unexistent_element
+    Element Should Be Focused    el_for_focus
 
 Span Element Not Focused
     [Documentation]    Focus on not Focusable Span
-    Go To Page "/"
+    [Setup]    Go To Page "/"
     Click Element    some_id
     Run Keyword And Expect Error    Element 'some_id' is not with focus.    Element Should Be Focused    some_id
 
 Table Element Not Focused
     [Documentation]    Focus on not Focusable Table
-    Go To Page "tables/tables.html"
+    [Setup]    Go To Page "tables/tables.html"
     Click Element    simpleTable
     Run Keyword And Expect Error    Element 'simpleTable' is not with focus.    Element Should Be Focused    simpleTable
+
+Radio Button Should Be Focused
+    [Documentation]    Radio Button with xpath should be focused
+    [Setup]    Go To Page "forms/prefilled_email_form.html"
+    Click Element    xpath=//input[@name='sex' and @value='male']
+    Element Should Be Focused    xpath=//input[@name='sex' and @value='male']
+    Run Keyword And Expect Error    Element 'xpath=//input[@name=\'sex\' and @value=\'female\']' is not with focus.    Element Should Be Focused    xpath=//input[@name='sex' and @value='female']
+
+Checkbox Should Be Focused
+    [Documentation]    Checkbox with xpath should be focused
+    [Setup]    Go To Page "forms/prefilled_email_form.html"
+    Click Element    xpath=//input[@name='can_send_sms']
+    Element Should Be Focused    xpath=//input[@name='can_send_sms']
+    Run Keyword And Expect Error    Element 'xpath=//input[@name=\'can_send_email\']' is not with focus.    Element Should Be Focused    xpath=//input[@name='can_send_email']
+
+Select Button Should Be Focused
+    [Documentation]    Select Button with xpath should be focused
+    [Setup]    Go To Page "forms/prefilled_email_form.html"
+    Mouse Down    xpath=//select[@name='preferred_channel']
+    Element Should Be Focused    xpath=//select[@name='preferred_channel']
+    Run Keyword And Expect Error    Element 'xpath=//select[@name=\'preferred_channel\']/option[@value=\'phone\']' is not with focus.    Element Should Be Focused    xpath=//select[@name='preferred_channel']/option[@value='phone']
+    Click Element    xpath=//option[@value='email']
+    Run Keyword And Expect Error    Element 'xpath=//option[@value=\'email\']' is not with focus.    Element Should Be Focused    xpath=//option[@value='email']
+
+Submit Button Should Be Focused
+    [Documentation]    Submit Button should be focused
+    [Setup]    Go To Page "forms/prefilled_email_form.html"
+    Mouse Up    preferred_channel
+    Mouse Down    submit
+    Sleep    1 second
+    Element Should Be Focused    submit
+    Mouse Up    submit


### PR DESCRIPTION
See issue #851.

In reality the elements are not with Focus, but selected. If we do Mouse Over, we can see in the browser elements getting focus, but it would change the state to active.

More testing is required. It was only tested on Chrome, Firefox and PhantomJS. Would be nice to have it tested on Edge, IE 11, and Safari.