### PR TITLE
Moved one Wait For Condition  keyword test to own test

### DIFF
--- a/test/acceptance/keywords/waiting.robot
+++ b/test/acceptance/keywords/waiting.robot
@@ -7,10 +7,13 @@ Force Tags        Known Issue Internet Explorer
 Wait For Condition
     Title Should Be    Original
     Wait For Condition    return window.document.title == "Changed"
-    Wait For Condition    style = document.querySelector('#content').style; return style.background == "red" && style.color == "white"
     Run Keyword And Expect Error
     ...    Condition 'return window.document.title == "Invalid"' did not become true in 100 milliseconds.
     ...    Wait For Condition    return window.document.title == "Invalid"    ${0.1}
+
+Wait For Condition Comlext Wait
+    [Tags]    Known Issue Firefox
+    Wait For Condition    style = document.querySelector('#content').style; return style.background == 'red' && style.color == 'white'
 
 Wait For Condition requires `return`
     Run Keyword And Expect Error

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -76,8 +76,6 @@ ROBOT_OPTIONS = [
 ]
 REBOT_OPTIONS = [
     '--outputdir', RESULTS_DIR,
-    '--critical', 'regression',
-    '--noncritical', 'inprogress',
     '--noncritical', 'known issue {browser}',
 ]
 


### PR DESCRIPTION
Is the seems that Firefox has regression but and executing
complex JavaScript does not work correctly. Moving it to own
test and marking the test to Known Issue Firefox tag.

Also refactored run_tests.py to set regression and inprogress tags