### PR TITLE
Removes the PY_VERSION variable for acceptance tests

### DIFF
--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -68,7 +68,6 @@ ROBOT_OPTIONS = [
     '--doc', 'Selenium2Library acceptance tests with {browser}',
     '--outputdir', RESULTS_DIR,
     '--variable', 'BROWSER:{browser}',
-    '--variable', 'PY_VERSION:{py_version}',
     '--report', 'NONE',
     '--log', 'NONE',
     '--loglevel', 'DEBUG',
@@ -123,11 +122,7 @@ def http_server():
 def execute_tests(interpreter, browser, rf_options, sauce_username, sauce_key):
     options = []
     runner = interpreter.split() + ['-m', 'robot.run']
-    options.extend(
-        [opt.format(browser=browser,
-         py_version=interpreter + sys.version[:3])
-            for opt in ROBOT_OPTIONS]
-    )
+    options.extend([opt.format(browser=browser) for opt in ROBOT_OPTIONS])
     options += rf_options
     if sauce_username and sauce_key:
         options.extend(get_sauce_conf(browser, sauce_username, sauce_key))


### PR DESCRIPTION
By looking the tests, the PY_VERSION variable not used anywhere.
Therefore decided to remove the variable and the code that sets the
variable in the acceptance tests.

Fixes #742