### PR TITLE
Fix for #1021:Wait Until Page Contains keyword does not work if text …

### DIFF
--- a/src/SeleniumLibrary/utils/__init__.py
+++ b/src/SeleniumLibrary/utils/__init__.py
@@ -24,6 +24,7 @@ from .webdrivercache import WebDriverCache
 
 
 def escape_xpath_value(value):
+    value = str(value)
     if '"' in value and '\'' in value:
         parts_wo_apos = value.split('\'')
         return "concat('%s')" % "', \"'\", '".join(parts_wo_apos)

--- a/test/acceptance/keywords/waiting.robot
+++ b/test/acceptance/keywords/waiting.robot
@@ -22,6 +22,7 @@ Wait For Condition requires `return`
 
 Wait Until Page Contains
     Wait Until Page Contains    New Content    2 s
+    Wait Until Page Contains    ${123}    2 s
     Run Keyword And Expect Error
     ...    Text 'invalid' did not appear in 100 milliseconds.
     ...    Wait Until Page Contains    invalid    0.1

--- a/test/resources/html/javascript/delayed_events.html
+++ b/test/resources/html/javascript/delayed_events.html
@@ -53,6 +53,8 @@
 
     <body onload="modifyAfterDelay()">
     <div id="content" style="color: white; background: red">This is content</div>
+    <div>The following text is a number:</div>
+    <div>123</div>
     <div id="container"></div>
     <div id="not_present">Element that should disappear</div>
     <div id="hide_delay">Element that should set display:none</div>


### PR DESCRIPTION
The "escape_xpath_value function" in utils.py expects the argument to be of type string. But when we use the integer variables like ${1}, ${123} etc. this functions throws the error "TypeError: argument of type 'int' is not iterable". So added a line of code to convert the argument to string.