### PR TITLE
Removes SL own JYTHON implementation

### DIFF
--- a/src/SeleniumLibrary/utils/platform.py
+++ b/src/SeleniumLibrary/utils/platform.py
@@ -1,4 +1,0 @@
-import sys
-
-# Can be removed when Robot Framework 2.8.4 is not supported.
-JYTHON = sys.platform.startswith('java')

--- a/utest/test/keywords/test_javascript.py
+++ b/utest/test/keywords/test_javascript.py
@@ -1,7 +1,8 @@
 import os
 import unittest
 
-from SeleniumLibrary.utils.platform import JYTHON
+from robot.utils import JYTHON
+
 try:
     from approvaltests.approvals import verify, verify_all
     from approvaltests.reporters.generic_diff_reporter_factory import GenericDiffReporterFactory


### PR DESCRIPTION
Because RF 2.8 support was dropped, this cleans some to relay utilities provided by the RF.