### PR TITLE
Get and Set Inner Window Size

### DIFF
--- a/atest/acceptance/windows.robot
+++ b/atest/acceptance/windows.robot
@@ -75,15 +75,15 @@ Set Window Size using strings
     Should Be Equal    ${width}    ${600}
     Should Be Equal    ${height}    ${800}
 
-Get and Set Page Size
-    Set Page Size    ${800}    ${600}
-    ${width}    ${height}=    Get Page Size
+Get and Set Inner Window Size
+    Set Inner Window Size    ${800}    ${600}
+    ${width}    ${height}=    Get Inner Window Size
     Should Be Equal    ${width}    ${800}
     Should Be Equal    ${height}    ${600}
 
-Set Page Size using strings
-    Set Page Size    800    600
-    ${width}    ${height}=    Get Page Size
+Set Inner Window Size using strings
+    Set Inner Window Size    800    600
+    ${width}    ${height}=    Get Inner Window Size
     Should Be Equal    ${width}    ${800}
     Should Be Equal    ${height}    ${600}
 

--- a/atest/acceptance/windows.robot
+++ b/atest/acceptance/windows.robot
@@ -92,11 +92,10 @@ Get and Set Inner Window Size with Frames
     Set Window Size         ${800}    ${600}    ${True}
     ${page_width}           ${page_height}=     Get Window Size    ${True}
     Select Frame            left
-    Set Window Size         ${800}    ${600}    ${True}
+    Set Window Size         ${400}    ${300}    ${True}
     ${frame_width}          ${frame_height}=    Get Window Size    ${True}
-    Should Be Equal         ${frame_width}      ${800}
-    Should Be Equal         ${frame_height}     ${600}
-    Should Not Be Equal     ${frame_width}      ${page_width}
+    Should Be Equal         ${frame_width}      ${400}
+    Should Be Equal         ${frame_height}     ${300}
 
 Get and Set Window Position
     [Tags]  Known Issue Chrome    Known Issue Safari

--- a/atest/acceptance/windows.robot
+++ b/atest/acceptance/windows.robot
@@ -75,6 +75,18 @@ Set Window Size using strings
     Should Be Equal    ${width}    ${600}
     Should Be Equal    ${height}    ${800}
 
+Get and Set Page Size
+    Set Page Size    ${800}    ${600}
+    ${width}    ${height}=    Get Page Size
+    Should Be Equal    ${width}    ${800}
+    Should Be Equal    ${height}    ${600}
+
+Set Page Size using strings
+    Set Page Size    800    600
+    ${width}    ${height}=    Get Page Size
+    Should Be Equal    ${width}    ${800}
+    Should Be Equal    ${height}    ${600}
+
 Get and Set Window Position
     [Tags]  Known Issue Chrome    Known Issue Safari
     Set Window Position    ${300}    ${200}

--- a/atest/acceptance/windows.robot
+++ b/atest/acceptance/windows.robot
@@ -87,6 +87,16 @@ Set Inner Window Size using strings
     Should Be Equal    ${width}    ${800}
     Should Be Equal    ${height}    ${600}
 
+Get and Set Inner Window Size with Frames
+    Go To Page "frames/frameset.html"
+    ${page_width}           ${page_height}=     Get Window Size    ${True}
+    Select Frame            left
+    Set Window Size         ${800}    ${600}    ${True}
+    ${frame_width}          ${frame_height}=    Get Window Size    ${True}
+    Should Be Equal         ${frame_width}      ${800}
+    Should Be Equal         ${frame_height}     ${600}
+    Should Not Be Equal     ${frame_width}      ${page_width}
+
 Get and Set Window Position
     [Tags]  Known Issue Chrome    Known Issue Safari
     Set Window Position    ${300}    ${200}

--- a/atest/acceptance/windows.robot
+++ b/atest/acceptance/windows.robot
@@ -89,6 +89,7 @@ Set Inner Window Size using strings
 
 Get and Set Inner Window Size with Frames
     Go To Page "frames/frameset.html"
+    Set Window Size         ${800}    ${600}    ${True}
     ${page_width}           ${page_height}=     Get Window Size    ${True}
     Select Frame            left
     Set Window Size         ${800}    ${600}    ${True}

--- a/atest/acceptance/windows.robot
+++ b/atest/acceptance/windows.robot
@@ -89,13 +89,11 @@ Set Inner Window Size using strings
 
 Get and Set Inner Window Size with Frames
     Go To Page "frames/frameset.html"
-    Set Window Size         ${800}    ${600}    ${True}
-    ${page_width}           ${page_height}=     Get Window Size    ${True}
     Select Frame            left
     Set Window Size         ${400}    ${300}    ${True}
     ${frame_width}          ${frame_height}=    Get Window Size    ${True}
-    Should Be Equal         ${frame_width}      ${400}
-    Should Be Equal         ${frame_height}     ${300}
+    ${check}=               Run Keyword And Return Status       Check Frame Size    ${frame_width}      ${frame_height}     ${400}    ${300}
+    Should Be Equal         ${check}    ${False}
 
 Get and Set Window Position
     [Tags]  Known Issue Chrome    Known Issue Safari
@@ -224,3 +222,8 @@ Wait Until New Window Is Open
 New Windows Should Be Open
     ${titles} =    Get Window Titles
     Should Be True    len(${titles}) > 1
+
+Check Frame Size
+    [Arguments]     ${frame_width}      ${frame_height}     ${width}    ${height}
+    Should Be Equal         ${frame_width}      ${width}
+    Should Be Equal         ${frame_height}     ${height}

--- a/atest/acceptance/windows.robot
+++ b/atest/acceptance/windows.robot
@@ -76,14 +76,14 @@ Set Window Size using strings
     Should Be Equal    ${height}    ${800}
 
 Get and Set Inner Window Size
-    Set Inner Window Size    ${800}    ${600}
-    ${width}    ${height}=    Get Inner Window Size
+    Set Window Size    ${800}    ${600}    ${True}
+    ${width}    ${height}=    Get Window Size    ${True}
     Should Be Equal    ${width}    ${800}
     Should Be Equal    ${height}    ${600}
 
 Set Inner Window Size using strings
-    Set Inner Window Size    800    600
-    ${width}    ${height}=    Get Inner Window Size
+    Set Window Size    800    600    ${True}
+    ${width}    ${height}=    Get Window Size    ${True}
     Should Be Equal    ${width}    ${800}
     Should Be Equal    ${height}    ${600}
 

--- a/atest/acceptance/windows.robot
+++ b/atest/acceptance/windows.robot
@@ -90,10 +90,9 @@ Set Inner Window Size using strings
 Get and Set Inner Window Size with Frames
     Go To Page "frames/frameset.html"
     Select Frame            left
-    Set Window Size         ${400}    ${300}    ${True}
-    ${frame_width}          ${frame_height}=    Get Window Size    ${True}
-    ${check}=               Run Keyword And Return Status       Check Frame Size    ${frame_width}      ${frame_height}     ${400}    ${300}
-    Should Be Equal         ${check}    ${False}
+    Run Keyword And Expect Error
+    ...    Keyword failed setting correct window size.
+    ...    Set Window Size         ${400}    ${300}    ${True}
 
 Get and Set Window Position
     [Tags]  Known Issue Chrome    Known Issue Safari
@@ -222,8 +221,3 @@ Wait Until New Window Is Open
 New Windows Should Be Open
     ${titles} =    Get Window Titles
     Should Be True    len(${titles}) > 1
-
-Check Frame Size
-    [Arguments]     ${frame_width}      ${frame_height}     ${width}    ${height}
-    Should Be Equal         ${frame_width}      ${width}
-    Should Be Equal         ${frame_height}     ${height}

--- a/src/SeleniumLibrary/keywords/window.py
+++ b/src/SeleniumLibrary/keywords/window.py
@@ -161,19 +161,29 @@ class WindowKeywords(LibraryComponent):
         self.driver.maximize_window()
 
     @keyword
-    def get_window_size(self):
+    def get_window_size(self, inner=False):
         """Returns current window width and height as integers.
 
         See also `Set Window Size`.
 
+        With optional `inner` parameter you receive
+        the inner size, excluding the browser bars, borders and so on.
+
         Example:
         | ${width} | ${height}= | `Get Window Size` |
+        | ${width} | ${height}= | `Get Window Size` | True |
         """
-        size = self.driver.get_window_size()
-        return size['width'], size['height']
+        if inner == True:
+            inner_width = int(self.driver.execute_script("window.innerWidth"))
+            inner_height = int(self.driver.execute_script("window.innerHeight"))
+
+            return inner_width, inner_height
+        else:
+            size = self.driver.get_window_size()
+            return size['width'], size['height']
 
     @keyword
-    def set_window_size(self, width, height):
+    def set_window_size(self, width, height, inner=False):
         """Sets current windows size to given ``width`` and ``height``.
 
         Values can be given using strings containing numbers or by using
@@ -183,55 +193,24 @@ class WindowKeywords(LibraryComponent):
         smaller will cause the actual size to be bigger than the requested
         size.
 
-        Example:
-        | `Set Window Size` | 800 | 600 |
-        """
-        return self.driver.set_window_size(int(width), int(height))
-
-    @keyword
-    def get_inner_window_size(self):
-        """Returns current inner window width and height as integers.
-
-        See also `Set Inner Window Size`.
-
-        Example:
-        | ${width} | ${height}= | `Get Inner Window Size` |
-
-        The main difference with `Get Window Size` is that you receive
-        the inner size, excluding the browser bars, borders and so on.
-        """
-        inner_width = int(self.driver.execute_script("window.innerWidth"))
-        inner_height = int(self.driver.execute_script("window.innerHeight"))
-
-        return inner_width, inner_height
-
-    @keyword
-    def set_inner_window_size(self, width, height):
-        """Sets current windows size adapted to contain page
-        with given ``width`` and ``height``.
-
-        The main difference with `Set Window Size` is that you can give
+        With optional `inner` parameter you can give
         the inner size required, excluding the browser bars, borders and so on.
         The window size is adapted to provide the correct page size for each browser.
 
-        Values can be given using strings containing numbers or by using
-        actual numbers. See also `Get Window Size` and `Set Window Size` .
-
-        Browsers have a limit how small they can be set. Trying to set them
-        smaller will cause the actual size to be bigger than the requested
-        size.
 
         Example:
-        | `Set Inner Window Size` | 800 | 600 |
+        | `Set Window Size` | 800 | 600 |
+        | `Set Window Size` | 800 | 600 | True |
         """
-        self.driver.set_window_size(int(width), int(height))
-        inner_width = int(self.driver.execute_script("window.innerWidth"))
-        inner_height = int(self.driver.execute_script("window.innerHeight"))
-        width_offset = width - inner_width
-        height_offset = height - inner_height
-        window_width = width + width_offset
-        window_height = height + height_offset
-        return self.driver.set_window_size(int(window_width), int(window_height))
+        if inner == True:
+            self.driver.set_window_size(int(width), int(height))
+            inner_width = int(self.driver.execute_script("window.innerWidth"))
+            inner_height = int(self.driver.execute_script("window.innerHeight"))
+            width_offset = width - inner_width
+            height_offset = height - inner_height
+            return self.driver.set_window_size(int(width + width_offset), int(height + height_offset))
+        else:
+            return self.driver.set_window_size(int(width), int(height))
 
     @keyword
     def get_window_position(self):

--- a/src/SeleniumLibrary/keywords/window.py
+++ b/src/SeleniumLibrary/keywords/window.py
@@ -169,10 +169,10 @@ class WindowKeywords(LibraryComponent):
         If ``inner`` parameter is set to True, keyword returns
         HTML DOM window.innerWidth and window.innerHeight properties.
         See `Boolean arguments` for more details how to set boolean
-        arguments.
+        arguments. The ``inner`` is new in SeleniumLibrary 4.0.
 
         Example:
-        | ${width} | ${height}= | `Get Window Size` |
+        | ${width} | ${height}= | `Get Window Size` |      |
         | ${width} | ${height}= | `Get Window Size` | True |
         """
         if is_truthy(inner):
@@ -195,15 +195,15 @@ class WindowKeywords(LibraryComponent):
 
         If ``inner`` parameter is set to True, keyword sets the necessary
         window width and height to have the desired HTML DOM window.innerWidth
-        and window.innerHeight
+        and window.innerHeight The ``inner`` is new in SeleniumLibrary 4.0.
         See `Boolean arguments` for more details how to set boolean
         arguments.
 
-        This keyword does NOT support Frames. If a frame is selected,
+        This ``inner`` argument does not support Frames. If a frame is selected,
         switch to default before running this.
 
         Example:
-        | `Set Window Size` | 800 | 600 |
+        | `Set Window Size` | 800 | 600 |      |
         | `Set Window Size` | 800 | 600 | True |
         """
         width, height = int(width), int(height)
@@ -215,12 +215,12 @@ class WindowKeywords(LibraryComponent):
             height_offset = height - inner_height
             window_width = width + width_offset
             window_height = height + height_offset
-            res = self.driver.set_window_size(window_width, window_height)
+            size = self.driver.set_window_size(window_width, window_height)
             result_width = int(self.driver.execute_script("return window.innerWidth;"))
             result_height = int(self.driver.execute_script("return window.innerHeight;"))
             if result_width != width or result_height != height:
                 raise AssertionError("Keyword failed setting correct window size.")
-            return res
+            return size['width'], size['height']
         return self.driver.set_window_size(width, height)
 
     @keyword

--- a/src/SeleniumLibrary/keywords/window.py
+++ b/src/SeleniumLibrary/keywords/window.py
@@ -174,8 +174,8 @@ class WindowKeywords(LibraryComponent):
         | ${width} | ${height}= | `Get Window Size` | True |
         """
         if inner == True:
-            inner_width = int(self.driver.execute_script("window.innerWidth"))
-            inner_height = int(self.driver.execute_script("window.innerHeight"))
+            inner_width = int(self.driver.execute_script("return window.innerWidth;"))
+            inner_height = int(self.driver.execute_script("return window.innerHeight;"))
 
             return inner_width, inner_height
         else:
@@ -204,11 +204,13 @@ class WindowKeywords(LibraryComponent):
         """
         if inner == True:
             self.driver.set_window_size(int(width), int(height))
-            inner_width = int(self.driver.execute_script("window.innerWidth"))
-            inner_height = int(self.driver.execute_script("window.innerHeight"))
-            width_offset = width - inner_width
-            height_offset = height - inner_height
-            return self.driver.set_window_size(int(width + width_offset), int(height + height_offset))
+            inner_width = self.driver.execute_script("return window.innerWidth;")
+            inner_height = self.driver.execute_script("return window.innerHeight;")
+            width_offset = int(width) - int(inner_width)
+            height_offset = int(height) - int(inner_height)
+            window_width = int(width) + int(width_offset)
+            window_height = int(height) + int(height_offset)
+            return self.driver.set_window_size(int(window_width), int(window_height))
         else:
             return self.driver.set_window_size(int(width), int(height))
 

--- a/src/SeleniumLibrary/keywords/window.py
+++ b/src/SeleniumLibrary/keywords/window.py
@@ -189,16 +189,16 @@ class WindowKeywords(LibraryComponent):
         return self.driver.set_window_size(int(width), int(height))
 
     @keyword
-    def get_page_size(self):
-        """Returns current page width and height as integers.
+    def get_inner_window_size(self):
+        """Returns current inner window width and height as integers.
 
-        See also `Set Page Size`.
+        See also `Set Inner Window Size`.
 
         Example:
-        | ${width} | ${height}= | `Get Page Size` |
+        | ${width} | ${height}= | `Get Inner Window Size` |
 
         The main difference with `Get Window Size` is that you receive
-        the page size, excluding the browser bars, borders and so on.
+        the inner size, excluding the browser bars, borders and so on.
         """
         inner_width = int(self.driver.execute_script("window.innerWidth"))
         inner_height = int(self.driver.execute_script("window.innerHeight"))
@@ -206,12 +206,12 @@ class WindowKeywords(LibraryComponent):
         return inner_width, inner_height
 
     @keyword
-    def set_page_size(self, width, height):
+    def set_inner_window_size(self, width, height):
         """Sets current windows size adapted to contain page
         with given ``width`` and ``height``.
 
         The main difference with `Set Window Size` is that you can give
-        the page size required, excluding the browser bars, borders and so on.
+        the inner size required, excluding the browser bars, borders and so on.
         The window size is adapted to provide the correct page size for each browser.
 
         Values can be given using strings containing numbers or by using
@@ -222,7 +222,7 @@ class WindowKeywords(LibraryComponent):
         size.
 
         Example:
-        | `Set Page Size` | 800 | 600 |
+        | `Set Inner Window Size` | 800 | 600 |
         """
         self.driver.set_window_size(int(width), int(height))
         inner_width = int(self.driver.execute_script("window.innerWidth"))

--- a/src/SeleniumLibrary/keywords/window.py
+++ b/src/SeleniumLibrary/keywords/window.py
@@ -189,6 +189,51 @@ class WindowKeywords(LibraryComponent):
         return self.driver.set_window_size(int(width), int(height))
 
     @keyword
+    def get_page_size(self):
+        """Returns current page width and height as integers.
+
+        See also `Set Page Size`.
+
+        Example:
+        | ${width} | ${height}= | `Get Page Size` |
+
+        The main difference with `Get Window Size` is that you receive
+        the page size, excluding the browser bars, borders and so on.
+        """
+        inner_width = int(self.driver.execute_script("window.innerWidth"))
+        inner_height = int(self.driver.execute_script("window.innerHeight"))
+
+        return inner_width, inner_height
+
+    @keyword
+    def set_page_size(self, width, height):
+        """Sets current windows size adapted to contain page
+        with given ``width`` and ``height``.
+
+        The main difference with `Set Window Size` is that you can give
+        the page size required, excluding the browser bars, borders and so on.
+        The window size is adapted to provide the correct page size for each browser.
+
+        Values can be given using strings containing numbers or by using
+        actual numbers. See also `Get Window Size` and `Set Window Size` .
+
+        Browsers have a limit how small they can be set. Trying to set them
+        smaller will cause the actual size to be bigger than the requested
+        size.
+
+        Example:
+        | `Set Page Size` | 800 | 600 |
+        """
+        self.driver.set_window_size(int(width), int(height))
+        inner_width = int(self.driver.execute_script("window.innerWidth"))
+        inner_height = int(self.driver.execute_script("window.innerHeight"))
+        width_offset = width - inner_width
+        height_offset = height - inner_height
+        window_width = width + width_offset
+        window_height = height + height_offset
+        return self.driver.set_window_size(int(window_width), int(window_height))
+
+    @keyword
     def get_window_position(self):
         """Returns current window position.
 

--- a/src/SeleniumLibrary/keywords/window.py
+++ b/src/SeleniumLibrary/keywords/window.py
@@ -207,21 +207,22 @@ class WindowKeywords(LibraryComponent):
         | `Set Window Size` | 800 | 600 | True |
         """
         width, height = int(width), int(height)
-        if is_truthy(inner):
-            self.driver.set_window_size(width, height)
-            inner_width = int(self.driver.execute_script("return window.innerWidth;"))
-            inner_height = int(self.driver.execute_script("return window.innerHeight;"))
-            width_offset = width - inner_width
-            height_offset = height - inner_height
-            window_width = width + width_offset
-            window_height = height + height_offset
-            size = self.driver.set_window_size(window_width, window_height)
-            result_width = int(self.driver.execute_script("return window.innerWidth;"))
-            result_height = int(self.driver.execute_script("return window.innerHeight;"))
-            if result_width != width or result_height != height:
-                raise AssertionError("Keyword failed setting correct window size.")
-            return size['width'], size['height']
-        return self.driver.set_window_size(width, height)
+        if is_falsy(inner):
+            return self.driver.set_window_size(width, height)
+        self.driver.set_window_size(width, height)
+        inner_width = int(self.driver.execute_script("return window.innerWidth;"))
+        inner_height = int(self.driver.execute_script("return window.innerHeight;"))
+        self.info('window.innerWidth is %s and window.innerHeight is %s' % (inner_width, inner_height))
+        width_offset = width - inner_width
+        height_offset = height - inner_height
+        window_width = width + width_offset
+        window_height = height + height_offset
+        self.info('Setting window size to %s %s' % (window_width, window_height))
+        self.driver.set_window_size(window_width, window_height)
+        result_width = int(self.driver.execute_script("return window.innerWidth;"))
+        result_height = int(self.driver.execute_script("return window.innerHeight;"))
+        if result_width != width or result_height != height:
+            raise AssertionError("Keyword failed setting correct window size.")
 
     @keyword
     def get_window_position(self):

--- a/src/SeleniumLibrary/keywords/window.py
+++ b/src/SeleniumLibrary/keywords/window.py
@@ -199,6 +199,9 @@ class WindowKeywords(LibraryComponent):
         See `Boolean arguments` for more details how to set boolean
         arguments.
 
+        This keyword does NOT support Frames. If a frame is selected,
+        switch to default before running this.
+
         Example:
         | `Set Window Size` | 800 | 600 |
         | `Set Window Size` | 800 | 600 | True |
@@ -212,7 +215,12 @@ class WindowKeywords(LibraryComponent):
             height_offset = height - inner_height
             window_width = width + width_offset
             window_height = height + height_offset
-            return self.driver.set_window_size(window_width, window_height)
+            res = self.driver.set_window_size(window_width, window_height)
+            result_width = int(self.driver.execute_script("return window.innerWidth;"))
+            result_height = int(self.driver.execute_script("return window.innerHeight;"))
+            if result_width != width or result_height != height:
+                raise AssertionError("Keyword failed setting correct window size.")
+            return res
         return self.driver.set_window_size(width, height)
 
     @keyword

--- a/src/SeleniumLibrary/keywords/window.py
+++ b/src/SeleniumLibrary/keywords/window.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 import time
 
-from SeleniumLibrary.utils import is_falsy, timestr_to_secs
+from SeleniumLibrary.utils import is_truthy, is_falsy, timestr_to_secs
 from selenium.common.exceptions import NoSuchWindowException
 
 from SeleniumLibrary.base import keyword, LibraryComponent
@@ -166,21 +166,21 @@ class WindowKeywords(LibraryComponent):
 
         See also `Set Window Size`.
 
-        With optional `inner` parameter you receive
-        the inner size, excluding the browser bars, borders and so on.
+        If ``inner`` parameter is set to True, keyword returns
+        HTML DOM window.innerWidth and window.innerHeight properties.
+        See `Boolean arguments` for more details how to set boolean
+        arguments.
 
         Example:
         | ${width} | ${height}= | `Get Window Size` |
         | ${width} | ${height}= | `Get Window Size` | True |
         """
-        if inner == True:
+        if is_truthy(inner):
             inner_width = int(self.driver.execute_script("return window.innerWidth;"))
             inner_height = int(self.driver.execute_script("return window.innerHeight;"))
-
             return inner_width, inner_height
-        else:
-            size = self.driver.get_window_size()
-            return size['width'], size['height']
+        size = self.driver.get_window_size()
+        return size['width'], size['height']
 
     @keyword
     def set_window_size(self, width, height, inner=False):
@@ -193,26 +193,27 @@ class WindowKeywords(LibraryComponent):
         smaller will cause the actual size to be bigger than the requested
         size.
 
-        With optional `inner` parameter you can give
-        the inner size required, excluding the browser bars, borders and so on.
-        The window size is adapted to provide the correct page size for each browser.
-
+        If ``inner`` parameter is set to True, keyword sets the necessary
+        window width and height to have the desired HTML DOM window.innerWidth
+        and window.innerHeight
+        See `Boolean arguments` for more details how to set boolean
+        arguments.
 
         Example:
         | `Set Window Size` | 800 | 600 |
         | `Set Window Size` | 800 | 600 | True |
         """
-        if inner == True:
-            self.driver.set_window_size(int(width), int(height))
-            inner_width = self.driver.execute_script("return window.innerWidth;")
-            inner_height = self.driver.execute_script("return window.innerHeight;")
-            width_offset = int(width) - int(inner_width)
-            height_offset = int(height) - int(inner_height)
-            window_width = int(width) + int(width_offset)
-            window_height = int(height) + int(height_offset)
-            return self.driver.set_window_size(int(window_width), int(window_height))
-        else:
-            return self.driver.set_window_size(int(width), int(height))
+        width, height = int(width), int(height)
+        if is_truthy(inner):
+            self.driver.set_window_size(width, height)
+            inner_width = int(self.driver.execute_script("return window.innerWidth;"))
+            inner_height = int(self.driver.execute_script("return window.innerHeight;"))
+            width_offset = width - inner_width
+            height_offset = height - inner_height
+            window_width = width + width_offset
+            window_height = height + height_offset
+            return self.driver.set_window_size(window_width, window_height)
+        return self.driver.set_window_size(width, height)
 
     @keyword
     def get_window_position(self):

--- a/src/SeleniumLibrary/keywords/window.py
+++ b/src/SeleniumLibrary/keywords/window.py
@@ -200,8 +200,8 @@ class WindowKeywords(LibraryComponent):
         The main difference with `Get Window Size` is that you receive
         the inner size, excluding the browser bars, borders and so on.
         """
-        inner_width = int(self.driver.execute_script("window.innerWidth"))
-        inner_height = int(self.driver.execute_script("window.innerHeight"))
+        inner_width = int(self.driver.execute_script("return window.innerWidth;"))
+        inner_height = int(self.driver.execute_script("return window.innerHeight;"))
 
         return inner_width, inner_height
 
@@ -225,12 +225,12 @@ class WindowKeywords(LibraryComponent):
         | `Set Inner Window Size` | 800 | 600 |
         """
         self.driver.set_window_size(int(width), int(height))
-        inner_width = int(self.driver.execute_script("window.innerWidth"))
-        inner_height = int(self.driver.execute_script("window.innerHeight"))
-        width_offset = width - inner_width
-        height_offset = height - inner_height
-        window_width = width + width_offset
-        window_height = height + height_offset
+        inner_width = self.driver.execute_script("return window.innerWidth;")
+        inner_height = self.driver.execute_script("return window.innerHeight;")
+        width_offset = int(width) - int(inner_width)
+        height_offset = int(height) - int(inner_height)
+        window_width = int(width) + int(width_offset)
+        window_height = int(height) + int(height_offset)
         return self.driver.set_window_size(int(window_width), int(window_height))
 
     @keyword


### PR DESCRIPTION
This keywords allows users to define/receve the window sizing by the desired inner size.
This is mission-critical when you need a specific size (for layout breakpoints or more)