### PR TITLE
Headless Firefox and Chrome support

### DIFF
--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -93,6 +93,8 @@ class BrowserManagementKeywords(LibraryComponent):
         |    = Browser =    |        = Name(s) =       |
         | Firefox           | firefox, ff              |
         | Google Chrome     | googlechrome, chrome, gc |
+        | Headless Firefox  | headlessfirefox, headlessff |
+        | Headless Google Chrome | headlessgooglechrome, headlesschrome, headlessgc |
         | Internet Explorer | internetexplorer, ie     |
         | Edge              | edge                     |
         | Safari            | safari                   |

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -108,7 +108,8 @@ class BrowserManagementKeywords(LibraryComponent):
         To be able to actually use one of these browsers, you need to have
         a matching Selenium browser driver available. See the
         [https://github.com/robotframework/SeleniumLibrary#browser-drivers|
-        project documentation] for more details.
+        project documentation] for more details. Headless Firefox and
+        Headless Google Chrome require Selenium 3.8.0 or newer.
 
         Optional ``alias`` is an alias given for this browser instance and
         it can be used for switching between browsers. An alternative

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -93,8 +93,8 @@ class BrowserManagementKeywords(LibraryComponent):
         |    = Browser =    |        = Name(s) =       |
         | Firefox           | firefox, ff              |
         | Google Chrome     | googlechrome, chrome, gc |
-        | Headless Firefox  | headlessfirefox, headlessff |
-        | Headless Google Chrome | headlessgooglechrome, headlesschrome, headlessgc |
+        | Headless Firefox  | headlessfirefox          |
+        | Headless Chrome   | headlesschrome           |
         | Internet Explorer | internetexplorer, ie     |
         | Edge              | edge                     |
         | Safari            | safari                   |
@@ -109,7 +109,8 @@ class BrowserManagementKeywords(LibraryComponent):
         a matching Selenium browser driver available. See the
         [https://github.com/robotframework/SeleniumLibrary#browser-drivers|
         project documentation] for more details. Headless Firefox and
-        Headless Google Chrome require Selenium 3.8.0 or newer.
+        Headless Chrome are new additions in SeleniumLibrary 3.1.0
+        and require Selenium 3.8.0 or newer.
 
         Optional ``alias`` is an alias given for this browser instance and
         it can be used for switching between browsers. An alternative
@@ -478,17 +479,15 @@ class BrowserManagementKeywords(LibraryComponent):
             webdriver.Ie, webdriver.DesiredCapabilities.INTERNETEXPLORER,
             remote, desired_capabilities)
 
-    def _make_chrome(self, remote, desired_capabilities, profile_dir):
+    def _make_chrome(self, remote, desired_capabilities, profile_dir, options=None):
         return self._generic_make_driver(
             webdriver.Chrome, webdriver.DesiredCapabilities.CHROME, remote,
-            desired_capabilities)
+            desired_capabilities, options=options)
 
     def _make_headless_chrome(self, remote, desired_capabilities, profile_dir):
         options = webdriver.ChromeOptions()
         options.set_headless()
-        return self._generic_make_driver(
-            webdriver.Chrome, webdriver.DesiredCapabilities.CHROME, remote,
-            desired_capabilities, options=options)
+        return self._make_chrome(remote, desired_capabilities, profile_dir, options)
 
     def _make_opera(self, remote, desired_capabilities, profile_dir):
         return self._generic_make_driver(

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -46,9 +46,6 @@ BROWSER_NAMES = NormalizedDict({
     'safari': "_make_safari",
     'edge': "_make_edge",
     'headlessfirefox': '_make_headless_ff',
-    'headlessff': '_make_headless_ff',
-    'headlessgooglechrome': '_make_headless_chrome',
-    'headlessgc': '_make_headless_chrome',
     'headlesschrome': '_make_headless_chrome'
 })
 

--- a/test/acceptance/create_webdriver.robot
+++ b/test/acceptance/create_webdriver.robot
@@ -37,17 +37,14 @@ Set Driver Variables
     ${drivers}=    Create Dictionary    ff=Firefox    firefox=Firefox    ie=Ie
     ...    internetexplorer=Ie    googlechrome=Chrome    gc=Chrome
     ...    chrome=Chrome    opera=Opera    phantomjs=PhantomJS    safari=Safari
-    ...    headlesschrome=Chrome    headlessgc=Chrome
-    ...    headlessgooglechrome=Chrome
-    ...    headlessfirefox=Firefox    headlessff=Firefox
+    ...    headlesschrome=Chrome    headlessfirefox=Firefox
     ${name}=    Evaluate    "Remote" if "${REMOTE_URL}"!="None" else ${drivers}["${BROWSER.lower().replace(' ', '')}"]
     Set Test Variable    ${DRIVER_NAME}    ${name}
     ${dc names}=    Create Dictionary    ff=FIREFOX    firefox=FIREFOX    ie=INTERNETEXPLORER
     ...    internetexplorer=INTERNETEXPLORER    googlechrome=CHROME    gc=CHROME
     ...    chrome=CHROME    opera=OPERA    phantomjs=PHANTOMJS    htmlunit=HTMLUNIT
     ...    htmlunitwithjs=HTMLUNITWITHJS    android=ANDROID    iphone=IPHONE
-    ...    safari=SAFARI    headlessfirefox=FIREFOX    headlessff=FIREFOX
-    ...    headlesschrome=CHROME    headlessgooglechrome=CHROME    headlessgc=CHROME
+    ...    safari=SAFARI    headlessfirefox=FIREFOX    headlesschrome=CHROME
     ${dc name}=    Get From Dictionary    ${dc names}    ${BROWSER.lower().replace(' ', '')}
     ${caps}=    Evaluate    sys.modules['selenium.webdriver'].DesiredCapabilities.${dc name}
     ...    selenium.webdriver,sys

--- a/test/acceptance/create_webdriver.robot
+++ b/test/acceptance/create_webdriver.robot
@@ -37,13 +37,17 @@ Set Driver Variables
     ${drivers}=    Create Dictionary    ff=Firefox    firefox=Firefox    ie=Ie
     ...    internetexplorer=Ie    googlechrome=Chrome    gc=Chrome
     ...    chrome=Chrome    opera=Opera    phantomjs=PhantomJS    safari=Safari
+    ...    headlesschrome=Chrome    headlessgc=Chrome
+    ...    headlessgooglechrome=Chrome
+    ...    headlessfirefox=Firefox    headlessff=Firefox
     ${name}=    Evaluate    "Remote" if "${REMOTE_URL}"!="None" else ${drivers}["${BROWSER.lower().replace(' ', '')}"]
     Set Test Variable    ${DRIVER_NAME}    ${name}
     ${dc names}=    Create Dictionary    ff=FIREFOX    firefox=FIREFOX    ie=INTERNETEXPLORER
     ...    internetexplorer=INTERNETEXPLORER    googlechrome=CHROME    gc=CHROME
     ...    chrome=CHROME    opera=OPERA    phantomjs=PHANTOMJS    htmlunit=HTMLUNIT
     ...    htmlunitwithjs=HTMLUNITWITHJS    android=ANDROID    iphone=IPHONE
-    ...    safari=SAFARI
+    ...    safari=SAFARI    headlessfirefox=FIREFOX    headlessff=FIREFOX
+    ...    headlesschrome=CHROME    headlessgooglechrome=CHROME    headlessgc=CHROME
     ${dc name}=    Get From Dictionary    ${dc names}    ${BROWSER.lower().replace(' ', '')}
     ${caps}=    Evaluate    sys.modules['selenium.webdriver'].DesiredCapabilities.${dc name}
     ...    selenium.webdriver,sys


### PR DESCRIPTION
This PR adds headless Firefox and Chrome support for `Open Browser` keyword. It adds two browsers; Headless Firefox and Headless Google Chrome with couple aliases.

This allows us to write tests like this:

```
*** Settings ***
Library    SeleniumLibrary

*** Test Cases ***
Firefox
    Open Browser    http://robotframework.org/    headlessfirefox
    Capture Page Screenshot
    [Teardown]    Close All Browsers

Chrome
    Open Browser    http://robotframework.org/     headlesschrome
    Capture Page Screenshot
    [Teardown]    Close All Browsers
```
