### PR TITLE
Set log source default level to TRACE.

### DIFF
--- a/atest/README.rst
+++ b/atest/README.rst
@@ -82,7 +82,7 @@ from the `.travis.yam`_. Generally speaking the test are automatically run
 by using Chrome and Firefox browsers. The project uses Python 2.7, Python 3.4,
 Python 3.6 and PyPy 3.5 for test execution. The project uses and latest available 
 Selenium 3 version for test execution. Test uses Robot Framework versions 
-2.9.2 and 3.0.2 for acceptance test execution.
+2.9.2 and 3.0.4 for acceptance test execution.
 
 .. _browser driver: https://github.com/robotframework/SeleniumLibrary#browser-drivers
 .. _PATH: https://en.wikipedia.org/wiki/PATH_(variable)

--- a/atest/acceptance/big_list_of_naught_strings.robot
+++ b/atest/acceptance/big_list_of_naught_strings.robot
@@ -11,7 +11,6 @@ Big List Of Naughty Strings
     :FOR    ${string}    IN    @{blns}
     \    Check Blns Error Check    ${string}
 
-
 *** Keywords ***
 Check Blns Error Check
     [Arguments]    ${string}

--- a/atest/acceptance/extending.robot
+++ b/atest/acceptance/extending.robot
@@ -4,7 +4,6 @@ Suite Teardown    ExtSeLib.Close All Browsers
 Resource          resource.robot
 Library           ExtSL.ExtSL    WITH NAME    ExtSeLib
 
-
 *** Test Cases ***
 When Extending SeleniumLibrary Keywords With Decorated Name Can Be Used For Extending
     ${elements} =    ExtSeLib.Ext Web Element    //tr

--- a/atest/acceptance/keywords/click_element_modifier.robot
+++ b/atest/acceptance/keywords/click_element_modifier.robot
@@ -3,7 +3,6 @@ Suite Setup       Go To Page "javascript/click_modifier.html"
 Test Setup        Initialize Page
 Resource          ../resource.robot
 
-
 *** Test Cases ***
 Click Element Modifier CTRL
     Click Element    Button    modifier=CTRL

--- a/atest/acceptance/keywords/content_assertions.robot
+++ b/atest/acceptance/keywords/content_assertions.robot
@@ -70,9 +70,11 @@ Page Should Contain With Custom Log Level DEBUG
 Page Should Contain With Custom Log Level TRACE
     [Documentation]    Html content is shown at DEBUG level.
     ...    FAIL Page should have contained text 'non existing text' but did not.
-    ...    LOG 2:14 TRACE REGEXP: (?i)<html.*</html>
-    ...    LOG 2:15 FAIL Page should have contained text 'non existing text' but did not.
+    ...    LOG 3:15 TRACE REGEXP: (?i)<html.*</html>
+    ...    LOG 3:16 FAIL Page should have contained text 'non existing text' but did not.
+    Set Log Level    TRACE
     Page Should Contain    non existing text    TRACE
+    [Teardown]    Set Log Level    DEBUG
 
 Page Should Contain With Disabling Source Logging
     [Documentation]    LOG 3:2 NONE

--- a/atest/acceptance/keywords/content_assertions.robot
+++ b/atest/acceptance/keywords/content_assertions.robot
@@ -46,24 +46,33 @@ Title Should Be
     ...    Title Should Be    not a title   message=Page title was not expected
 
 Page Should Contain
-    [Documentation]    LOG 2:7 Current page contains text 'needle'.
-    ...    LOG 4.1:14 REGEXP: (?i)<html.*</html>
+    [Documentation]    The last step fails and doesn't contain the html content.
+    ...    FAIL Page should have contained text 'non existing text' but did not.
+    ...    LOG 2:7 Current page contains text 'needle'.
+    ...    LOG 3:7 INFO Current page contains text 'This is the haystack'.
+    ...    LOG 4:14 FAIL Page should have contained text 'non existing text' but did not.
     Page Should Contain    needle
     Page Should Contain    This is the haystack
-    Run Keyword And Expect Error
-    ...    Page should have contained text 'non existing text' but did not.
-    ...    Page Should Contain    non existing text
+    Page Should Contain    non existing text
 
-Page Should Contain with text having internal elements
+Page Should Contain With Text Having Internal Elements
     Page Should Contain    This is the haystack and somewhere on this page is a needle.
     Go to page "links.html"
     Page Should Contain    Relative with text after
 
-Page Should Contain With Custom Log Level
-    [Documentation]    LOG 2.1:14 DEBUG REGEXP: (?i)<html.*</html>
-    Run Keyword And Expect Error
-    ...    Page should have contained text 'non existing text' but did not.
-    ...    Page Should Contain    non existing text    DEBUG
+Page Should Contain With Custom Log Level DEBUG
+    [Documentation]    Html content is shown at DEBUG level.
+    ...    FAIL Page should have contained text 'non existing text' but did not.
+    ...    LOG 2:14 DEBUG REGEXP: (?i)<html.*</html>
+    ...    LOG 2:15 FAIL Page should have contained text 'non existing text' but did not.
+    Page Should Contain    non existing text    DEBUG
+
+Page Should Contain With Custom Log Level TRACE
+    [Documentation]    Html content is shown at DEBUG level.
+    ...    FAIL Page should have contained text 'non existing text' but did not.
+    ...    LOG 2:14 TRACE REGEXP: (?i)<html.*</html>
+    ...    LOG 2:15 FAIL Page should have contained text 'non existing text' but did not.
+    Page Should Contain    non existing text    TRACE
 
 Page Should Contain With Disabling Source Logging
     [Documentation]    LOG 3:2 NONE
@@ -78,12 +87,12 @@ Page Should Contain With Frames
     Page Should Contain    You're looking at right.
 
 Page Should Not Contain
-    [Documentation]    LOG 2:11 Current page does not contain text 'non existing text'.
-    ...    LOG 3.1:10 REGEXP: (?i)<html.*</html>
+    [Documentation]    Default log level does not have html output.
+    ...    FAIL Page should not have contained text 'needle'.
+    ...    LOG 2:11 Current page does not contain text 'non existing text'.
+    ...    LOG 3:10 FAIL Page should not have contained text 'needle'.
     Page Should Not Contain    non existing text
-    Run Keyword And Expect Error
-    ...    Page should not have contained text 'needle'.
-    ...    Page Should Not Contain    needle
+    Page Should Not Contain    needle
 
 Page Should Not Contain With Custom Log Level
     [Documentation]    LOG 2.1:10 DEBUG REGEXP: (?i)<html.*</html>

--- a/atest/acceptance/keywords/content_assertions.robot
+++ b/atest/acceptance/keywords/content_assertions.robot
@@ -20,7 +20,6 @@ Location Should Be
     ...    Location should have been 'non existing' but was 'http://localhost:7000/html/'.
     ...    Location Should Be    non existing  message=None
 
-
 Location Should Contain
     [Documentation]    LOG 2:4 Current location contains 'html'.
     Location Should Contain    html
@@ -36,7 +35,6 @@ Location Should Contain
     ...    Location should have contained 'not a location' but it was 'http://localhost:7000/html/'.
     ...    Location Should Contain    not a location  message=None
 
-
 Title Should Be
     [Documentation]    LOG 2:4 Page title is '(root)/index.html'.
     Title Should Be    (root)/index.html
@@ -46,7 +44,6 @@ Title Should Be
     Run Keyword And Expect Error
     ...    Page title was not expected
     ...    Title Should Be    not a title   message=Page title was not expected
-
 
 Page Should Contain
     [Documentation]    LOG 2:7 Current page contains text 'needle'.

--- a/atest/acceptance/keywords/cookies.robot
+++ b/atest/acceptance/keywords/cookies.robot
@@ -5,7 +5,6 @@ Suite Teardown    Delete All Cookies
 Test Setup        Add Cookies
 Resource          ../resource.robot
 
-
 *** Test Cases ***
 Get Cookies
     ${cookies}=    Get Cookies

--- a/atest/acceptance/keywords/counting_elements.robot
+++ b/atest/acceptance/keywords/counting_elements.robot
@@ -100,14 +100,12 @@ Page Should Contain Element When Limit Is Not Number
     ...    Page Should Contain Element    name: div_name    limit=AA
 
 Page Should Contain Element When Error With Limit And Different Loglevels
-    [Documentation]
-    ...    LOG 2.1:7    INFO REGEXP: .*links\\.html.*
-    ...    LOG 3.1:7    DEBUG REGEXP: .*links\\.html.*
+    [Documentation]    Only at DEBUG loglevel is the html placed in the log.
+    ...    FAIL Page should have contained "99" element(s), but it did contain "2" element(s).
+    ...    LOG 2.1:7    FAIL Page should have contained "99" element(s), but it did contain "2" element(s).
+    ...    LOG 3:7    DEBUG REGEXP: .*links\\.html.*
+    ...    LOG 3:8    FAIL Page should have contained "99" element(s), but it did contain "2" element(s).
     [Setup]    Go To Page "links.html"
     Run Keyword And Ignore Error
     ...    Page Should Contain Element    name: div_name    limit=99
-    Run Keyword And Ignore Error
-    ...    Page Should Contain Element
-    ...    name: div_name
-    ...    loglevel=debug
-    ...    limit=99
+    Page Should Contain Element    name: div_name    loglevel=debug    limit=99

--- a/atest/acceptance/keywords/screenshot_element.robot
+++ b/atest/acceptance/keywords/screenshot_element.robot
@@ -3,7 +3,6 @@ Documentation    Suite description
 Suite Setup       Go To Page "links.html"
 Resource          ../resource.robot
 
-
 *** Test Cases ***
 Capture Element Screenshot
     [Setup]    Remove Files    ${OUTPUTDIR}/selenium-element-screenshot-1.png

--- a/atest/run.py
+++ b/atest/run.py
@@ -52,19 +52,19 @@ except ImportError:
 
 # Folder settings
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
-ACCEPTANCE_TEST_DIR = os.path.join(ROOT_DIR, "acceptance")
-UNIT_TEST_RUNNER = os.path.join(ROOT_DIR, '..', 'utest', 'run.py')
-RESOURCES_DIR = os.path.join(ROOT_DIR, "resources")
-RESULTS_DIR = os.path.join(ROOT_DIR, "results")
-SRC_DIR = os.path.normpath(os.path.join(ROOT_DIR, "..", "src"))
-TEST_LIBS_DIR = os.path.join(RESOURCES_DIR, "testlibs")
-HTTP_SERVER_FILE = os.path.join(RESOURCES_DIR, "testserver", "testserver.py")
+ACCEPTANCE_TEST_DIR = os.path.join(ROOT_DIR, 'acceptance')
+UNIT_TEST_RUNNER = os.path.join(ROOT_DIR, os.pardir, 'utest', 'run.py')
+RESOURCES_DIR = os.path.join(ROOT_DIR, 'resources')
+RESULTS_DIR = os.path.join(ROOT_DIR, 'results')
+SRC_DIR = os.path.normpath(os.path.join(ROOT_DIR, os.pardir, 'src'))
+TEST_LIBS_DIR = os.path.join(RESOURCES_DIR, 'testlibs')
+HTTP_SERVER_FILE = os.path.join(RESOURCES_DIR, 'testserver', 'testserver.py')
 # Travis settings for pull request
-TRAVIS = os.environ.get("TRAVIS", False)
-TRAVIS_EVENT_TYPE = os.environ.get("TRAVIS_EVENT_TYPE", None)
-TRAVIS_JOB_NUMBER = os.environ.get("TRAVIS_JOB_NUMBER", "localtunnel")
-SAUCE_USERNAME = os.environ.get("SAUCE_USERNAME", None)
-SAUCE_ACCESS_KEY = os.environ.get("SAUCE_ACCESS_KEY", None)
+TRAVIS = os.environ.get('TRAVIS', False)
+TRAVIS_EVENT_TYPE = os.environ.get('TRAVIS_EVENT_TYPE', None)
+TRAVIS_JOB_NUMBER = os.environ.get('TRAVIS_JOB_NUMBER', 'localtunnel')
+SAUCE_USERNAME = os.environ.get('SAUCE_USERNAME', None)
+SAUCE_ACCESS_KEY = os.environ.get('SAUCE_ACCESS_KEY', None)
 TRAVIS_BROWSERS = ['chrome', 'firefox', 'headlesschrome']
 
 ROBOT_OPTIONS = [
@@ -91,7 +91,7 @@ def unit_tests():
         sys.exit(failures)
 
 
-def acceptance_tests(interpreter, browser, rf_options=[],
+def acceptance_tests(interpreter, browser, rf_options=None,
                      sauce_username=None, sauce_key=None):
     if os.path.exists(RESULTS_DIR):
         shutil.rmtree(RESULTS_DIR)
@@ -125,7 +125,8 @@ def execute_tests(interpreter, browser, rf_options, sauce_username, sauce_key):
     options = []
     runner = interpreter.split() + ['-m', 'robot.run']
     options.extend([opt.format(browser=browser) for opt in ROBOT_OPTIONS])
-    options += rf_options
+    if rf_options:
+        options += rf_options
     if sauce_username and sauce_key:
         options.extend(get_sauce_conf(browser, sauce_username, sauce_key))
     command = runner

--- a/src/SeleniumLibrary/base/librarycomponent.py
+++ b/src/SeleniumLibrary/base/librarycomponent.py
@@ -40,7 +40,7 @@ class LibraryComponent(ContextAware):
     def warn(self, msg, html=False):
         logger.warn(msg, html)
 
-    def log_source(self, loglevel='TRACE'):
+    def log_source(self, loglevel='INFO'):
         self.ctx.log_source(loglevel)
 
     def assert_page_contains(self, locator, tag=None, message=None,

--- a/src/SeleniumLibrary/base/librarycomponent.py
+++ b/src/SeleniumLibrary/base/librarycomponent.py
@@ -40,11 +40,11 @@ class LibraryComponent(ContextAware):
     def warn(self, msg, html=False):
         logger.warn(msg, html)
 
-    def log_source(self, loglevel='INFO'):
+    def log_source(self, loglevel='TRACE'):
         self.ctx.log_source(loglevel)
 
     def assert_page_contains(self, locator, tag=None, message=None,
-                             loglevel='INFO'):
+                             loglevel='TRACE'):
         if not self.find_element(locator, tag, required=False):
             self.log_source(loglevel)
             if is_noney(message):
@@ -55,7 +55,7 @@ class LibraryComponent(ContextAware):
                     % (tag or 'element', locator))
 
     def assert_page_not_contains(self, locator, tag=None, message=None,
-                                 loglevel='INFO'):
+                                 loglevel='TRACE'):
         if self.find_element(locator, tag, required=False):
             self.log_source(loglevel)
             if is_noney(message):

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -296,8 +296,8 @@ class BrowserManagementKeywords(LibraryComponent):
         """Logs and returns the HTML source of the current page or frame.
 
         The ``loglevel`` argument defines the used log level. Valid log
-        levels are ``WARN``, ``INFO`` (default), ``DEBUG``, and ``NONE``
-        (no logging).
+        levels are ``WARN``, ``INFO`` (default), ``DEBUG``, ``TRACE``
+        and ``NONE`` (no logging).
         """
         source = self.get_source()
         self.log(source, loglevel)

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -292,7 +292,7 @@ class BrowserManagementKeywords(LibraryComponent):
         return url
 
     @keyword
-    def log_source(self, loglevel='INFO'):
+    def log_source(self, loglevel='TRACE'):
         """Logs and returns the HTML source of the current page or frame.
 
         The ``loglevel`` argument defines the used log level. Valid log

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -292,7 +292,7 @@ class BrowserManagementKeywords(LibraryComponent):
         return url
 
     @keyword
-    def log_source(self, loglevel='TRACE'):
+    def log_source(self, loglevel='INFO'):
         """Logs and returns the HTML source of the current page or frame.
 
         The ``loglevel`` argument defines the used log level. Valid log

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -105,7 +105,7 @@ class ElementKeywords(LibraryComponent):
                   % (locator, expected_before))
 
     @keyword
-    def page_should_contain(self, text, loglevel='INFO'):
+    def page_should_contain(self, text, loglevel='TRACE'):
         """Verifies that current page contains ``text``.
 
         If this keyword fails, it automatically logs the page source
@@ -122,7 +122,7 @@ class ElementKeywords(LibraryComponent):
 
     @keyword
     def page_should_contain_element(self, locator, message=None,
-                                    loglevel='INFO', limit=None):
+                                    loglevel='TRACE', limit=None):
         """Verifies that element ``locator`` is found on the current page.
 
         See the `Locating elements` section for details about the locator
@@ -163,7 +163,7 @@ class ElementKeywords(LibraryComponent):
             raise AssertionError(message)
 
     @keyword
-    def locator_should_match_x_times(self, locator, x, message=None, loglevel='INFO'):
+    def locator_should_match_x_times(self, locator, x, message=None, loglevel='TRACE'):
         """Deprecated, use `Page Should Contain Element` with ``limit`` argument instead."""
         count = len(self.find_elements(locator))
         x = int(x)
@@ -178,7 +178,7 @@ class ElementKeywords(LibraryComponent):
                   % (count, locator))
 
     @keyword
-    def page_should_not_contain(self, text, loglevel='INFO'):
+    def page_should_not_contain(self, text, loglevel='TRACE'):
         """Verifies the current page does not contain ``text``.
 
         See `Page Should Contain` for explanation about the ``loglevel``
@@ -191,7 +191,7 @@ class ElementKeywords(LibraryComponent):
         self.info("Current page does not contain text '%s'." % text)
 
     @keyword
-    def page_should_not_contain_element(self, locator, message=None, loglevel='INFO'):
+    def page_should_not_contain_element(self, locator, message=None, loglevel='TRACE'):
         """Verifies that element ``locator`` is found on the current page.
 
         See the `Locating elements` section for details about the locator
@@ -745,7 +745,7 @@ return !element.dispatchEvent(evt);
         action.click_and_hold(element).perform()
 
     @keyword
-    def page_should_contain_link(self, locator, message=None, loglevel='INFO'):
+    def page_should_contain_link(self, locator, message=None, loglevel='TRACE'):
         """Verifies link identified by ``locator`` is found from current page.
 
         See the `Locating elements` section for details about the locator
@@ -758,7 +758,7 @@ return !element.dispatchEvent(evt);
         self.assert_page_contains(locator, 'link', message, loglevel)
 
     @keyword
-    def page_should_not_contain_link(self, locator, message=None, loglevel='INFO'):
+    def page_should_not_contain_link(self, locator, message=None, loglevel='TRACE'):
         """Verifies link identified by ``locator`` is not found from current page.
 
         See the `Locating elements` section for details about the locator
@@ -798,7 +798,7 @@ return !element.dispatchEvent(evt);
         action.click_and_hold(element).perform()
 
     @keyword
-    def page_should_contain_image(self, locator, message=None, loglevel='INFO'):
+    def page_should_contain_image(self, locator, message=None, loglevel='TRACE'):
         """Verifies image identified by ``locator`` is found from current page.
 
         See the `Locating elements` section for details about the locator
@@ -811,7 +811,7 @@ return !element.dispatchEvent(evt);
         self.assert_page_contains(locator, 'image', message, loglevel)
 
     @keyword
-    def page_should_not_contain_image(self, locator, message=None, loglevel='INFO'):
+    def page_should_not_contain_image(self, locator, message=None, loglevel='TRACE'):
         """Verifies image identified by ``locator`` is found from current page.
 
         See the `Locating elements` section for details about the locator
@@ -830,7 +830,7 @@ return !element.dispatchEvent(evt);
         return str(count) if is_truthy(return_str) else count
 
     @keyword
-    def xpath_should_match_x_times(self, xpath, x, message=None, loglevel='INFO'):
+    def xpath_should_match_x_times(self, xpath, x, message=None, loglevel='TRACE'):
         """*DEPRECATED in SeleniumLibrary 3.2.* Use `Page Should Contain Element` with ``limit`` argument instead."""
         self.locator_should_match_x_times('xpath:'+xpath, x, message, loglevel)
 

--- a/src/SeleniumLibrary/keywords/formelement.py
+++ b/src/SeleniumLibrary/keywords/formelement.py
@@ -65,7 +65,7 @@ class FormElementKeywords(LibraryComponent):
                                  "selected." % locator)
 
     @keyword
-    def page_should_contain_checkbox(self, locator, message=None, loglevel='INFO'):
+    def page_should_contain_checkbox(self, locator, message=None, loglevel='TRACE'):
         """Verifies checkbox ``locator`` is found from current page.
 
         See `Page Should Contain Element` for explanation about ``message``
@@ -77,7 +77,7 @@ class FormElementKeywords(LibraryComponent):
         self.assert_page_contains(locator, 'checkbox', message, loglevel)
 
     @keyword
-    def page_should_not_contain_checkbox(self, locator, message=None, loglevel='INFO'):
+    def page_should_not_contain_checkbox(self, locator, message=None, loglevel='TRACE'):
         """Verifies checkbox ``locator`` is not found from current page.
 
         See `Page Should Contain Element` for explanation about ``message``
@@ -117,7 +117,7 @@ class FormElementKeywords(LibraryComponent):
             element.click()
 
     @keyword
-    def page_should_contain_radio_button(self, locator, message=None, loglevel='INFO'):
+    def page_should_contain_radio_button(self, locator, message=None, loglevel='TRACE'):
         """Verifies radio button ``locator`` is found from current page.
 
         See `Page Should Contain Element` for explanation about ``message``
@@ -130,7 +130,7 @@ class FormElementKeywords(LibraryComponent):
         self.assert_page_contains(locator, 'radio button', message, loglevel)
 
     @keyword
-    def page_should_not_contain_radio_button(self, locator, message=None, loglevel='INFO'):
+    def page_should_not_contain_radio_button(self, locator, message=None, loglevel='TRACE'):
         """Verifies radio button ``locator`` is not found from current page.
 
         See `Page Should Contain Element` for explanation about ``message``
@@ -248,7 +248,7 @@ class FormElementKeywords(LibraryComponent):
         self._input_text_into_text_field(locator, text)
 
     @keyword
-    def page_should_contain_textfield(self, locator, message=None, loglevel='INFO'):
+    def page_should_contain_textfield(self, locator, message=None, loglevel='TRACE'):
         """Verifies text field ``locator`` is found from current page.
 
         See `Page Should Contain Element` for explanation about ``message``
@@ -260,7 +260,7 @@ class FormElementKeywords(LibraryComponent):
         self.assert_page_contains(locator, 'text field', message, loglevel)
 
     @keyword
-    def page_should_not_contain_textfield(self, locator, message=None, loglevel='INFO'):
+    def page_should_not_contain_textfield(self, locator, message=None, loglevel='TRACE'):
         """Verifies text field ``locator`` is not found from current page.
 
         See `Page Should Contain Element` for explanation about ``message``
@@ -354,7 +354,7 @@ class FormElementKeywords(LibraryComponent):
         element.click()
 
     @keyword
-    def page_should_contain_button(self, locator, message=None, loglevel='INFO'):
+    def page_should_contain_button(self, locator, message=None, loglevel='TRACE'):
         """Verifies button ``locator`` is found from current page.
 
         See `Page Should Contain Element` for explanation about ``message``
@@ -370,7 +370,7 @@ class FormElementKeywords(LibraryComponent):
             self.assert_page_contains(locator, 'button', message, loglevel)
 
     @keyword
-    def page_should_not_contain_button(self, locator, message=None, loglevel='INFO'):
+    def page_should_not_contain_button(self, locator, message=None, loglevel='TRACE'):
         """Verifies button ``locator`` is not found from current page.
 
         See `Page Should Contain Element` for explanation about ``message``

--- a/src/SeleniumLibrary/keywords/frames.py
+++ b/src/SeleniumLibrary/keywords/frames.py
@@ -48,7 +48,7 @@ class FrameKeywords(LibraryComponent):
         self.driver.switch_to.default_content()
 
     @keyword
-    def current_frame_should_contain(self, text, loglevel='INFO'):
+    def current_frame_should_contain(self, text, loglevel='TRACE'):
         """Verifies that current frame contains ``text``.
 
         See `Page Should Contain` for explanation about the ``loglevel``
@@ -64,12 +64,12 @@ class FrameKeywords(LibraryComponent):
         self.info("Current frame contains text '%s'." % text)
 
     @keyword
-    def current_frame_contains(self, text, loglevel='INFO'):
+    def current_frame_contains(self, text, loglevel='TRACE'):
         """*DEPRECATED in SeleniumLibrary 3.2.* Use `Current Frame Should Contain` instead."""
         self.current_frame_should_contain(text, loglevel)
 
     @keyword
-    def current_frame_should_not_contain(self, text, loglevel='INFO'):
+    def current_frame_should_not_contain(self, text, loglevel='TRACE'):
         """Verifies that current frame does not contains ``text``.
 
         See `Page Should Contain` for explanation about the ``loglevel``
@@ -82,7 +82,7 @@ class FrameKeywords(LibraryComponent):
         self.info("Current frame did not contain text '%s'." % text)
 
     @keyword
-    def frame_should_contain(self, locator, text, loglevel='INFO'):
+    def frame_should_contain(self, locator, text, loglevel='TRACE'):
         """Verifies that frame identified by ``locator`` contains ``text``.
 
         See the `Locating elements` section for details about the locator

--- a/src/SeleniumLibrary/keywords/selectelement.py
+++ b/src/SeleniumLibrary/keywords/selectelement.py
@@ -151,7 +151,7 @@ class SelectElementKeywords(LibraryComponent):
                                  % (locator, selection))
 
     @keyword
-    def page_should_contain_list(self, locator, message=None, loglevel='INFO'):
+    def page_should_contain_list(self, locator, message=None, loglevel='TRACE'):
         """Verifies selection list ``locator`` is found from current page.
 
         See `Page Should Contain Element` for explanation about ``message``
@@ -163,7 +163,7 @@ class SelectElementKeywords(LibraryComponent):
         self.assert_page_contains(locator, 'list', message, loglevel)
 
     @keyword
-    def page_should_not_contain_list(self, locator, message=None, loglevel='INFO'):
+    def page_should_not_contain_list(self, locator, message=None, loglevel='TRACE'):
         """Verifies selection list ``locator`` is not found from current page.
 
         See `Page Should Contain Element` for explanation about ``message``

--- a/src/SeleniumLibrary/keywords/tableelement.py
+++ b/src/SeleniumLibrary/keywords/tableelement.py
@@ -20,7 +20,7 @@ from SeleniumLibrary.base import LibraryComponent, keyword
 class TableElementKeywords(LibraryComponent):
 
     @keyword
-    def get_table_cell(self, locator, row, column, loglevel='INFO'):
+    def get_table_cell(self, locator, row, column, loglevel='TRACE'):
         """Returns contents of table cell.
 
         The table is located using the ``locator`` argument and its cell
@@ -76,7 +76,7 @@ class TableElementKeywords(LibraryComponent):
         return rows
 
     @keyword
-    def table_cell_should_contain(self, locator, row, column, expected, loglevel='INFO'):
+    def table_cell_should_contain(self, locator, row, column, expected, loglevel='TRACE'):
         """Verifies table cell contains text ``expected``.
 
         See `Get Table Cell` that this keyword uses internally for
@@ -92,7 +92,7 @@ class TableElementKeywords(LibraryComponent):
         self.info("Table cell contains '%s'." % content)
 
     @keyword
-    def table_column_should_contain(self, locator, column, expected, loglevel='INFO'):
+    def table_column_should_contain(self, locator, column, expected, loglevel='TRACE'):
         """Verifies table column contains text ``expected``.
 
         The table is located using the ``locator`` argument and its column
@@ -116,7 +116,7 @@ class TableElementKeywords(LibraryComponent):
                                  "'%s'." % (locator, column, expected))
 
     @keyword
-    def table_footer_should_contain(self, locator, expected, loglevel='INFO'):
+    def table_footer_should_contain(self, locator, expected, loglevel='TRACE'):
         """Verifies table footer contains text ``expected``.
 
         Any ``<td>`` element inside ``<tfoot>`` element is considered to
@@ -135,7 +135,7 @@ class TableElementKeywords(LibraryComponent):
                                  "'%s'." % (locator, expected))
 
     @keyword
-    def table_header_should_contain(self, locator, expected, loglevel='INFO'):
+    def table_header_should_contain(self, locator, expected, loglevel='TRACE'):
         """Verifies table header contains text ``expected``.
 
         Any ``<th>`` element anywhere in the table is considered to be
@@ -154,7 +154,7 @@ class TableElementKeywords(LibraryComponent):
                                  "'%s'." % (locator, expected))
 
     @keyword
-    def table_row_should_contain(self, locator, row, expected, loglevel='INFO'):
+    def table_row_should_contain(self, locator, row, expected, loglevel='TRACE'):
         """Verifies that table row contains text ``expected``.
 
         The table is located using the ``locator`` argument and its column
@@ -178,7 +178,7 @@ class TableElementKeywords(LibraryComponent):
                                  "'%s'." % (locator, row, expected))
 
     @keyword
-    def table_should_contain(self, locator, expected, loglevel='INFO'):
+    def table_should_contain(self, locator, expected, loglevel='TRACE'):
         """Verifies table contains text ``expected``.
 
         The table is located using the ``locator`` argument. See the

--- a/utest/run.py
+++ b/utest/run.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import os
 import sys
 from os.path import abspath, dirname, join
 from unittest import defaultTestLoader, TextTestRunner
@@ -9,7 +10,7 @@ CURDIR = dirname(abspath(__file__))
 
 
 def run_unit_tests():
-    sys.path.insert(0, join(CURDIR, '..', 'src'))
+    sys.path.insert(0, join(CURDIR, os.pardir, 'src'))
     try:
         suite = defaultTestLoader.discover(join(CURDIR, 'test'), 'test_*.py')
         result = TextTestRunner().run(suite)

--- a/utest/test/keywords/test_javascript.py
+++ b/utest/test/keywords/test_javascript.py
@@ -37,7 +37,7 @@ class JavaScriptKeywordsTest(unittest.TestCase):
             ('JAVASCRIPT', 'code1', 'code2', 'ARGUMENTS ARG2', 'arg3')]
         cls.js = JavaScriptKeywords(None)
         path = os.path.dirname(__file__)
-        reporter_json = os.path.abspath(os.path.join(path, '..', 'approvals_reporters.json'))
+        reporter_json = os.path.abspath(os.path.join(path, os.pardir, 'approvals_reporters.json'))
         factory = GenericDiffReporterFactory()
         factory.load(reporter_json)
         cls.reporter = factory.get_first_working()


### PR DESCRIPTION
Addresses issue #1199 

Having the whole DOM in these keywords at the INFO level is too much clutter and causes the size of the logs to increase dramatically.