### PR TITLE
Allow public access to TableElementFinder methods.

### DIFF
--- a/src/Selenium2Library/__init__.py
+++ b/src/Selenium2Library/__init__.py
@@ -13,6 +13,7 @@ from .keywords import SelectElementKeywords
 from .keywords import TableElementKeywords
 from .keywords import WaitingKeywords
 from .locators import ElementFinder
+from .locators import TableElementFinder
 from .utils import BrowserCache
 from .utils import LibraryListener
 
@@ -218,6 +219,7 @@ class Selenium2Library(DynamicCore):
         self.register_keyword_to_run_on_failure(run_on_failure)
         self.ROBOT_LIBRARY_LISTENER = LibraryListener()
         self.element_finder = ElementFinder(self)
+        self.table_element_finder = TableElementFinder(self)
 
     def run_keyword(self, name, args, kwargs):
         try:


### PR DESCRIPTION
Per [issue 911](https://github.com/robotframework/SeleniumLibrary/issues/911), this PR allows access to TableElementFinder methods.