### PR TITLE
Get latest ChromeDriver in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 before_install:
   - CDVERSION=`curl http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
   - echo $CDVERSION
-  - wget --no-verbose http://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip
+  - wget --no-verbose http://chromedriver.storage.googleapis.com/$CDVERSION/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - sudo chmod u+x chromedriver
   - sudo mv chromedriver /usr/bin/

--- a/atest/acceptance/keywords/press_keys.robot
+++ b/atest/acceptance/keywords/press_keys.robot
@@ -13,21 +13,33 @@ Press Keys Normal Keys
     Wait Until Page Contains    AAAAA
 
 Press Keys Normal Keys Many Times
+    [Documentation]    Marked temporally as non-critical because Chrome 76 has bug with
+    ...    Selenium ActionChains
+    [Tags]    known issue chrome    known issue headlesschrome
     Press Keys    text_field    AAAAA+BBB
     Click Button    OK
     Wait Until Page Contains    AAAAABBB
 
 Press Keys Sends c++
+    [Documentation]    Marked temporally as non-critical because Chrome 76 has bug with
+    ...    Selenium ActionChains
+    [Tags]    known issue chrome    known issue headlesschrome
     Press Keys    text_field    c++
     Click Button    OK
     Wait Until Page Contains    c+
 
 Press Keys Normal Keys Many Arguments
+    [Documentation]    Marked temporally as non-critical because Chrome 76 has bug with
+    ...    Selenium ActionChains
+    [Tags]    known issue chrome    known issue headlesschrome
     Press Keys    text_field    ccc    DDDD
     Click Button    OK
     Wait Until Page Contains    cccDDDD
 
 Press Keys Normal Keys Many Times With Many Args
+    [Documentation]    Marked temporally as non-critical because Chrome 76 has bug with
+    ...    Selenium ActionChains
+    [Tags]    known issue chrome    known issue headlesschrome
     Press Keys    text_field    a+b    C+D
     Click Button    OK
     Wait Until Page Contains    abCD
@@ -38,6 +50,9 @@ Press Keys Special Keys SHIFT
     Wait Until Page Contains    CC
 
 Press Keys Special Keys SHIFT Many Times
+    [Documentation]    Marked temporally as non-critical because Chrome 76 has bug with
+    ...    Selenium ActionChains
+    [Tags]    known issue chrome    known issue headlesschrome
     Press Keys    text_field    SHIFT+cc    SHIFT+dd
     Click Button    OK
     Wait Until Page Contains    CCDD     timeout=3
@@ -52,16 +67,25 @@ Press Keys To Multiple Elements
     Page Should Contain Element     //p[text()="tidii"]    limit=4
 
 Press Keys ASCII Code Send As Is
+    [Documentation]    Marked temporally as non-critical because Chrome 76 has bug with
+    ...    Selenium ActionChains
+    [Tags]    known issue chrome    known issue headlesschrome
     Press Keys    text_field    \\108    \\13
     Click Button    OK
     Wait Until Page Contains    \\108\\13     timeout=3
 
 Press Keys With Scandic Letters
+    [Documentation]    Marked temporally as non-critical because Chrome 76 has bug with
+    ...    Selenium ActionChains
+    [Tags]    known issue chrome    known issue headlesschrome
     Press Keys    text_field    ÖÄÖÄÖ    ÅÖÄP
     Click Button    OK
     Wait Until Page Contains    ÖÄÖÄÖÅÖÄP     timeout=3
 
 Press Keys With Asian Text
+    [Documentation]    Marked temporally as non-critical because Chrome 76 has bug with
+    ...    Selenium ActionChains
+    [Tags]    known issue chrome    known issue headlesschrome
     Press Keys    text_field    田中さんにあげ+て下    さい
     Click Button    OK
     Wait Until Page Contains    田中さんにあげて下さい     timeout=3

--- a/atest/acceptance/keywords/scroll_into_view.robot
+++ b/atest/acceptance/keywords/scroll_into_view.robot
@@ -8,6 +8,9 @@ ${TEXT}=   You scrolled in div.
 
 *** Test Cases ***
 Verify Scroll Element Into View
+    [Documentation]    Marked temporally as non-critical because Chrome 76 has bug with
+    ...    Selenium ActionChains
+    [Tags]    known issue chrome    known issue headlesschrome
     [Setup]    Go To Page "scroll/index.html"
     ${initial_postion}=    Get Vertical Position    css:#target
     Scroll Element Into View    css:#target


### PR DESCRIPTION
There is still problems with ChromeDriver 76, which is the current latest, but the ChromeDriver 74 is not anymore compatible with Chrome 76 and in practice all acceptance tests do fail with ChromeDriver 74. But with ChromeDriver 76 has only 9 failures. 