### PR TITLE
Get Cookies keyword able to return dict now

### DIFF
--- a/atest/acceptance/keywords/cookies.robot
+++ b/atest/acceptance/keywords/cookies.robot
@@ -11,6 +11,11 @@ Get Cookies
     Should Match Regexp    ${cookies}
     ...    ^(test=seleniumlibrary; another=value)|(another=value; test=seleniumlibrary)$
 
+Get Cookies As Dict
+    ${cookies}=    Get Cookies        as_dict=True
+    ${expected_cookies}=    Create Dictionary   test=seleniumlibrary    another=value
+    Dictionaries Should Be Equal  ${expected_cookies}   ${cookies}
+
 Get Cookie Value Set By Selenium
     ${value} =    Get Cookie Value    another
     Should Be Equal    ${value}       value
@@ -65,6 +70,13 @@ Get Cookies When There Are None
     Delete All Cookies
     ${cookies} =    Get Cookies
     Should Be Equal    ${cookies}    ${EMPTY}
+
+Get Cookies As Dict When There Are None
+    [Tags]    Known Issue Safari
+    Delete All Cookies
+    ${cookies} =    Get Cookies   as_dict=True
+    ${expected_cookies}=    Create Dictionary
+    Dictionaries Should Be Equal  ${expected_cookies}   ${cookies}
 
 Test Get Cookie Object Expiry
     ${cookie} =    Get Cookie      another

--- a/src/SeleniumLibrary/keywords/cookie.py
+++ b/src/SeleniumLibrary/keywords/cookie.py
@@ -43,15 +43,17 @@ class CookieKeywords(LibraryComponent):
     def get_cookies(self, as_dict=False):
         """Returns all cookies of the current page.
 
-        The cookie information is returned as a single string in format
-        ``name1=value1; name2=value2; name3=value3`` if optional
-        ``as_dict`` is not provided or not explictly set to True.
-        Keyword can be used, for example, for logging purposes or in
-        headers when sending HTTP requests. In later case, setting
-        ``as_dict`` to True is helpful as then the result can be passed
-        to requests library's Create Session keyword's optional cookies
-        parameter.
-
+        If ``as_dict`` argument evaluates as false, see `Boolean arguments` 
+        for more details, then cookie information is returned as 
+        a single string in format ``name1=value1; name2=value2; name3=value3``.
+        When ``as_dict`` argument evaluates as true, cookie information
+        is returned as Robot Framework dictionary format. The string format 
+        can be used, for example, for logging purposes or in headers when
+        sending HTTP requests. The dictionary format is helpful when
+        the result can be passed to requests library's Create Session
+        keyword's optional cookies parameter.
+        
+        The `` as_dict`` argument is new in SeleniumLibrary 3.3
         """
         if is_falsy(as_dict):
             pairs = []

--- a/src/SeleniumLibrary/keywords/cookie.py
+++ b/src/SeleniumLibrary/keywords/cookie.py
@@ -17,10 +17,11 @@
 from datetime import datetime
 
 from robot.libraries.DateTime import convert_date
+from robot.utils import DotDict
 
 from SeleniumLibrary.base import LibraryComponent, keyword
 from SeleniumLibrary.errors import CookieNotFound
-from SeleniumLibrary.utils import is_truthy, is_noney
+from SeleniumLibrary.utils import is_truthy, is_noney, is_falsy
 
 
 class CookieKeywords(LibraryComponent):
@@ -39,18 +40,29 @@ class CookieKeywords(LibraryComponent):
         self.driver.delete_cookie(name)
 
     @keyword
-    def get_cookies(self):
+    def get_cookies(self, as_dict=False):
         """Returns all cookies of the current page.
 
         The cookie information is returned as a single string in format
-        ``name1=value1; name2=value2; name3=value3``. It can be used,
-        for example, for logging purposes or in headers when sending
-        HTTP requests.
+        ``name1=value1; name2=value2; name3=value3`` if optional
+        ``as_dict`` is not provided or not explictly set to True.
+        Keyword can be used, for example, for logging purposes or in
+        headers when sending HTTP requests. In later case, setting
+        ``as_dict`` to True is helpful as then the result can be passed
+        to requests library's Create Session keyword's optional cookies
+        parameter.
+
         """
-        pairs = []
-        for cookie in self.driver.get_cookies():
-            pairs.append(cookie['name'] + "=" + cookie['value'])
-        return '; '.join(pairs)
+        if is_falsy(as_dict):
+            pairs = []
+            for cookie in self.driver.get_cookies():
+                pairs.append(cookie['name'] + "=" + cookie['value'])
+            return '; '.join(pairs)
+        else:
+            pairs = DotDict()
+            for cookie in self.driver.get_cookies():
+                pairs[cookie['name']] = cookie['value']
+            return pairs
 
     @keyword
     def get_cookie_value(self, name):


### PR DESCRIPTION
This is usefull as Requests Library's Create Session keywords expects
cookies parameter to be a dict, not a string that Get Cookies returns by
default.

Fixes #979

