### PR TITLE
No Fail For Capture Page Screenshot When No Browser Is Opened (Issue #816)

### DIFF
--- a/src/SeleniumLibrary/keywords/screenshot.py
+++ b/src/SeleniumLibrary/keywords/screenshot.py
@@ -113,13 +113,13 @@ class ScreenshotKeywords(LibraryComponent):
 
         """
         try:
-			# try to access the browser property
-			b = self.browser
-			
-		except RuntimeError:
-			# we got an error, just exit
-			self.info("Couldn't capture page screenshot because no browser is opened")
-			return
+            # try to access the browser property
+            b = self.browser
+            
+        except RuntimeError:
+            # we got an error, just exit
+            self.info("Couldn't capture page screenshot because no browser is opened")
+            return
         
         path, link = self._get_screenshot_paths(filename)
         self._create_directory(path)

--- a/src/SeleniumLibrary/keywords/screenshot.py
+++ b/src/SeleniumLibrary/keywords/screenshot.py
@@ -112,9 +112,14 @@ class ScreenshotKeywords(LibraryComponent):
         | File Should Exist | ${OTHER_DIR}${/}sc-000001.png |
 
         """
-        if not self.browser:
-            self.info("Couldn't capture page screenshot because no browser is opened")
-            return
+        try:
+			# try to access the browser property
+			b = self.browser
+			
+		except RuntimeError:
+			# we got an error, just exit
+			self.info("Couldn't capture page screenshot because no browser is opened")
+			return
         
         path, link = self._get_screenshot_paths(filename)
         self._create_directory(path)

--- a/src/SeleniumLibrary/keywords/screenshot.py
+++ b/src/SeleniumLibrary/keywords/screenshot.py
@@ -113,29 +113,27 @@ class ScreenshotKeywords(LibraryComponent):
 
         """
         try:
-            # try to access the browser property
-            b = self.browser
+            self.browser
             
         except RuntimeError:
-            # we got an error, just exit
             self.info("Couldn't capture page screenshot because no browser is opened")
-            return
         
-        path, link = self._get_screenshot_paths(filename)
-        self._create_directory(path)
-        if hasattr(self.browser, 'get_screenshot_as_file'):
-            if not self.browser.get_screenshot_as_file(path):
-                raise RuntimeError('Failed to save screenshot ' + link)
         else:
-            if not self.browser.save_screenshot(path):
-                raise RuntimeError('Failed to save screenshot ' + link)
-        # Image is shown on its own row and thus prev row is closed on purpose
-        msg = (
-            '</td></tr><tr><td colspan="3"><a href="{}">'
-            '<img src="{}" width="800px"></a>'.format(link, link)
-        )
-        self.info(msg, html=True)
-        return path
+            path, link = self._get_screenshot_paths(filename)
+            self._create_directory(path)
+            if hasattr(self.browser, 'get_screenshot_as_file'):
+                if not self.browser.get_screenshot_as_file(path):
+                    raise RuntimeError('Failed to save screenshot ' + link)
+            else:
+                if not self.browser.save_screenshot(path):
+                    raise RuntimeError('Failed to save screenshot ' + link)
+            # Image is shown on its own row and thus prev row is closed on purpose
+            msg = (
+                '</td></tr><tr><td colspan="3"><a href="{}">'
+                '<img src="{}" width="800px"></a>'.format(link, link)
+            )
+            self.info(msg, html=True)
+            return path
 
     def _create_directory(self, path):
         target_dir = os.path.dirname(path)

--- a/src/SeleniumLibrary/keywords/screenshot.py
+++ b/src/SeleniumLibrary/keywords/screenshot.py
@@ -112,10 +112,10 @@ class ScreenshotKeywords(LibraryComponent):
         | File Should Exist | ${OTHER_DIR}${/}sc-000001.png |
 
         """
-		if not self.browser:
-			self.info("Couldn't capture page screenshot because no browser is opened")
-			return
-		
+        if not self.browser:
+            self.info("Couldn't capture page screenshot because no browser is opened")
+            return
+        
         path, link = self._get_screenshot_paths(filename)
         self._create_directory(path)
         if hasattr(self.browser, 'get_screenshot_as_file'):

--- a/src/SeleniumLibrary/keywords/screenshot.py
+++ b/src/SeleniumLibrary/keywords/screenshot.py
@@ -112,6 +112,10 @@ class ScreenshotKeywords(LibraryComponent):
         | File Should Exist | ${OTHER_DIR}${/}sc-000001.png |
 
         """
+		if not self.browser:
+			self.info("Couldn't capture page screenshot because no browser is opened")
+			return
+		
         path, link = self._get_screenshot_paths(filename)
         self._create_directory(path)
         if hasattr(self.browser, 'get_screenshot_as_file'):

--- a/test/acceptance/keywords/screenshots.robot
+++ b/test/acceptance/keywords/screenshots.robot
@@ -138,7 +138,7 @@ Capture page screenshot explicit name will overwrite
     Should be equal as numbers  ${count}  1  values=False
     ...  msg=Expected to find one screenshot file, found ${count}
     File Should Exist    ${OUTPUTDIR}/explicit-screenshot-1.png
-    
+
 Capture Page Screenshot With Closed Browser
     [Documentation]    LOG 1    Couldn't capture page screenshot because no browser is opened
     [Setup]    Close All Browsers

--- a/test/acceptance/keywords/screenshots.robot
+++ b/test/acceptance/keywords/screenshots.robot
@@ -138,9 +138,9 @@ Capture page screenshot explicit name will overwrite
     Should be equal as numbers  ${count}  1  values=False
     ...  msg=Expected to find one screenshot file, found ${count}
     File Should Exist    ${OUTPUTDIR}/explicit-screenshot-1.png
-	
+    
 Capture Page Screenshot With Closed Browser
     [Documentation]    LOG 1    Couldn't capture page screenshot because no browser is opened
     [Setup]    Close All Browsers
     Capture Page Screenshot
-	[Teardown]    Open Browser To Start Page
+    [Teardown]    Open Browser To Start Page

--- a/test/acceptance/keywords/screenshots.robot
+++ b/test/acceptance/keywords/screenshots.robot
@@ -138,3 +138,9 @@ Capture page screenshot explicit name will overwrite
     Should be equal as numbers  ${count}  1  values=False
     ...  msg=Expected to find one screenshot file, found ${count}
     File Should Exist    ${OUTPUTDIR}/explicit-screenshot-1.png
+	
+Capture Page Screenshot With Closed Browser
+    [Documentation]    LOG 1    Couldn't capture page screenshot because no browser is opened
+    [Setup]    Close All Browsers
+    Capture Page Screenshot
+	[Teardown]    Open Browser To Start Page

--- a/test/acceptance/keywords/screenshots.robot
+++ b/test/acceptance/keywords/screenshots.robot
@@ -140,7 +140,7 @@ Capture page screenshot explicit name will overwrite
     File Should Exist    ${OUTPUTDIR}/explicit-screenshot-1.png
 
 Capture page screenshot with closed browser
-    [Documentation]    LOG 1    Couldn't capture page screenshot because no browser is opened
+    [Documentation]    LOG 2:1    Couldn't capture page screenshot because no browser is opened
     [Setup]    Close All Browsers
     Capture Page Screenshot
     [Teardown]    Open Browser To Start Page

--- a/test/acceptance/keywords/screenshots.robot
+++ b/test/acceptance/keywords/screenshots.robot
@@ -139,7 +139,7 @@ Capture page screenshot explicit name will overwrite
     ...  msg=Expected to find one screenshot file, found ${count}
     File Should Exist    ${OUTPUTDIR}/explicit-screenshot-1.png
 
-Capture Page Screenshot With Closed Browser
+Capture page screenshot with closed browser
     [Documentation]    LOG 1    Couldn't capture page screenshot because no browser is opened
     [Setup]    Close All Browsers
     Capture Page Screenshot


### PR DESCRIPTION
The keyword `Capture Page Screenshot` will no longer fail, and simply return with a message when no browser is opened.