### PR TITLE
Fixes regression caused by 159206fb

### DIFF
--- a/atest/acceptance/open_and_close.robot
+++ b/atest/acceptance/open_and_close.robot
@@ -76,3 +76,8 @@ Get Session Id
     Run Keyword And Expect Error
     ...    No browser with index or alias 'Browser 2' found.
     ...    Switch Browser    Browser 2
+
+Open Browser desired_capabilities As Dictionary
+    ${caps}    Create Dictionary    foo=${True}
+    Open Browser    ${ROOT}/forms/prefilled_email_form.html    ${BROWSER}
+     ...    remote_url=${REMOTE_URL}    desired_capabilities=${caps}

--- a/src/SeleniumLibrary/keywords/webdrivertools.py
+++ b/src/SeleniumLibrary/keywords/webdrivertools.py
@@ -65,22 +65,25 @@ class WebDriverCreator(object):
         raise ValueError('{} is not a supported browser.'.format(browser))
 
     def _parse_capabilities(self, capabilities, browser=None):
-        if isinstance(capabilities, dict):
-            return capabilities
-        desired_capabilities = {}
         if is_falsy(capabilities):
-            return desired_capabilities
-        for part in capabilities.split(','):
-            key, value = part.split(':')
-            desired_capabilities[key.strip()] = value.strip()
+            return {}
+        if not isinstance(capabilities, dict):
+            capabilities = self._string_to_dict(capabilities)
         browser_alias = {'googlechrome': "chrome", 'gc': "chrome",
                          'headlesschrome': 'chrome', 'ff': 'firefox',
                          'headlessfirefox': 'firefox',
                          'internetexplorer': 'ie'}
         browser = browser_alias.get(browser, browser)
         if browser in ['ie', 'firefox', 'edge']:
-            return {'capabilities': desired_capabilities}
-        return {'desired_capabilities': desired_capabilities}
+            return {'capabilities': capabilities}
+        return {'desired_capabilities': capabilities}
+
+    def _string_to_dict(self, capabilities):
+        desired_capabilities = {}
+        for part in capabilities.split(','):
+            key, value = part.split(':')
+            desired_capabilities[key.strip()] = value.strip()
+        return desired_capabilities
 
     def create_chrome(self, desired_capabilities, remote_url, options=None):
         if is_truthy(remote_url):

--- a/utest/test/keywords/test_webdrivercreator.py
+++ b/utest/test/keywords/test_webdrivercreator.py
@@ -69,13 +69,15 @@ class WebDriverCreatorTests(unittest.TestCase):
         caps = self.creator._parse_capabilities(None)
         self.assertDictEqual(caps, {})
 
-        caps = self.creator._parse_capabilities({'key1': 'value1', 'key2': 'value2'})
-        expected = {'desired_capabilities': {'key1': 'value1', 'key2': 'value2'}}
-        self.assertDictEqual(caps, expected)
+        for browser in [None, 'safari', 'headlesschrome', 'foobar']:
+            caps = self.creator._parse_capabilities({'key1': 'value1', 'key2': 'value2'}, browser)
+            expected = {'desired_capabilities': {'key1': 'value1', 'key2': 'value2'}}
+            self.assertDictEqual(caps, expected)
 
-        caps = self.creator._parse_capabilities({'key1': 'value1', 'key2': 'value2'}, 'ie')
-        expected = {'capabilities': {'key1': 'value1', 'key2': 'value2'}}
-        self.assertDictEqual(caps, expected)
+        for browser in ['ie', 'firefox', 'edge']:
+            caps = self.creator._parse_capabilities({'key1': 'value1', 'key2': 'value2'}, browser)
+            expected = {'capabilities': {'key1': 'value1', 'key2': 'value2'}}
+            self.assertDictEqual(caps, expected)
 
     def test_chrome(self):
         expected_webdriver = mock()

--- a/utest/test/keywords/test_webdrivercreator.py
+++ b/utest/test/keywords/test_webdrivercreator.py
@@ -48,8 +48,9 @@ class WebDriverCreatorTests(unittest.TestCase):
         caps = self.creator._parse_capabilities('key1:value1,key2:value2', 'edge')
         self.assertDictEqual(caps, expected)
 
-        caps = self.creator._parse_capabilities(expected)
-        self.assertDictEqual(caps, expected)
+        parsing_caps = expected.copy()
+        caps = self.creator._parse_capabilities(parsing_caps)
+        self.assertDictEqual(caps, {'desired_capabilities': expected})
 
         caps = self.creator._parse_capabilities('key1 : value1 , key2: value2')
         expected = {'desired_capabilities': {'key1': 'value1', 'key2': 'value2'}}
@@ -64,6 +65,17 @@ class WebDriverCreatorTests(unittest.TestCase):
 
         caps = self.creator._parse_capabilities({})
         self.assertDictEqual(caps, {})
+
+        caps = self.creator._parse_capabilities(None)
+        self.assertDictEqual(caps, {})
+
+        caps = self.creator._parse_capabilities({'key1': 'value1', 'key2': 'value2'})
+        expected = {'desired_capabilities': {'key1': 'value1', 'key2': 'value2'}}
+        self.assertDictEqual(caps, expected)
+
+        caps = self.creator._parse_capabilities({'key1': 'value1', 'key2': 'value2'}, 'ie')
+        expected = {'capabilities': {'key1': 'value1', 'key2': 'value2'}}
+        self.assertDictEqual(caps, expected)
 
     def test_chrome(self):
         expected_webdriver = mock()


### PR DESCRIPTION
If Open Browser keyword desired_capabilities is a dictionary, then Open Browser keyword fails.

Fixes #1277 