### PR TITLE
Hard code the Chromedriver version to 2.33.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ addons:
       - google-chrome-stable
 before_install:
   - CDVERSION=`curl http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
+  # For ChromeDriver problems in Travis, hard code the version to 2.33
+  - CDVERSION=2.33
   - wget --no-verbose http://chromedriver.storage.googleapis.com/$CDVERSION/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - sudo chmod u+x chromedriver


### PR DESCRIPTION
There has been lot of issues with the latest Chromedriver
in travis. Until new release of Chromedriver is released
hardcode the version to 2.33.