### PR TITLE
Add a new strategy to find element

### DIFF
--- a/src/SeleniumLibrary/base/context.py
+++ b/src/SeleniumLibrary/base/context.py
@@ -63,33 +63,23 @@ class ContextAware(object):
             return self.element_finder.find(locator, tag, True, required, parent)
         else:
             """
-            Editing code starting here
-            """
-            # 2. check for element locators
-            element = None
-            locators = locator.get('locators', '')
-            if(len(locators)==0):
-                raise AttributeError('List of locators is empty or you forgot to pass locators attribute.')
-            # 3. go & find the exsting locator
-            found = False
-            for a_locator in locators:
-                try:
-                    element = self.element_finder.find(a_locator, tag, True, required, parent)
-                    found = True
-                    break                
-                except:
-                    continue
-
-            element_name = locator.get('name', '')
-            if(element_name is ''):
-                element_name = ''
-            else:
-                element_name = "'" + element_name + "' "
+            Add a new strategy to find element.
+            locator format showing below:
+            {
+                'name':'locator_name',
+                'locators':['xpath=//locator_xpath','id', 'css'...]
+            }
             
-            if (found==False):
-                raise ElementNotFound("Element {}with locators '{}' not found."
-                                      .format(element_name, locators))
-            return element
+            name: optional field, you can provide a name to find an element. 
+                If element couldnot found, name will be taken to be displayed 
+                on the error message 
+            locators: list of element's locators that you want to find.
+                If the first locator is failed to find, keep searching
+                element by using the second then third...
+            
+            """
+            return self.element_finder.find_dict_element(locator)
+            
 
     def find_elements(self, locator, tag=None, parent=None):
         """Find all elements matching `locator`.

--- a/src/SeleniumLibrary/base/context.py
+++ b/src/SeleniumLibrary/base/context.py
@@ -58,7 +58,7 @@ class ContextAware(object):
         :raises SeleniumLibrary.errors.ElementNotFound: If element not found
             and `required` is true.
         """
-        if(type(locator)==str or type(locator)==unicode):
+        if(type(locator)==type('') or type(locator)==type(u'')):
             return self.element_finder.find(locator, tag, True, required, parent)
         else:
             """

--- a/src/SeleniumLibrary/base/context.py
+++ b/src/SeleniumLibrary/base/context.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 from SeleniumLibrary.utils import escape_xpath_value
-from SeleniumLibrary.errors import ElementNotFound
 
 class ContextAware(object):
 

--- a/src/SeleniumLibrary/base/context.py
+++ b/src/SeleniumLibrary/base/context.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from SeleniumLibrary.utils import escape_xpath_value
-
+from SeleniumLibrary.errors import ElementNotFound
 
 class ContextAware(object):
 
@@ -59,7 +59,37 @@ class ContextAware(object):
         :raises SeleniumLibrary.errors.ElementNotFound: If element not found
             and `required` is true.
         """
-        return self.element_finder.find(locator, tag, True, required, parent)
+        if(type(locator)==str or type(locator)==unicode):
+            return self.element_finder.find(locator, tag, True, required, parent)
+        else:
+            """
+            Editing code starting here
+            """
+            # 2. check for element locators
+            element = None
+            locators = locator.get('locators', '')
+            if(len(locators)==0):
+                raise AttributeError('List of locators is empty or you forgot to pass locators attribute.')
+            # 3. go & find the exsting locator
+            found = False
+            for a_locator in locators:
+                try:
+                    element = self.element_finder.find(a_locator, tag, True, required, parent)
+                    found = True
+                    break                
+                except:
+                    continue
+
+            element_name = locator.get('name', '')
+            if(element_name is ''):
+                element_name = ''
+            else:
+                element_name = "'" + element_name + "' "
+            
+            if (found==False):
+                raise ElementNotFound("Element {}with locators '{}' not found."
+                                      .format(element_name, locators))
+            return element
 
     def find_elements(self, locator, tag=None, parent=None):
         """Find all elements matching `locator`.

--- a/src/SeleniumLibrary/locators/elementfinder.py
+++ b/src/SeleniumLibrary/locators/elementfinder.py
@@ -80,6 +80,33 @@ class ElementFinder(ContextAware):
             return elements[0]
         return elements
 
+    def find_dict_element(self, locator):
+        element = None
+        locators = locator.get('locators', '')
+        if(len(locators)==0):
+            raise AttributeError('List of locators is empty or you forgot to pass locators attribute.')
+        # 3. go & find the exsting locator
+        found = False
+        for a_locator in locators:
+            try:
+                element = self.element_finder.find(a_locator, tag, True, required, parent)
+                found = True
+                break                
+            except:
+                continue
+
+        element_name = locator.get('name', '')
+        if(element_name is ''):
+            element_name = ''
+        else:
+            element_name = "'" + element_name + "' "
+        
+        if (found==False):
+            raise ElementNotFound("Element {}with locators '{}' not found."
+                                  .format(element_name, locators))
+        return element
+
+
     def register(self, strategy_name, strategy_keyword, persist=False):
         strategy = CustomLocator(self.ctx, strategy_name, strategy_keyword)
         if strategy.name in self._strategies:

--- a/src/SeleniumLibrary/locators/elementfinder.py
+++ b/src/SeleniumLibrary/locators/elementfinder.py
@@ -89,9 +89,9 @@ class ElementFinder(ContextAware):
         found = False
         for a_locator in locators:
             try:
-                element = self.element_finder.find(a_locator, tag, True, required, parent)
+                element = self.find(a_locator)
                 found = True
-                break                
+                break
             except:
                 continue
 


### PR DESCRIPTION
Currently, we can find an element by 1 locator only. 
We need to write multiple keywords to find different element 
locators if we want to and we need to handle those if else & try catch.

Now, I defined a new way to find an element by using a dictionary.

element_a = {
    'name' : 'element_name',
    'locators' : ['xpath', 'css', 'id', ...]
}

By using this way, we can define many ways to find an element.
If the first element's locator is failed to find, keep searching the 2nd then 3rd, etc.