### PR TITLE
Fixes ElementFinder when nonascii locator is used.

### DIFF
--- a/atest/acceptance/keywords/click_element.robot
+++ b/atest/acceptance/keywords/click_element.robot
@@ -16,6 +16,16 @@ Double Click Element
     Double Click Element    doubleClickButton
     Element Text Should Be    output    double clicked
 
+Click Element Error
+    [Documentation]    FAIL Element with locator 'id:äääääää' not found.
+    [Setup]    Go To Page "javascript/click.html"
+    Click Element    id:äääääää
+
+Double Click Element Error
+    [Documentation]    FAIL Element with locator 'id:öööö' not found.
+    [Setup]    Go To Page "javascript/click.html"
+    Double Click Element    id:öööö
+
 *** Keywords ***
 Initialize Page
     [Documentation]    Initialize Page

--- a/atest/acceptance/keywords/counting_elements.robot
+++ b/atest/acceptance/keywords/counting_elements.robot
@@ -43,8 +43,8 @@ Locator Should Match X Times Error
     ...    Locator 'name: div_name' should have matched 3 times but matched 2 times.
     ...    Locator Should Match X Times    name: div_name    3
     Run Keyword And Expect Error
-    ...    Custom error
-    ...    Locator Should Match X Times    name:div_name    3    Custom error
+    ...    Custom error ÄÄÄ
+    ...    Locator Should Match X Times    name:div_name    3    Custom error ÄÄÄ
 
 Get Element Count With Xpath Locator
     [Setup]    Go To Page "links.html"

--- a/atest/acceptance/keywords/waiting.robot
+++ b/atest/acceptance/keywords/waiting.robot
@@ -38,6 +38,9 @@ Wait Until Page Contains Element
     Run Keyword And Expect Error
     ...    Element '%cnon-existent' did not appear in 100 milliseconds.
     ...    Wait Until Page Contains Element    %cnon-existent    0.1 seconds
+    Run Keyword And Expect Error
+    ...    Element 'id:ääööåå' did not appear in 100 milliseconds.
+    ...    Wait Until Page Contains Element    id:ääööåå    0.1 seconds
 
 Wait Until Page Does Not Contain Element
     [Documentation]    Tests also that format characters (e.g. %c) are handled correctly in error messages
@@ -45,6 +48,9 @@ Wait Until Page Does Not Contain Element
     Run Keyword And Expect Error
     ...    Element 'content' did not disappear in 100 milliseconds.
     ...    Wait Until Page Does Not Contain Element    content    0.1 seconds
+    Run Keyword And Expect Error
+    ...    Custom Error ää ÖÖ
+    ...    Wait Until Page Does Not Contain Element    content    0.1 seconds    Custom Error ää ÖÖ
 
 Wait Until Element Is Enabled
     Run Keyword And Expect Error

--- a/src/SeleniumLibrary/locators/elementfinder.py
+++ b/src/SeleniumLibrary/locators/elementfinder.py
@@ -72,8 +72,8 @@ class ElementFinder(ContextAware):
         elements = strategy(criteria, tag, constraints,
                             parent=parent or self.driver)
         if required and not elements:
-            raise ElementNotFound("{} with locator '{}' not found."
-                                  .format(element_type, locator))
+            raise ElementNotFound("%s with locator '%s' not found."
+                                  % (element_type, locator))
         if first_only:
             if not elements:
                 return None


### PR DESCRIPTION
When nonascii locator does not find element, then raising the
exception fails with UnicodeEncodeError.