### PR TITLE
Fixes Set Selenium Speed when calling before opening browser

### DIFF
--- a/test/acceptance/keywords/set_selenium_speed.robot
+++ b/test/acceptance/keywords/set_selenium_speed.robot
@@ -13,10 +13,47 @@ Settimg selenium speed is possible multiple times
 
 Selenium speed should affect execution
     [Documentation]    Click Element executes two selenium commands and
-    ...    therefore total time is 6 seconds
-    Set Selenium Speed    3
+    ...    therefore total time is 2 seconds
+    Set Selenium Speed    1
     ${start} =    Get Time    epoch
     Click Element    xpath=//input[@name="email"]
     ${end} =    Get Time    epoch
     ${total} =    Evaluate    ${end} - ${start}
-    Should Be True     ${total} > ${5}
+    Should Be True     ${total} >= ${2}
+
+Selenium speed should affect before browser is opened
+    [Documentation]    Click Element executes two selenium commands and
+    ...    therefore total time is 2 seconds
+    Close All Browsers
+    Set Selenium Speed    1
+    Open Browser To "forms/prefilled_email_form.html"
+    ${start} =    Get Time    epoch
+    Click Element    xpath=//input[@name="email"]
+    ${end} =    Get Time    epoch
+    ${total} =    Evaluate    ${end} - ${start}
+    Should Be True     ${total} >= ${2}
+
+Selenium speed should affect all browsers
+    [Documentation]    Click Element executes two selenium commands and
+    ...    therefore total time is 2 seconds
+    Close All Browsers
+    Open Browser To "forms/prefilled_email_form.html"
+    Open Browser To "forms/prefilled_email_form.html"
+    Set Selenium Speed    1
+    ${start} =    Get Time    epoch
+    Click Element    xpath=//input[@name="email"]
+    ${end} =    Get Time    epoch
+    ${total} =    Evaluate    ${end} - ${start}
+    Should Be True     ${total} >= ${2}
+    Switch Browser    ${2}
+    ${start} =    Get Time    epoch
+    Click Element    xpath=//input[@name="email"]
+    ${end} =    Get Time    epoch
+    ${total} =    Evaluate    ${end} - ${start}
+    Should Be True     ${total} >= ${2}
+
+*** Keywords ***
+Open Browser To "forms/prefilled_email_form.html"
+    ${index} =    Open Browser    ${FRONT PAGE}    ${BROWSER}
+    ...    remote_url=${REMOTE_URL}    desired_capabilities=${DESIRED_CAPABILITIES}
+    Go To    ${ROOT}/forms/prefilled_email_form.html

--- a/test/acceptance/keywords/set_selenium_speed.robot
+++ b/test/acceptance/keywords/set_selenium_speed.robot
@@ -18,8 +18,7 @@ Selenium speed should affect execution
     ${start} =    Get Time    epoch
     Click Element    xpath=//input[@name="email"]
     ${end} =    Get Time    epoch
-    ${total} =    Evaluate    ${end} - ${start}
-    Should Be True     ${total} >= ${2}
+    Should Be True     ${end} - ${start} >= ${2}
 
 Selenium speed should affect before browser is opened
     [Documentation]    Click Element executes two selenium commands and
@@ -30,8 +29,7 @@ Selenium speed should affect before browser is opened
     ${start} =    Get Time    epoch
     Click Element    xpath=//input[@name="email"]
     ${end} =    Get Time    epoch
-    ${total} =    Evaluate    ${end} - ${start}
-    Should Be True     ${total} >= ${2}
+    Should Be True     ${end} - ${start} >= ${2}
 
 Selenium speed should affect all browsers
     [Documentation]    Click Element executes two selenium commands and
@@ -43,14 +41,12 @@ Selenium speed should affect all browsers
     ${start} =    Get Time    epoch
     Click Element    xpath=//input[@name="email"]
     ${end} =    Get Time    epoch
-    ${total} =    Evaluate    ${end} - ${start}
-    Should Be True     ${total} >= ${2}
+    Should Be True     ${end} - ${start} >= ${2}
     Switch Browser    ${2}
     ${start} =    Get Time    epoch
     Click Element    xpath=//input[@name="email"]
     ${end} =    Get Time    epoch
-    ${total} =    Evaluate    ${end} - ${start}
-    Should Be True     ${total} >= ${2}
+    Should Be True     ${end} - ${start} >= ${2}
 
 *** Keywords ***
 Open Browser To "forms/prefilled_email_form.html"

--- a/test/unit/keywords/test_browsermanagement.py
+++ b/test/unit/keywords/test_browsermanagement.py
@@ -3,7 +3,7 @@ import unittest
 from mockito import when, mock, verify, verifyNoMoreInteractions, unstub
 from selenium import webdriver
 
-from SeleniumLibrary.keywords.browsermanagement import BrowserManagementKeywords
+from SeleniumLibrary.keywords import BrowserManagementKeywords
 
 
 class BrowserManagementTests(unittest.TestCase):
@@ -142,6 +142,26 @@ class BrowserManagementTests(unittest.TestCase):
             verify(ctx).register_browser(driver, 'fake2')
         finally:
             del webdriver.FakeWebDriver
+        unstub()
+
+    def test_open_browser_speed(self):
+        ctx = mock()
+        ctx.speed = 5.0
+        browser = mock()
+        when(webdriver).Chrome().thenReturn(browser)
+        bm = BrowserManagementKeywords(ctx)
+        bm.open_browser('http://robotframework.org/', 'chrome')
+        self.assertEqual(browser._speed, 5.0)
+        unstub()
+
+    def test_create_webdriver_speed(self):
+        ctx = mock()
+        ctx.speed = 0.0
+        browser = mock()
+        when(webdriver).Chrome().thenReturn(browser)
+        bm = BrowserManagementKeywords(ctx)
+        bm.open_browser('http://robotframework.org/', 'chrome')
+        verify(browser, times=0).__call__('_speed')
         unstub()
 
     def verify_browser(self, webdriver_type, browser_name, **kw):


### PR DESCRIPTION
If Set Selenium Speed was called before the browser
is opened, the speed did not affect the browser. This PR fixes the
problem.

Fixes #898