### PR TITLE
Updates tag "Known Issue Firefox" for failed or blocking tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 sudo: required
 dist: trusty
 addons:
+  firefox: latest
+  # firefox: latest-esr
   apt:
     sources:
       - google-chrome
@@ -13,6 +15,15 @@ before_install:
   - unzip chromedriver_linux64.zip
   - sudo chmod u+x chromedriver
   - sudo mv chromedriver /usr/bin/
+  # Firefox latest
+  - FDVERSION=`curl -s -L https://github.com/mozilla/geckodriver/releases/latest | grep -E href=\"\(.*\)geckodriver-v\(.*\)-linux64.tar.gz\"`
+  - VFILE=`echo $FDVERSION | sed -E "s/^.*<a href=\"/https:\/\/github.com/" -- | sed -E "s/\" rel=\"nofollow\">//" --`
+  # Firefox latest-esr
+  # - VFILE=https://github.com//mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux64.tar.gz
+  - wget $VFILE
+  - tar xzf geckodriver*-linux64.tar.gz
+  - sudo chmod u+x geckodriver
+  - sudo mv geckodriver /usr/bin/
 install:
   - pip install .
   - pip install -r requirements.txt
@@ -24,30 +35,41 @@ matrix:
         - BROWSER=chrome
         - SELENIUM=3.5.0
         - ROBOTFRAMEWORK=3.0.2
+        - ROBOT_OPTIONS=
     - python: "2.7" # For PR and cron
       env:
         - BROWSER=chrome
         - SELENIUM=2.53.6
         - ROBOTFRAMEWORK=2.9.2
+        - ROBOT_OPTIONS=
     - python: "2.7" # For PR and cron
       env:
         - BROWSER=chrome
         - SELENIUM=3.5.0
         - ROBOTFRAMEWORK=2.8.7
+        - ROBOT_OPTIONS=
     - python: "3.3" # For PR and cron
       env:
         - BROWSER=chrome
         - SELENIUM=2.53.6
         - ROBOTFRAMEWORK=3.0.2
-    - python: "3.3" # For cron only
+        - ROBOT_OPTIONS=
+    - python: "3.6" # For PR and cron
       env:
         - BROWSER=firefox
         - SELENIUM=3.5.0
         - ROBOTFRAMEWORK=3.0.2
+        - ROBOT_OPTIONS="--exclude Known_Issue_Firefox"
+    - python: "2.7" # For PR and cron
+      env:
+        - BROWSER=firefox
+        - SELENIUM=3.5.0
+        - ROBOTFRAMEWORK=2.8.7
+        - ROBOT_OPTIONS="--exclude Known_Issue_Firefox"
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - pip install selenium==$SELENIUM
   - pip install robotframework==$ROBOTFRAMEWORK
 script:
-  - python test/run_tests.py $BROWSER
+  - python test/run_tests.py $BROWSER $ROBOT_OPTIONS

--- a/test/acceptance/keywords/click_element_at_coordinates.robot
+++ b/test/acceptance/keywords/click_element_at_coordinates.robot
@@ -7,9 +7,7 @@ Resource          ../resource.robot
 *** Test Cases ***
 Click Element At Coordinates
     [Documentation]    LOG 2 Click clicking element 'Clickable' in coordinates '10', '20'.
-    [Tags]    Known Issue Firefox
-    ...    Known Issue Internet Explorer
-    ...    Known Issue Safari
+    [Tags]    Known Issue Internet Explorer    Known Issue Safari
     Click Element At Coordinates    Clickable    ${10}    ${20}
     Element Text Should Be    outputX    110
     Element Text Should Be    outputY    120

--- a/test/acceptance/keywords/content_assertions.robot
+++ b/test/acceptance/keywords/content_assertions.robot
@@ -8,40 +8,33 @@ Resource          ../resource.robot
 Location Should Be
     [Documentation]    LOG 2:3 Current location is '${FRONT PAGE}'.
     Location Should Be    ${FRONT PAGE}
-    Run Keyword And Expect Error    Location should have been 'non existing' but was '${FRONT PAGE}'
-    ...    Location Should Be    non existing
+    Run Keyword And Expect Error    Location should have been 'non existing' but was '${FRONT PAGE}'    Location Should Be    non existing
 
 Location Should Contain
     [Documentation]    LOG 2:3 Current location contains 'html'.
     Location Should Contain    html
-    Run Keyword And Expect Error
-    ...    Location should have contained 'not a location' but it was '${FRONT PAGE}'.
-    ...    Location Should Contain    not a location
+    Run Keyword And Expect Error    Location should have contained 'not a location' but it was '${FRONT PAGE}'.    Location Should Contain    not a location
 
 Title Should Be
     [Documentation]    LOG 2:3 Page title is '(root)/index.html'.
     Title Should Be    (root)/index.html
-    Run Keyword And Expect Error    Title should have been 'not a title' but was '(root)/index.html'
-    ...    Title Should Be    not a title
+    Run Keyword And Expect Error    Title should have been 'not a title' but was '(root)/index.html'    Title Should Be    not a title
 
 Page Should Contain
     [Documentation]    LOG 2:5 Current page contains text 'needle'.
-    ...    LOG 4.1:10 REGEXP: (?i)<html .*</html>
+    ...    LOG 4.1:10 REGEXP: (?i)<html.*</html>
     Page Should Contain    needle
     Page Should Contain    This is the haystack
-    Run Keyword And Expect Error    Page should have contained text 'non existing text' but did not
-    ...    Page Should Contain    non existing text
+    Run Keyword And Expect Error    Page should have contained text 'non existing text' but did not    Page Should Contain    non existing text
 
 Page Should Contain With Custom Log Level
-    [Documentation]    LOG 2.1:10 DEBUG REGEXP: (?i)<html .*</html>
-    Run Keyword And Expect Error    Page should have contained text 'non existing text' but did not
-    ...    Page Should Contain    non existing text    DEBUG
+    [Documentation]    LOG 2.1:10 DEBUG REGEXP: (?i)<html.*</html>
+    Run Keyword And Expect Error    Page should have contained text 'non existing text' but did not    Page Should Contain    non existing text    DEBUG
 
 Page Should Contain With Disabling Source Logging
     [Documentation]    LOG 3:2 NONE
     Set Log Level    INFO
-    Run Keyword And Expect Error    Page should have contained text 'non existing text' but did not
-    ...    Page Should Contain    non existing text    loglevel=NONE
+    Run Keyword And Expect Error    Page should have contained text 'non existing text' but did not    Page Should Contain    non existing text    loglevel=NONE
     [Teardown]    Set Log Level    DEBUG
 
 Page Should Contain With Frames
@@ -51,176 +44,144 @@ Page Should Contain With Frames
 
 Page Should Not Contain
     [Documentation]    LOG 2:8 Current page does not contain text 'non existing text'.
-    ...    LOG 3.1:7 REGEXP: (?i)<html .*</html>
+    ...    LOG 3.1:7 REGEXP: (?i)<html.*</html>
     Page Should Not Contain    non existing text
-    Run Keyword And Expect Error    Page should not have contained text 'needle'
-    ...    Page Should Not Contain    needle
+    Run Keyword And Expect Error    Page should not have contained text 'needle'    Page Should Not Contain    needle
 
 Page Should Not Contain With Custom Log Level
-    [Documentation]    LOG 2.1:7 DEBUG REGEXP: (?i)<html .*</html>
-    Run Keyword And Expect Error    Page should not have contained text 'needle'
-    ...    Page Should Not Contain    needle    DEBUG
+    [Documentation]    LOG 2.1:7 DEBUG REGEXP: (?i)<html.*</html>
+    Run Keyword And Expect Error    Page should not have contained text 'needle'    Page Should Not Contain    needle    DEBUG
 
 Page Should Not Contain With Disabling Source Logging
     [Documentation]    LOG 3:2 NONE
     Set Log Level    INFO
-    Run Keyword And Expect Error    Page should not have contained text 'needle'
-    ...    Page Should Not Contain    needle    loglevel=NONE
+    Run Keyword And Expect Error    Page should not have contained text 'needle'    Page Should Not Contain    needle    loglevel=NONE
     [Teardown]    Set Log Level    DEBUG
 
 Page Should Contain Element
     [Documentation]    Page Should Contain Element
     Page Should Contain Element    some_id
-    Run Keyword And Expect Error    Page should have contained element 'non-existent' but did not
-    ...    Page Should Contain Element    non-existent
+    Run Keyword And Expect Error    Page should have contained element 'non-existent' but did not    Page Should Contain Element    non-existent
 
 Page Should Contain Element With Custom Message
     [Documentation]    Page Should Contain Element With Custom Message
-    Run Keyword And Expect Error    Custom error message    Page Should Contain Element
-    ...    invalid    Custom error message
+    Run Keyword And Expect Error    Custom error message    Page Should Contain Element    invalid    Custom error message
 
 Page Should Contain Element With Disabling Source Logging
     [Documentation]    LOG 3:2 NONE
     Set Log Level    INFO
-    Run Keyword And Expect Error    Page should have contained element 'non-existent' but did not
-    ...    Page Should Contain Element    non-existent    loglevel=NONE
+    Run Keyword And Expect Error    Page should have contained element 'non-existent' but did not    Page Should Contain Element    non-existent    loglevel=NONE
     [Teardown]    Set Log Level    DEBUG
 
 Page Should Not Contain Element
     [Documentation]    Page Should Not Contain Element
     Page Should Not Contain Element    non-existent
-    Run Keyword And Expect Error    Page should not have contained element 'some_id'
-    ...    Page Should Not Contain Element    some_id
+    Run Keyword And Expect Error    Page should not have contained element 'some_id'    Page Should Not Contain Element    some_id
 
 Page Should Not Contain Element With Disabling Source Logging
     [Documentation]    LOG 3:2 NONE
     Set Log Level    INFO
-    Run Keyword And Expect Error    Page should not have contained element 'some_id'
-    ...    Page Should Not Contain Element    some_id    loglevel=NONE
+    Run Keyword And Expect Error    Page should not have contained element 'some_id'    Page Should Not Contain Element    some_id    loglevel=NONE
     [Teardown]    Set Log Level    DEBUG
 
 Element Should Contain
     [Documentation]    Element Should Contain
     Element Should Contain    some_id    This text is inside an identified element
-    Run Keyword And Expect Error
-    ...    Element 'some_id' should have contained text 'non existing text' but its text was 'This text is inside an identified element'.
-    ...    Element Should Contain    some_id    non existing text
-    Run Keyword And Expect Error
-    ...    ValueError: Element locator 'missing_id' did not match any elements.
-    ...    Element Should Contain    missing_id    This should report missing element.
+    Run Keyword And Expect Error    Element 'some_id' should have contained text 'non existing text' but its text was 'This text is inside an identified element'.    Element Should Contain    some_id    non existing text
+    Run Keyword And Expect Error    ValueError: Element locator 'missing_id' did not match any elements.    Element Should Contain    missing_id    This should report missing element.
 
 Element Should Not Contain
     [Documentation]    Element Should Not Contain
     Element Should Not Contain    some_id    This text is not inside an identified element
     Element Should Not Contain    some_id    elementypo
-    Run Keyword And Expect Error
-    ...    Element 'some_id' should not contain text 'This text is inside an identified element' but it did.
-    ...    Element Should Not Contain    some_id    This text is inside an identified element
-    Run Keyword And Expect Error
-    ...    ValueError: Element locator 'missing_id' did not match any elements.
-    ...    Element Should Not Contain    missing_id    This should report missing element.
+    Run Keyword And Expect Error    Element 'some_id' should not contain text 'This text is inside an identified element' but it did.    Element Should Not Contain    some_id    This text is inside an identified element
+    Run Keyword And Expect Error    ValueError: Element locator 'missing_id' did not match any elements.    Element Should Not Contain    missing_id    This should report missing element.
 
 Element Text Should Be
     [Documentation]    Element Text Should Be
     Element Text Should Be    some_id    This text is inside an identified element
-    Run Keyword And Expect Error
-    ...    The text of element 'some_id' should have been 'inside' but in fact it was 'This text is inside an identified element'.
-    ...    Element Text Should Be    some_id    inside
+    Run Keyword And Expect Error    The text of element 'some_id' should have been 'inside' but in fact it was 'This text is inside an identified element'.    Element Text Should Be    some_id    inside
 
 Get Text
     [Documentation]    Get Text
     ${str} =    Get Text    some_id
     Should Match    ${str}    This text is inside an identified element
-    Run Keyword And Expect Error
-    ...    ValueError: Element locator 'missing_id' did not match any elements.
-    ...    Get Text    missing_id
+    Run Keyword And Expect Error    ValueError: Element locator 'missing_id' did not match any elements.    Get Text    missing_id
 
 Element Should Be Visible
     [Documentation]    Element Should Be Visible
     [Setup]    Go To Page "visibility.html"
     Element Should Be Visible    i_am_visible
-    Run Keyword And Expect Error    The element 'i_am_hidden' should be visible, but it is not.
-    ...    Element Should Be Visible    i_am_hidden
+    Run Keyword And Expect Error    The element 'i_am_hidden' should be visible, but it is not.    Element Should Be Visible    i_am_hidden
 
 Element Should Not Be Visible
     [Documentation]    Element Should Not Be Visible
     [Setup]    Go To Page "visibility.html"
     Element Should Not Be Visible    i_am_hidden
-    Run Keyword And Expect Error    The element 'i_am_visible' should not be visible, but it is.
-    ...    Element Should Not Be Visible    i_am_visible
+    Run Keyword And Expect Error    The element 'i_am_visible' should not be visible, but it is.    Element Should Not Be Visible    i_am_visible
 
 Page Should Contain Checkbox
     [Documentation]    LOG 2:5 Current page contains checkbox 'can_send_email'.
     [Setup]    Go To Page "forms/prefilled_email_form.html"
     Page Should Contain Checkbox    can_send_email
     Page Should Contain Checkbox    xpath=//input[@type='checkbox' and @name='can_send_sms']
-    Run Keyword And Expect Error    Page should have contained checkbox 'non-existing' but did not
-    ...    Page Should Contain Checkbox    non-existing
+    Run Keyword And Expect Error    Page should have contained checkbox 'non-existing' but did not    Page Should Contain Checkbox    non-existing
 
 Page Should Not Contain Checkbox
     [Documentation]    LOG 2:5 Current page does not contain checkbox 'non-existing'.
     [Setup]    Go To Page "forms/prefilled_email_form.html"
     Page Should Not Contain Checkbox    non-existing
-    Run Keyword And Expect Error    Page should not have contained checkbox 'can_send_email'
-    ...    Page Should Not Contain Checkbox    can_send_email
+    Run Keyword And Expect Error    Page should not have contained checkbox 'can_send_email'    Page Should Not Contain Checkbox    can_send_email
 
 Page Should Contain Radio Button
     [Documentation]    Page Should Contain Radio Button
     [Setup]    Go To Page "forms/prefilled_email_form.html"
     Page Should Contain Radio Button    sex
     Page Should Contain Radio Button    xpath=//input[@type="radio" and @value="male"]
-    Run Keyword And Expect Error    Page should have contained radio button 'non-existing' but did not
-    ...    Page Should Contain Radio Button    non-existing
+    Run Keyword And Expect Error    Page should have contained radio button 'non-existing' but did not    Page Should Contain Radio Button    non-existing
 
 Page Should Not Contain Radio Button
     [Documentation]    Page Should Not Contain Radio Button
     [Setup]    Go To Page "forms/prefilled_email_form.html"
     Page Should Not Contain Radio Button    non-existing
-    Run Keyword And Expect Error    Page should not have contained radio button 'sex'
-    ...    Page Should Not Contain Radio Button    sex
+    Run Keyword And Expect Error    Page should not have contained radio button 'sex'    Page Should Not Contain Radio Button    sex
 
 Page Should Contain Image
     [Documentation]    Page Should Contain Image
     [Setup]    Go To Page "links.html"
     Page Should contain Image    image.jpg
-    Run Keyword And Expect Error    Page should have contained image 'non-existent' but did not
-    ...    Page Should contain Image    non-existent
+    Run Keyword And Expect Error    Page should have contained image 'non-existent' but did not    Page Should contain Image    non-existent
 
 Page Should Not Contain Image
     [Documentation]    Page Should Not Contain Image
     [Setup]    Go To Page "links.html"
     Page Should not contain Image    non-existent
-    Run Keyword And Expect Error    Page should not have contained image 'image.jpg'
-    ...    Page Should not contain Image    image.jpg
+    Run Keyword And Expect Error    Page should not have contained image 'image.jpg'    Page Should not contain Image    image.jpg
 
 Page Should Contain Link
     [Documentation]    Page Should Contain Link
     [Setup]    Go To Page "links.html"
     Page Should contain link    Relative
     Page Should contain link    sub/index.html
-    Run Keyword And Expect Error    Page should have contained link 'non-existent' but did not
-    ...    Page Should contain link    non-existent
+    Run Keyword And Expect Error    Page should have contained link 'non-existent' but did not    Page Should contain link    non-existent
 
 Page Should Not Contain Link
     [Documentation]    Page Should Not Contain Link
     [Setup]    Go To Page "links.html"
     Page Should not contain link    non-existent
-    Run Keyword And Expect Error    Page should not have contained link 'Relative'
-    ...    Page Should not contain link    Relative
+    Run Keyword And Expect Error    Page should not have contained link 'Relative'    Page Should not contain link    Relative
 
 Page Should Contain List
     [Documentation]    Page Should Contain List
     [Setup]    Go To Page "forms/prefilled_email_form.html"
     Page should Contain List    possible_channels
-    Run Keyword And Expect Error    Page should have contained list 'non-existing' but did not
-    ...    Page Should Contain List    non-existing
+    Run Keyword And Expect Error    Page should have contained list 'non-existing' but did not    Page Should Contain List    non-existing
 
 Page Should Not Contain List
     [Documentation]    Page Should Not Contain List
     [Setup]    Go To Page "forms/prefilled_email_form.html"
     Page Should Not Contain List    non-existing
-    Run Keyword And Expect Error    Page should not have contained list 'possible_channels'
-    ...    Page Should Not Contain List    possible_channels
+    Run Keyword And Expect Error    Page should not have contained list 'possible_channels'    Page Should Not Contain List    possible_channels
 
 Page Should Contain TextField
     [Documentation]    Page Should Contain TextField
@@ -229,20 +190,16 @@ Page Should Contain TextField
     Page Should Contain Text Field    website
     Page Should Contain Text Field    xpath=//input[@type='text' and @name='email']
     Page Should Contain Text Field    xpath=//input[@type='url' and @name='website']
-    Run Keyword And Expect Error    Page should have contained text field 'non-existing' but did not
-    ...    Page Should Contain Text Field    non-existing
-    Run Keyword And Expect Error    Page should have contained text field 'can_send_email' but did not
-    ...    Page Should Contain Text Field    can_send_email
+    Run Keyword And Expect Error    Page should have contained text field 'non-existing' but did not    Page Should Contain Text Field    non-existing
+    Run Keyword And Expect Error    Page should have contained text field 'can_send_email' but did not    Page Should Contain Text Field    can_send_email
 
 Page Should Not Contain Text Field
     [Documentation]    Page Should Not Contain Text Field
     [Setup]    Go To Page "forms/prefilled_email_form.html"
     Page Should Not Contain Text Field    non-existing
     Page Should Not Contain Text Field    can_send_email
-    Run Keyword And Expect Error    Page should not have contained text field 'name'
-    ...    Page Should Not Contain Text Field    name
-    Run Keyword And Expect Error    Page should not have contained text field 'website'
-    ...    Page Should Not Contain Text Field    website
+    Run Keyword And Expect Error    Page should not have contained text field 'name'    Page Should Not Contain Text Field    name
+    Run Keyword And Expect Error    Page should not have contained text field 'website'    Page Should Not Contain Text Field    website
 
 TextField Should Contain
     [Documentation]    LOG 2:7 Text field 'name' contains text ''.
@@ -253,12 +210,8 @@ TextField Should Contain
     Input Text    website    https://example.org
     TextField Should contain    name    my name
     TextField Should contain    website    https://example.org
-    Run Keyword And Expect Error
-    ...    Text field 'name' should have contained text 'non-existing' but it contained 'my name'
-    ...    TextField Should contain    name    non-existing
-    Run Keyword And Expect Error
-    ...    Text field 'website' should have contained text 'https://w3.org' but it contained 'https://example.org'
-    ...    TextField Should contain    website    https://w3.org
+    Run Keyword And Expect Error    Text field 'name' should have contained text 'non-existing' but it contained 'my name'    TextField Should contain    name    non-existing
+    Run Keyword And Expect Error    Text field 'website' should have contained text 'https://w3.org' but it contained 'https://example.org'    TextField Should contain    website    https://w3.org
 
 TextField Value Should Be
     [Documentation]    LOG 2:7 Content of text field 'name' is ''.
@@ -266,9 +219,7 @@ TextField Value Should Be
     textfield Value Should Be    name    ${EMPTY}
     Input Text    name    my name
     textfield Value Should Be    name    my name
-    Run Keyword And Expect Error
-    ...    Value of text field 'name' should have been 'non-existing' but was 'my name'
-    ...    textfield Value Should Be    name    non-existing
+    Run Keyword And Expect Error    Value of text field 'name' should have been 'non-existing' but was 'my name'    textfield Value Should Be    name    non-existing
     Clear Element Text    name
     Textfield Value Should Be    name    ${EMPTY}
 
@@ -277,18 +228,14 @@ TextArea Should Contain
     [Setup]    Go To Page "forms/email_form.html"
     TextArea Should Contain    comment    ${EMPTY}
     Input Text    comment    This is a comment.
-    Run Keyword And Expect Error
-    ...    Text field 'comment' should have contained text 'Hello World!' but it contained 'This is a comment.'
-    ...    TextArea Should Contain    comment    Hello World!
+    Run Keyword And Expect Error    Text field 'comment' should have contained text 'Hello World!' but it contained 'This is a comment.'    TextArea Should Contain    comment    Hello World!
 
 TextArea Value Should Be
     [Documentation]    TextArea Value Should Be
     [Setup]    Go To Page "forms/email_form.html"
     TextArea Value Should Be    comment    ${EMPTY}
     Input Text    comment    This is a comment.
-    Run Keyword And Expect Error
-    ...    Text field 'comment' should have contained text 'Hello World!' but it contained 'This is a comment.'
-    ...    TextArea Value Should Be    comment    Hello World!
+    Run Keyword And Expect Error    Text field 'comment' should have contained text 'Hello World!' but it contained 'This is a comment.'    TextArea Value Should Be    comment    Hello World!
     Clear Element Text    comment
     TextArea Value Should Be    comment    ${EMPTY}
 
@@ -303,22 +250,19 @@ Page Should Contain Button
     Page Should Contain Button    xpath=//input[@type="submit"]
     Page Should Contain Button    Act!
     Page Should Contain Button    xpath=//input[@type="button"]
-    Run Keyword And Expect Error    Page should have contained button 'non-existing' but did not
-    ...    Page Should Contain Button    non-existing
+    Run Keyword And Expect Error    Page should have contained button 'non-existing' but did not    Page Should Contain Button    non-existing
 
 Page Should Not Contain Button In Button Tag
     [Documentation]    Page Should Not Contain Button In Button Tag
     [Setup]    Go To Page "forms/buttons.html"
     Page Should Not Contain Button    invalid
-    Run Keyword And Expect Error    Page should not have contained button 'button'
-    ...    Page Should Not Contain Button    button
+    Run Keyword And Expect Error    Page should not have contained button 'button'    Page Should Not Contain Button    button
 
 Page Should Not Contain Button In Input Tag
     [Documentation]    Page Should Not Contain Button In Input Tag
     [Setup]    Go To Page "forms/buttons.html"
     Page Should Not Contain Button    invalid
-    Run Keyword And Expect Error    Page should not have contained input 'Act!'
-    ...    Page Should Not Contain Button    Act!
+    Run Keyword And Expect Error    Page should not have contained input 'Act!'    Page Should Not Contain Button    Act!
 
 Get All Links
     [Documentation]    Get All Links
@@ -332,9 +276,7 @@ Xpath Should Match X Times
     [Setup]    Go To Page "forms/login.html"
     Xpath Should Match X Times    //input[@type="text"]    1
     Xpath Should Match X Times    //input[@type="text"]    ${1}
-    Run Keyword And Expect Error
-    ...    Xpath //input[@type="text"] should have matched 2 times but matched 1 times
-    ...    Xpath Should Match X Times    //input[@type="text"]    2
+    Run Keyword And Expect Error    Xpath //input[@type="text"] should have matched 2 times but matched 1 times    Xpath Should Match X Times    //input[@type="text"]    2
 
 Locator Should Match X Times
     [Documentation]    Locator Should Match X Times

--- a/test/acceptance/keywords/forms_and_buttons.robot
+++ b/test/acceptance/keywords/forms_and_buttons.robot
@@ -59,12 +59,10 @@ Click button created with <button> by tag content
 
 Choose File
     [Documentation]    Choose File
+    [Tags]    Known Issue Firefox    Known Issue Internet Explorer    Known Issue Safari
     [Setup]    Navigate To File Upload Form And Create Temp File To Upload
-    [Tags]  Known Issue Internet Explorer    Known Issue Safari
     Choose File    file_to_upload    ${CURDIR}${/}temp.txt
-    ${dep_browser}=    Set Variable If
-    ...    '${BROWSER}'.lower() == 'ff' or '${BROWSER}'.lower() == 'firefox'
-    ...    temp.txt    C:\\fakepath\\temp.txt    #Needs to be checked in Windows and OS X
+    ${dep_browser}=    Set Variable If    '${BROWSER}'.lower() == 'ff' or '${BROWSER}'.lower() == 'firefox'    temp.txt    C:\\fakepath\\temp.txt    #Needs to be checked in Windows and OS X
     Textfield Value Should Be    name= file_to_upload    ${dep_browser}
     [Teardown]    Remove File    ${CURDIR}${/}temp.txt
 

--- a/test/acceptance/keywords/javascript.robot
+++ b/test/acceptance/keywords/javascript.robot
@@ -19,8 +19,7 @@ Alert Should Be Present
     Click Link    Click Me Too!
     Alert Should Be Present    MULTILINE ALERT!
     Click Link    Click Me!
-    Run Keyword And Expect Error    Alert text should have been 'foo bar' but was 'ALERT!'
-    ...    Alert Should Be Present    foo bar
+    Run Keyword And Expect Error    Alert text should have been 'foo bar' but was 'ALERT!'    Alert Should Be Present    foo bar
 
 Get Alert Message
     [Documentation]    Get Alert Message
@@ -52,7 +51,7 @@ Input Text Into Prompt
 
 Mouse Down On Link
     [Documentation]    Mouse Down On Link
-    [Tags]    Known Issue Safari    Known Issue Firefox
+    [Tags]    Known Issue Safari
     [Setup]    Go To Page "javascript/mouse_events.html"
     Mouse Down On Image    image_mousedown
     Text Field Should Contain    textfield    onmousedown
@@ -94,13 +93,13 @@ Execute Javascript from File
 
 Open Context Menu
     [Documentation]    Open Context Menu
-    [Tags]    Known Issue Safari    Known Issue Firefox
+    [Tags]    Known Issue Safari
     Go To Page "javascript/context_menu.html"
     Open Context Menu    myDiv
 
 Drag and Drop
     [Documentation]    Drag and Drop
-    [Tags]  Known Issue Internet Explorer    Known Issue Safari
+    [Tags]    Known Issue Internet Explorer    Known Issue Safari
     [Setup]    Go To Page "javascript/drag_and_drop.html"
     Element Text Should Be    id=droppable    Drop here
     Drag and Drop    id=draggable    id=droppable
@@ -108,7 +107,7 @@ Drag and Drop
 
 Drag and Drop by Offset
     [Documentation]    Drag and Drop by Offset
-    [Tags]  Known Issue Internet Explorer    Known Issue Safari
+    [Tags]    Known Issue Firefox    Known Issue Internet Explorer    Known Issue Safari
     [Setup]    Go To Page "javascript/drag_and_drop.html"
     Element Text Should Be    id=droppable    Drop here
     Drag and Drop by Offset    id=draggable    ${1}    ${1}
@@ -117,9 +116,9 @@ Drag and Drop by Offset
     Element Text Should Be    id=droppable    Dropped!
 
 Verify Console Log Can be Caught
-   [Tags]    Known Issue - Firefox
-   ${message}  Set Variable   Sample Console Error
-   Execute Javascript  console.error('${message}')
-   ${logs}=  Get Log  browser
-   ${err}=  Convert To string  ${logs}
-   Should Contain  ${err}  ${message}
+    [Tags]    Known Issue Firefox
+    ${message}    Set Variable    Sample Console Error
+    Execute Javascript    console.error('${message}')
+    ${logs}=    Get Log    browser
+    ${err}=    Convert To string    ${logs}
+    Should Contain    ${err}    ${message}

--- a/test/acceptance/keywords/mouse.robot
+++ b/test/acceptance/keywords/mouse.robot
@@ -1,27 +1,27 @@
 *** Settings ***
 Documentation     Tests mouse
 Test Setup        Go To Page "mouse/index.html"
-Resource          ../resource.robot
 Force Tags        Known Issue Internet Explorer
+Resource          ../resource.robot
 
 *** Test Cases ***
 Mouse Over
     [Documentation]    Mouse Over
-    [Tags]    Known Issue Safari    Known Issue Firefox
+    [Tags]    Known Issue Safari
     Mouse Over    el_for_mouseover
     Textfield Value Should Be    el_for_mouseover    mouseover el_for_mouseover
     Run Keyword And Expect Error    ERROR: Element not_there not found.    Mouse Over    not_there
 
 Mouse Out
     [Documentation]    Mouse Out
-    [Tags]    Known Issue Safari    Known Issue Firefox
+    [Tags]    Known Issue Safari
     Mouse Out    el_for_mouseout
     Textfield Value Should Be    el_for_mouseout    mouseout el_for_mouseout
     Run Keyword And Expect Error    ERROR: Element not_there not found.    Mouse Out    not_there
 
 Mouse Down
     [Documentation]    Mouse Down
-    [Tags]    Known Issue Safari    Known Issue Firefox
+    [Tags]    Known Issue Safari
     Mouse Down    el_for_mousedown
     Textfield Value Should Be    el_for_mousedown    mousedown el_for_mousedown
     Run Keyword And Expect Error    ERROR: Element not_there not found.    Mouse Down    not_there

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -57,7 +57,7 @@ RESULTS_DIR = os.path.join(ROOT_DIR, "results")
 SRC_DIR = os.path.normpath(os.path.join(ROOT_DIR, "..", "src"))
 TEST_LIBS_DIR = os.path.join(RESOURCES_DIR, "testlibs")
 HTTP_SERVER_FILE = os.path.join(RESOURCES_DIR, "testserver", "testserver.py")
-# Travis settins for pull request
+# Travis settings for pull request
 TRAVIS = os.environ.get("TRAVIS", False)
 TRAVIS_EVENT_TYPE = os.environ.get("TRAVIS_EVENT_TYPE", None)
 TRAVIS_JOB_NUMBER = os.environ.get("TRAVIS_JOB_NUMBER", "localtunnel")
@@ -146,7 +146,7 @@ def log_start(command_list, *hiddens):
 
 
 def get_sauce_conf(browser, sauce_username, sauce_key):
-    if browser == 'chrome' and TRAVIS:
+    if browser in ['chrome', 'firefox'] and TRAVIS:
         return []
     return [
         '--variable', 'SAUCE_USERNAME:{}'.format(sauce_username),
@@ -208,21 +208,21 @@ if __name__ == '__main__':
     parser.add_argument(
         '--sauceusername',
         '-U',
-        help='Username to order browser from SaucuLabs'
+        help='Username to order browser from SauceLabs'
     )
     parser.add_argument(
         '--saucekey',
         '-K',
-        help='Access key to order browser from SaucuLabs'
+        help='Access key to order browser from SauceLabs'
     )
     args, rf_options = parser.parse_known_args()
     browser = args.browser.lower().strip()
-    if TRAVIS and browser != 'chrome' and TRAVIS_EVENT_TYPE != 'cron':
+    if TRAVIS and browser not in ['chrome', 'firefox'] and TRAVIS_EVENT_TYPE != 'cron':
         print(
             'Can not run test with browser "{}" from SauceLabs with PR.\n'
             'SauceLabs can be used only when running with cron and from '
             'SeleniumLibrary master branch, but your event type '
-            'was "{}". Only Chrome is supported with PR and when using '
+            'was "{}". Only Chrome and Firefox are supported with PR and when using '
             'Travis'.format(browser, TRAVIS_EVENT_TYPE)
         )
         sys.exit(0)


### PR DESCRIPTION
This PR replaces PR #887, where Travis is activated for testing with Firefox., on Python 2.7 and 3.6.
The tests were blocked by "Submit Button Should Be Focused", and would timeout if not excluded.
The tag "Known Issue Firefox" was removed from some tests, and added to others.
