### PR TITLE
Update Choose File doc to mention support for grid

### DIFF
--- a/src/SeleniumLibrary/keywords/formelement.py
+++ b/src/SeleniumLibrary/keywords/formelement.py
@@ -197,10 +197,12 @@ class FormElementKeywords(LibraryComponent):
 
         This keyword is most often used to input files into upload forms.
         The file specified with ``file_path`` must be available on machine
-        where tests are executed. When using Selenium Grid, Selenium
-        will, magically, transfer the file from the local file system
-        to the node file system. Then Selenium will send the file path,
-        from to node file system, to the browser.
+        where tests are executed. When using Selenium Grid, Seleniun will,
+        [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_remote/selenium.webdriver.remote.command.html?highlight=upload#selenium.webdriver.remote.command.Command.UPLOAD_FILE|magically],
+        transfer the file from the machine where test are executed
+        to the Selenium Grid node where the browser is running. 
+        Then Selenium will send the file path, from to node file 
+        system, to the browser.
 
         Example:
         | `Choose File` | my_upload_field | ${CURDIR}/trades.csv |

--- a/src/SeleniumLibrary/keywords/formelement.py
+++ b/src/SeleniumLibrary/keywords/formelement.py
@@ -197,7 +197,10 @@ class FormElementKeywords(LibraryComponent):
 
         This keyword is most often used to input files into upload forms.
         The file specified with ``file_path`` must be available on machine
-        where tests are executed.
+        where tests are executed. When using Selenium Grid, Selenium
+        will, magically, transfer the file from the local file system
+        to the node file system. Then Selenium will send the file path,
+        from to node file system, to the browser.
 
         Example:
         | `Choose File` | my_upload_field | ${CURDIR}/trades.csv |


### PR DESCRIPTION
The Selenium will, magically, transfer the file from the file system where Robot Framework is running to the Selenium Grid node file system. Selenium will ensure that file is transferred to know location, like %TMP% or $TMP and file system does not have to same (Example transfer from Windows to Linux works fine.) 

Fixes #449