### PR TITLE
Configure Travis to get latest or pinned geckodriver, and set to test Firefox (or ESR) on PR and Cron.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 sudo: required
 dist: trusty
 addons:
+  firefox: latest
   apt:
     sources:
       - google-chrome
@@ -13,6 +14,12 @@ before_install:
   - unzip chromedriver_linux64.zip
   - sudo chmod u+x chromedriver
   - sudo mv chromedriver /usr/bin/
+  - FDVERSION=`curl -s -L https://github.com/mozilla/geckodriver/releases/latest | grep -E href=\"\(.*\)geckodriver-v\(.*\)-linux64.tar.gz\"`
+  - VFILE=`echo $FDVERSION | sed -E "s/^.*<a href=\"/https:\/\/github.com/" -- | sed -E "s/\" rel=\"nofollow\">//" --`
+  - wget $VFILE
+  - tar xzf geckodriver*-linux64.tar.gz
+  - sudo chmod u+x geckodriver
+  - sudo mv geckodriver /usr/bin/
 install:
   - pip install .
   - pip install -r requirements.txt
@@ -39,11 +46,16 @@ matrix:
         - BROWSER=chrome
         - SELENIUM=2.53.6
         - ROBOTFRAMEWORK=3.0.2
-    - python: "3.3" # For cron only
+    - python: "3.6" # For PR and cron
       env:
         - BROWSER=firefox
         - SELENIUM=3.5.0
         - ROBOTFRAMEWORK=3.0.2
+    - python: "2.7" # For PR and cron
+      env:
+        - BROWSER=firefox
+        - SELENIUM=3.5.0
+        - ROBOTFRAMEWORK=2.8.7
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
     #- FDVERSION=`curl -s -L https://github.com/mozilla/geckodriver/releases/latest | grep -E href=\"\(.*\)geckodriver-v\(.*\)-linux64.tar.gz\"`
     #- VFILE=`echo $FDVERSION | sed -E "s/^.*<a href=\"/https:\/\/github.com/" -- | sed -E "s/\" rel=\"nofollow\">//" --`
     # Firefox latest-esr
-  - VFILE=https://github.com//mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz
+  - VFILE=https://github.com//mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux64.tar.gz
   - wget $VFILE
   - tar xzf geckodriver*-linux64.tar.gz
   - sudo chmod u+x geckodriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: python
 sudo: required
 dist: trusty
 addons:
-  firefox: latest
+        # firefox: latest
+  firefox: latest-esr
   apt:
     sources:
       - google-chrome
@@ -14,8 +15,11 @@ before_install:
   - unzip chromedriver_linux64.zip
   - sudo chmod u+x chromedriver
   - sudo mv chromedriver /usr/bin/
-  - FDVERSION=`curl -s -L https://github.com/mozilla/geckodriver/releases/latest | grep -E href=\"\(.*\)geckodriver-v\(.*\)-linux64.tar.gz\"`
-  - VFILE=`echo $FDVERSION | sed -E "s/^.*<a href=\"/https:\/\/github.com/" -- | sed -E "s/\" rel=\"nofollow\">//" --`
+    # Firefox latest
+    #- FDVERSION=`curl -s -L https://github.com/mozilla/geckodriver/releases/latest | grep -E href=\"\(.*\)geckodriver-v\(.*\)-linux64.tar.gz\"`
+    #- VFILE=`echo $FDVERSION | sed -E "s/^.*<a href=\"/https:\/\/github.com/" -- | sed -E "s/\" rel=\"nofollow\">//" --`
+    # Firefox latest-esr
+  - VFILE=https://github.com//mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz
   - wget $VFILE
   - tar xzf geckodriver*-linux64.tar.gz
   - sudo chmod u+x geckodriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,35 +35,41 @@ matrix:
         - BROWSER=chrome
         - SELENIUM=3.5.0
         - ROBOTFRAMEWORK=3.0.2
+        - ROBOT_OPTIONS=
     - python: "2.7" # For PR and cron
       env:
         - BROWSER=chrome
         - SELENIUM=2.53.6
         - ROBOTFRAMEWORK=2.9.2
+        - ROBOT_OPTIONS=
     - python: "2.7" # For PR and cron
       env:
         - BROWSER=chrome
         - SELENIUM=3.5.0
         - ROBOTFRAMEWORK=2.8.7
+        - ROBOT_OPTIONS=
     - python: "3.3" # For PR and cron
       env:
         - BROWSER=chrome
         - SELENIUM=2.53.6
         - ROBOTFRAMEWORK=3.0.2
+        - ROBOT_OPTIONS=
     - python: "3.6" # For PR and cron
       env:
         - BROWSER=firefox
         - SELENIUM=3.5.0
         - ROBOTFRAMEWORK=3.0.2
+        - ROBOT_OPTIONS="--exclude known_issue_$BROWSER"
     - python: "2.7" # For PR and cron
       env:
         - BROWSER=firefox
         - SELENIUM=3.5.0
         - ROBOTFRAMEWORK=2.8.7
+        - ROBOT_OPTIONS="--exclude known_issue_$BROWSER"
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - pip install selenium==$SELENIUM
   - pip install robotframework==$ROBOTFRAMEWORK
 script:
-  - python test/run_tests.py $BROWSER
+  - python test/run_tests.py $BROWSER $ROBOT_OPTIONS

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -57,7 +57,7 @@ RESULTS_DIR = os.path.join(ROOT_DIR, "results")
 SRC_DIR = os.path.normpath(os.path.join(ROOT_DIR, "..", "src"))
 TEST_LIBS_DIR = os.path.join(RESOURCES_DIR, "testlibs")
 HTTP_SERVER_FILE = os.path.join(RESOURCES_DIR, "testserver", "testserver.py")
-# Travis settins for pull request
+# Travis settings for pull request
 TRAVIS = os.environ.get("TRAVIS", False)
 TRAVIS_EVENT_TYPE = os.environ.get("TRAVIS_EVENT_TYPE", None)
 TRAVIS_JOB_NUMBER = os.environ.get("TRAVIS_JOB_NUMBER", "localtunnel")
@@ -146,7 +146,7 @@ def log_start(command_list, *hiddens):
 
 
 def get_sauce_conf(browser, sauce_username, sauce_key):
-    if browser == 'chrome' and TRAVIS:
+    if browser in ['chrome', 'firefox'] and TRAVIS:
         return []
     return [
         '--variable', 'SAUCE_USERNAME:{}'.format(sauce_username),
@@ -208,21 +208,21 @@ if __name__ == '__main__':
     parser.add_argument(
         '--sauceusername',
         '-U',
-        help='Username to order browser from SaucuLabs'
+        help='Username to order browser from SauceLabs'
     )
     parser.add_argument(
         '--saucekey',
         '-K',
-        help='Access key to order browser from SaucuLabs'
+        help='Access key to order browser from SauceLabs'
     )
     args, rf_options = parser.parse_known_args()
     browser = args.browser.lower().strip()
-    if TRAVIS and browser != 'chrome' and TRAVIS_EVENT_TYPE != 'cron':
+    if TRAVIS and browser not in ['chrome', 'firefox'] and TRAVIS_EVENT_TYPE != 'cron':
         print(
             'Can not run test with browser "{}" from SauceLabs with PR.\n'
             'SauceLabs can be used only when running with cron and from '
             'SeleniumLibrary master branch, but your event type '
-            'was "{}". Only Chrome is supported with PR and when using '
+            'was "{}". Only Chrome and Firefox are supported with PR and when using '
             'Travis'.format(browser, TRAVIS_EVENT_TYPE)
         )
         sys.exit(0)


### PR DESCRIPTION
Added configuration for:
Python 2.7; RF 2.8.7 and Python 3.6; RF 3.0.2
Uses latest Firefox and geckodriver (current 52.0.2 and 0.18)
(Update) Commented the "latest" setup and set the "latest-esr" with geckodriver 0.16.1.
(it is difficult to know which version is for ff ESR 53)

Exposes 7 failed tests on both setups.