### PR TITLE
Depreacted Get Matching Xpath Count and Xpath Should Match X Times kw

### DIFF
--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -171,12 +171,8 @@ class ElementKeywords(LibraryComponent):
         `Locator Should Match X Times`.
 
         Examples assumes that locator matches to three elements
-        | ${count} =                 | Get Matching Locator Count | xpath: //*[@name="div_name"] |
-        | Should Be Equal As Numbers | ${count}                   | 3                            |
-        | ${count} =                 | Get Matching Locator Count | name:div_name                |
-        | Should Be Equal As Numbers | ${count}                   | 3                            |
-        | ${count} =                 | Get Matching Locator Count | div_name                     |
-        | Should Be Equal As Numbers | ${count}                   | 3                            |
+        | ${count} =      | Get Matching Locator Count | name:div_name  |
+        | Should Be True  | ${count} > 2               |                |
 
         New in SeleniumLibrary 3.0
         """
@@ -193,9 +189,7 @@ class ElementKeywords(LibraryComponent):
         `loglevel` arguments.
 
         Examples assumes that locator matches to three elements
-        | Locator Should Match X Times | xpath: //*[@name="div_name"] | 3 |
-        | locator_should_match_x_times | name:div_name                | 3 |
-        | locator_should_match_x_times | div_name                     | 3 |
+        | locator_should_match_x_times | name:div_name | 3 |
         """
         actual_locator_count = len(self.find_element(
             locator, first_only=False, required=False)
@@ -758,25 +752,16 @@ return !element.dispatchEvent(evt);
     @keyword
     def get_matching_xpath_count(self, xpath, return_str=True):
         """Deprecated. Use `Get Matching Locator Count` instead."""
-        count = len(self.find_element("xpath=" + xpath, first_only=False,
-                                      required=False))
+        count = self.get_matching_locator_count("xpath=" + xpath)
         return str(count) if is_truthy(return_str) else count
 
     @keyword
     def xpath_should_match_x_times(self, xpath, expected_xpath_count,
                                    message='', loglevel='INFO'):
         """Deprecated. Use `Locator Should Match X Times` instead."""
-        actual_xpath_count = len(self.find_element(
-            "xpath=" + xpath, first_only=False, required=False))
-        if int(actual_xpath_count) != int(expected_xpath_count):
-            if is_falsy(message):
-                message = ("Xpath %s should have matched %s times but "
-                           "matched %s times"
-                           % (xpath, expected_xpath_count, actual_xpath_count))
-            self.ctx.log_source(loglevel)
-            raise AssertionError(message)
-        self.info("Current page contains %s elements matching '%s'."
-                  % (actual_xpath_count, xpath))
+        self.locator_should_match_x_times("xpath=" + xpath,
+                                          expected_xpath_count, message,
+                                          loglevel)
 
     @keyword
     def add_location_strategy(self, strategy_name, strategy_keyword, persist=False):

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -171,12 +171,12 @@ class ElementKeywords(LibraryComponent):
         `Locator Should Match X Times`.
 
         Examples assumes that locator matches to three elements
-        | ${count} =                 | Get Matching Locator Count | xpath:`/``/`*[@name="div_name"] |
-        | Should Be Equal As Numbers | ${count}                   | 3                           |
-        | ${count} =                 | Get Matching Locator Count | name:div_name               |
-        | Should Be Equal As Numbers | ${count}                   | 3                           |
-        | ${count} =                 | Get Matching Locator Count | div_name                    |
-        | Should Be Equal As Numbers | ${count}                   | 3                           |
+        | ${count} =                 | Get Matching Locator Count | xpath: //*[@name="div_name"] |
+        | Should Be Equal As Numbers | ${count}                   | 3                            |
+        | ${count} =                 | Get Matching Locator Count | name:div_name                |
+        | Should Be Equal As Numbers | ${count}                   | 3                            |
+        | ${count} =                 | Get Matching Locator Count | div_name                     |
+        | Should Be Equal As Numbers | ${count}                   | 3                            |
 
         New in SeleniumLibrary 3.0
         """
@@ -193,9 +193,9 @@ class ElementKeywords(LibraryComponent):
         `loglevel` arguments.
 
         Examples assumes that locator matches to three elements
-        | Locator Should Match X Times | xpath:`/``/`*[@name="div_name"] | 3 |
-        | locator_should_match_x_times | name:div_name                   | 3 |
-        | locator_should_match_x_times | div_name                        | 3 |
+        | Locator Should Match X Times | xpath: //*[@name="div_name"] | 3 |
+        | locator_should_match_x_times | name:div_name                | 3 |
+        | locator_should_match_x_times | div_name                     | 3 |
         """
         actual_locator_count = len(self.find_element(
             locator, first_only=False, required=False)

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -165,16 +165,15 @@ class ElementKeywords(LibraryComponent):
 
     @keyword
     def get_matching_locator_count(self, locator):
-        """Returns number of elements matching ``locator``
+        """Returns number of elements matching ``locator``.
 
         If you wish to assert the number of matching elements, use
         `Locator Should Match X Times`. Keyword will always return an integer.
+        New in SeleniumLibrary 3.0.
 
-        Examples assumes that locator matches to three elements
+        Example:
         | ${count} =      | Get Matching Locator Count | name:div_name  |
         | Should Be True  | ${count} > 2               |                |
-
-        New in SeleniumLibrary 3.0
         """
         return len(self.find_element(locator, first_only=False,
                                      required=False))
@@ -185,11 +184,8 @@ class ElementKeywords(LibraryComponent):
 
         See `introduction` for details about locating elements.
 
-        See `Page Should Contain Element` for explanation about `message` and
-        `loglevel` arguments.
-
-        Examples assumes that locator matches to three elements
-        | locator_should_match_x_times | name:div_name | 3 |
+        See `Page Should Contain Element` for explanation about ``message`` and
+        ``loglevel`` arguments.
         """
         actual_locator_count = len(self.find_element(
             locator, first_only=False, required=False)

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -164,13 +164,38 @@ class ElementKeywords(LibraryComponent):
         self.assert_page_contains(locator, message=message, loglevel=loglevel)
 
     @keyword
+    def get_matching_locator_count(self, locator):
+        """Returns number of elements matching ``locator``
+
+        If you wish to assert the number of matching elements, use
+        `Locator Should Match X Times`.
+
+        Examples assumes that locator matches to three elements
+        | ${count} =                 | Get Matching Locator Count | xpath:`/``/`*[@name="div_name"] |
+        | Should Be Equal As Numbers | ${count}                   | 3                           |
+        | ${count} =                 | Get Matching Locator Count | name:div_name               |
+        | Should Be Equal As Numbers | ${count}                   | 3                           |
+        | ${count} =                 | Get Matching Locator Count | div_name                    |
+        | Should Be Equal As Numbers | ${count}                   | 3                           |
+
+        New in SeleniumLibrary 3.0
+        """
+        return len(self.find_element(locator, first_only=False,
+                                     required=False))
+
+    @keyword
     def locator_should_match_x_times(self, locator, expected_locator_count, message='', loglevel='INFO'):
-        """Verifies that the page contains the given number of elements located by the given `locator`.
+        """Verifies that the page contains the given number of elements located by the given ``locator``.
 
         See `introduction` for details about locating elements.
 
         See `Page Should Contain Element` for explanation about `message` and
         `loglevel` arguments.
+
+        Examples assumes that locator matches to three elements
+        | Locator Should Match X Times | xpath:`/``/`*[@name="div_name"] | 3 |
+        | locator_should_match_x_times | name:div_name                   | 3 |
+        | locator_should_match_x_times | div_name                        | 3 |
         """
         actual_locator_count = len(self.find_element(
             locator, first_only=False, required=False)
@@ -178,7 +203,8 @@ class ElementKeywords(LibraryComponent):
         if int(actual_locator_count) != int(expected_locator_count):
             if is_falsy(message):
                 message = "Locator %s should have matched %s times but matched %s times"\
-                            %(locator, expected_locator_count, actual_locator_count)
+                          % (locator, expected_locator_count,
+                             actual_locator_count)
             self.ctx.log_source(loglevel)
             raise AssertionError(message)
         self.info("Current page contains %s elements matching '%s'."
@@ -731,39 +757,15 @@ return !element.dispatchEvent(evt);
 
     @keyword
     def get_matching_xpath_count(self, xpath, return_str=True):
-        """Returns number of elements matching `xpath`
-
-        The default return type is `str` but it can changed to `int` by setting
-        the ``return_str`` argument to Python False.
-
-        One should not use the xpath= prefix for 'xpath'. XPath is assumed.
-
-        Correct:
-        | count = | Get Matching Xpath Count | //div[@id='sales-pop']
-        Incorrect:
-        | count = | Get Matching Xpath Count | xpath=//div[@id='sales-pop']
-
-        If you wish to assert the number of matching elements, use
-        `Xpath Should Match X Times`.
-        """
+        """Deprecated. Use `Get Matching Locator Count` instead."""
         count = len(self.find_element("xpath=" + xpath, first_only=False,
                                       required=False))
         return str(count) if is_truthy(return_str) else count
 
     @keyword
-    def xpath_should_match_x_times(self, xpath, expected_xpath_count, message='', loglevel='INFO'):
-        """Verifies that the page contains the given number of elements located by the given `xpath`.
-
-        One should not use the xpath= prefix for 'xpath'. XPath is assumed.
-
-        Correct:
-        | Xpath Should Match X Times | //div[@id='sales-pop'] | 1
-        Incorrect:
-        | Xpath Should Match X Times | xpath=//div[@id='sales-pop'] | 1
-
-        See `Page Should Contain Element` for explanation about `message` and
-        `loglevel` arguments.
-        """
+    def xpath_should_match_x_times(self, xpath, expected_xpath_count,
+                                   message='', loglevel='INFO'):
+        """Deprecated. Use `Locator Should Match X Times` instead."""
         actual_xpath_count = len(self.find_element(
             "xpath=" + xpath, first_only=False, required=False))
         if int(actual_xpath_count) != int(expected_xpath_count):

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -168,7 +168,7 @@ class ElementKeywords(LibraryComponent):
         """Returns number of elements matching ``locator``
 
         If you wish to assert the number of matching elements, use
-        `Locator Should Match X Times`.
+        `Locator Should Match X Times`. Keyword will always return an integer.
 
         Examples assumes that locator matches to three elements
         | ${count} =      | Get Matching Locator Count | name:div_name  |
@@ -751,7 +751,12 @@ return !element.dispatchEvent(evt);
 
     @keyword
     def get_matching_xpath_count(self, xpath, return_str=True):
-        """Deprecated. Use `Get Matching Locator Count` instead."""
+        """Deprecated. Use `Get Matching Locator Count` instead.
+
+        In the `Get Matching Locator Count` keyword, the return value type
+        is changed to integer and it's not anymore possible change the
+        return value type between string and integer.
+        """
         count = self.get_matching_locator_count("xpath=" + xpath)
         return str(count) if is_truthy(return_str) else count
 

--- a/test/acceptance/keywords/content_assertions.robot
+++ b/test/acceptance/keywords/content_assertions.robot
@@ -1,5 +1,4 @@
 *** Settings ***
-Documentation     Tests contents
 Test Setup        Go To Front Page
 Default Tags      assertions
 Resource          ../resource.robot
@@ -40,7 +39,6 @@ Page Should Contain With Disabling Source Logging
     [Teardown]    Set Log Level    DEBUG
 
 Page Should Contain With Frames
-    [Documentation]    Page Should Contain With Frames
     [Setup]    Go To Page "frames/frameset.html"
     Page Should Contain    You're looking at right.
 
@@ -61,12 +59,10 @@ Page Should Not Contain With Disabling Source Logging
     [Teardown]    Set Log Level    DEBUG
 
 Page Should Contain Element
-    [Documentation]    Page Should Contain Element
     Page Should Contain Element    some_id
     Run Keyword And Expect Error    Page should have contained element 'non-existent' but did not    Page Should Contain Element    non-existent
 
 Page Should Contain Element With Custom Message
-    [Documentation]    Page Should Contain Element With Custom Message
     Run Keyword And Expect Error    Custom error message    Page Should Contain Element    invalid    Custom error message
 
 Page Should Contain Element With Disabling Source Logging
@@ -76,7 +72,6 @@ Page Should Contain Element With Disabling Source Logging
     [Teardown]    Set Log Level    DEBUG
 
 Page Should Not Contain Element
-    [Documentation]    Page Should Not Contain Element
     Page Should Not Contain Element    non-existent
     Run Keyword And Expect Error    Page should not have contained element 'some_id'    Page Should Not Contain Element    some_id
 
@@ -87,37 +82,31 @@ Page Should Not Contain Element With Disabling Source Logging
     [Teardown]    Set Log Level    DEBUG
 
 Element Should Contain
-    [Documentation]    Element Should Contain
     Element Should Contain    some_id    This text is inside an identified element
     Run Keyword And Expect Error    Element 'some_id' should have contained text 'non existing text' but its text was 'This text is inside an identified element'.    Element Should Contain    some_id    non existing text
     Run Keyword And Expect Error    ValueError: Element locator 'missing_id' did not match any elements.    Element Should Contain    missing_id    This should report missing element.
 
 Element Should Not Contain
-    [Documentation]    Element Should Not Contain
     Element Should Not Contain    some_id    This text is not inside an identified element
     Element Should Not Contain    some_id    elementypo
     Run Keyword And Expect Error    Element 'some_id' should not contain text 'This text is inside an identified element' but it did.    Element Should Not Contain    some_id    This text is inside an identified element
     Run Keyword And Expect Error    ValueError: Element locator 'missing_id' did not match any elements.    Element Should Not Contain    missing_id    This should report missing element.
 
 Element Text Should Be
-    [Documentation]    Element Text Should Be
     Element Text Should Be    some_id    This text is inside an identified element
     Run Keyword And Expect Error    The text of element 'some_id' should have been 'inside' but in fact it was 'This text is inside an identified element'.    Element Text Should Be    some_id    inside
 
 Get Text
-    [Documentation]    Get Text
     ${str} =    Get Text    some_id
     Should Match    ${str}    This text is inside an identified element
     Run Keyword And Expect Error    ValueError: Element locator 'missing_id' did not match any elements.    Get Text    missing_id
 
 Element Should Be Visible
-    [Documentation]    Element Should Be Visible
     [Setup]    Go To Page "visibility.html"
     Element Should Be Visible    i_am_visible
     Run Keyword And Expect Error    The element 'i_am_hidden' should be visible, but it is not.    Element Should Be Visible    i_am_hidden
 
 Element Should Not Be Visible
-    [Documentation]    Element Should Not Be Visible
     [Setup]    Go To Page "visibility.html"
     Element Should Not Be Visible    i_am_hidden
     Run Keyword And Expect Error    The element 'i_am_visible' should not be visible, but it is.    Element Should Not Be Visible    i_am_visible
@@ -136,57 +125,48 @@ Page Should Not Contain Checkbox
     Run Keyword And Expect Error    Page should not have contained checkbox 'can_send_email'    Page Should Not Contain Checkbox    can_send_email
 
 Page Should Contain Radio Button
-    [Documentation]    Page Should Contain Radio Button
     [Setup]    Go To Page "forms/prefilled_email_form.html"
     Page Should Contain Radio Button    sex
     Page Should Contain Radio Button    xpath=//input[@type="radio" and @value="male"]
     Run Keyword And Expect Error    Page should have contained radio button 'non-existing' but did not    Page Should Contain Radio Button    non-existing
 
 Page Should Not Contain Radio Button
-    [Documentation]    Page Should Not Contain Radio Button
     [Setup]    Go To Page "forms/prefilled_email_form.html"
     Page Should Not Contain Radio Button    non-existing
     Run Keyword And Expect Error    Page should not have contained radio button 'sex'    Page Should Not Contain Radio Button    sex
 
 Page Should Contain Image
-    [Documentation]    Page Should Contain Image
     [Setup]    Go To Page "links.html"
     Page Should contain Image    image.jpg
     Run Keyword And Expect Error    Page should have contained image 'non-existent' but did not    Page Should contain Image    non-existent
 
 Page Should Not Contain Image
-    [Documentation]    Page Should Not Contain Image
     [Setup]    Go To Page "links.html"
     Page Should not contain Image    non-existent
     Run Keyword And Expect Error    Page should not have contained image 'image.jpg'    Page Should not contain Image    image.jpg
 
 Page Should Contain Link
-    [Documentation]    Page Should Contain Link
     [Setup]    Go To Page "links.html"
     Page Should contain link    Relative
     Page Should contain link    sub/index.html
     Run Keyword And Expect Error    Page should have contained link 'non-existent' but did not    Page Should contain link    non-existent
 
 Page Should Not Contain Link
-    [Documentation]    Page Should Not Contain Link
     [Setup]    Go To Page "links.html"
     Page Should not contain link    non-existent
     Run Keyword And Expect Error    Page should not have contained link 'Relative'    Page Should not contain link    Relative
 
 Page Should Contain List
-    [Documentation]    Page Should Contain List
     [Setup]    Go To Page "forms/prefilled_email_form.html"
     Page should Contain List    possible_channels
     Run Keyword And Expect Error    Page should have contained list 'non-existing' but did not    Page Should Contain List    non-existing
 
 Page Should Not Contain List
-    [Documentation]    Page Should Not Contain List
     [Setup]    Go To Page "forms/prefilled_email_form.html"
     Page Should Not Contain List    non-existing
     Run Keyword And Expect Error    Page should not have contained list 'possible_channels'    Page Should Not Contain List    possible_channels
 
 Page Should Contain TextField
-    [Documentation]    Page Should Contain TextField
     [Setup]    Go To Page "forms/prefilled_email_form.html"
     Page Should Contain Text Field    name
     Page Should Contain Text Field    website
@@ -196,7 +176,6 @@ Page Should Contain TextField
     Run Keyword And Expect Error    Page should have contained text field 'can_send_email' but did not    Page Should Contain Text Field    can_send_email
 
 Page Should Not Contain Text Field
-    [Documentation]    Page Should Not Contain Text Field
     [Setup]    Go To Page "forms/prefilled_email_form.html"
     Page Should Not Contain Text Field    non-existing
     Page Should Not Contain Text Field    can_send_email
@@ -226,14 +205,12 @@ TextField Value Should Be
     Textfield Value Should Be    name    ${EMPTY}
 
 TextArea Should Contain
-    [Documentation]    TextArea Should Contain
     [Setup]    Go To Page "forms/email_form.html"
     TextArea Should Contain    comment    ${EMPTY}
     Input Text    comment    This is a comment.
     Run Keyword And Expect Error    Text field 'comment' should have contained text 'Hello World!' but it contained 'This is a comment.'    TextArea Should Contain    comment    Hello World!
 
 TextArea Value Should Be
-    [Documentation]    TextArea Value Should Be
     [Setup]    Go To Page "forms/email_form.html"
     TextArea Value Should Be    comment    ${EMPTY}
     Input Text    comment    This is a comment.
@@ -242,7 +219,6 @@ TextArea Value Should Be
     TextArea Value Should Be    comment    ${EMPTY}
 
 Page Should Contain Button
-    [Documentation]    Page Should Contain Button
     [Setup]    Go To Page "forms/buttons.html"
     Page Should Contain Button    button
     Page Should Contain Button    Sisään
@@ -255,33 +231,17 @@ Page Should Contain Button
     Run Keyword And Expect Error    Page should have contained button 'non-existing' but did not    Page Should Contain Button    non-existing
 
 Page Should Not Contain Button In Button Tag
-    [Documentation]    Page Should Not Contain Button In Button Tag
     [Setup]    Go To Page "forms/buttons.html"
     Page Should Not Contain Button    invalid
     Run Keyword And Expect Error    Page should not have contained button 'button'    Page Should Not Contain Button    button
 
 Page Should Not Contain Button In Input Tag
-    [Documentation]    Page Should Not Contain Button In Input Tag
     [Setup]    Go To Page "forms/buttons.html"
     Page Should Not Contain Button    invalid
     Run Keyword And Expect Error    Page should not have contained input 'Act!'    Page Should Not Contain Button    Act!
 
 Get All Links
-    [Documentation]    Get All Links
     [Setup]    Go To Page "links.html"
     ${links}=    Get All Links
     Length Should Be    ${links}    19
     List Should Contain Value    ${links}    bold_id
-
-Xpath Should Match X Times
-    [Documentation]    Xpath Should Match X Times
-    [Setup]    Go To Page "forms/login.html"
-    Xpath Should Match X Times    //input[@type="text"]    1
-    Xpath Should Match X Times    //input[@type="text"]    ${1}
-    Run Keyword And Expect Error    Xpath //input[@type="text"] should have matched 2 times but matched 1 times    Xpath Should Match X Times    //input[@type="text"]    2
-
-Locator Should Match X Times
-    [Documentation]    Locator Should Match X Times
-    [Setup]    Go To Page "links.html"
-    Locator Should Match X Times    link=Link    2
-    Locator Should Match X Times    link=Missing Link    0

--- a/test/acceptance/keywords/counting_elements.robot
+++ b/test/acceptance/keywords/counting_elements.robot
@@ -1,0 +1,64 @@
+*** Settings ***
+Test Setup        Go To Front Page
+Default Tags      element count
+Resource          ../resource.robot
+Library           String
+
+*** Test Cases ***
+Get Matching XPath Count
+    [Setup]    Go To Page "links.html"
+    ${count}=    Get Matching XPath Count    //a
+    Should Be Equal    ${count}    19
+    ${count}=    Get Matching XPath Count    //a    ${True}
+    Should Be Equal    ${count}    19
+    Should Be String    ${count}
+    ${count}=    Get Matching XPath Count    //a    ${False}
+    Should Be Equal    ${count}    ${19}
+    Should Not Be String    ${count}
+    ${count}=    Get Matching XPath Count    //div[@id="first_div"]/a
+    Should Be Equal    ${count}    2
+
+Xpath Should Match X Times
+    [Setup]    Go To Page "forms/login.html"
+    Xpath Should Match X Times    //input[@type="text"]    1
+    Xpath Should Match X Times    //input[@type="text"]    ${1}
+    Run Keyword And Expect Error    Xpath //input[@type="text"] should have matched 2 times but matched 1 times
+    ...    Xpath Should Match X Times    //input[@type="text"]    2
+
+Locator Should Match X Times
+    [Setup]    Go To Page "links.html"
+    Locator Should Match X Times    link=Link    2
+    Locator Should Match X Times    link=Missing Link    0
+    Locator Should Match X Times    name:div_name    2
+    Locator Should Match X Times    xpath://*[@name="div_name"]    2
+
+Locator Should Match X Times Error
+    [Setup]    Go To Page "links.html"
+    Run Keyword And Expect Error
+    ...    Locator name:div_name should have matched 3 times but matched 2 times
+    ...    Locator Should Match X Times    name:div_name    3
+    Run Keyword And Expect Error
+    ...    Custom error
+    ...    Locator Should Match X Times    name:div_name    3    Custom error
+
+Get Matching Locator Count With Xpath Locator
+    [Setup]    Go To Page "links.html"
+    ${count} =     Get Matching Locator Count    xpath://*[@name="div_name"]
+    Should Be Equal    ${count}    ${2}
+    ${count} =     Get Matching Locator Count    //*[@name="div_name"]
+    Should Be Equal    ${count}    ${2}
+
+Get Matching Locator Count With Default Locator
+    [Setup]    Go To Page "links.html"
+    ${count} =     Get Matching Locator Count    div_name
+    Should Be Equal    ${count}    ${2}
+
+Get Matching Locator Count With Name Locator
+    [Setup]    Go To Page "links.html"
+    ${count} =     Get Matching Locator Count    name:div_name
+    Should Be Equal    ${count}    ${2}
+
+Get Matching Locator Count Should Not Fail When Zero Elements Is Found
+    [Setup]    Go To Page "links.html"
+    ${count} =     Get Matching Locator Count    name:not_exist
+    Should Be Equal    ${count}    ${0}

--- a/test/acceptance/keywords/counting_elements.robot
+++ b/test/acceptance/keywords/counting_elements.robot
@@ -22,7 +22,7 @@ Xpath Should Match X Times
     [Setup]    Go To Page "forms/login.html"
     Xpath Should Match X Times    //input[@type="text"]    1
     Xpath Should Match X Times    //input[@type="text"]    ${1}
-    Run Keyword And Expect Error    Xpath //input[@type="text"] should have matched 2 times but matched 1 times
+    Run Keyword And Expect Error    Locator xpath=//input[@type="text"] should have matched 2 times but matched 1 times
     ...    Xpath Should Match X Times    //input[@type="text"]    2
 
 Locator Should Match X Times

--- a/test/acceptance/keywords/elements.robot
+++ b/test/acceptance/keywords/elements.robot
@@ -55,18 +55,6 @@ Get Element Attribute
     ${class}=    Get Element Attribute    ${second_div}    class
     Should Be Equal    ${class}    Second Class
 
-Get Matching XPath Count
-    ${count}=    Get Matching XPath Count    //a
-    Should Be Equal    ${count}    19
-    ${count}=    Get Matching XPath Count    //a    ${True}
-    Should Be Equal    ${count}    19
-    Should Be String    ${count}
-    ${count}=    Get Matching XPath Count    //a    ${False}
-    Should Be Equal    ${count}    ${19}
-    Should Not Be String    ${count}
-    ${count}=    Get Matching XPath Count    //div[@id="first_div"]/a
-    Should Be Equal    ${count}    2
-
 Get Horizontal Position
     ${pos}=    Get Horizontal Position    link=Link
     Should Be True    ${pos} > ${0}

--- a/test/resources/html/links.html
+++ b/test/resources/html/links.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
   </head>
   <body>
-    <div id="div_id">
+    <div id="div_id" name="div_name">
       <a href="index.html">Relative</a><br/>
       <a href="sub/index.html">Relative to sub-directory</a><br/>
       <a href="http://www.google.com">Absolute external link</a><br/>
@@ -27,7 +27,7 @@
       </a><br/>
       <a href="target/first.html" id="bold_id"><b>Link with bolded text</b></a>
     </div>
-    <div id="first_div">
+    <div id="first_div"  name="div_name">
       <a href="target/first.html"><img src="robot.png" alt="Image"/></a>
       <a href="target/first.html">Link</a>
     </div>


### PR DESCRIPTION
There was already Locator Should Match X Times which should be used
instead of the Xpath Should Match X Times keyword. Created
Get Matching Locator Count keyword and therefore deprecated
Get Matching Xpath Count keyword.

Fixes #949