### PR TITLE
Added keywords for minimizing and fullscreening window

### DIFF
--- a/atest/acceptance/windows.robot
+++ b/atest/acceptance/windows.robot
@@ -195,6 +195,40 @@ Select Window With Delay By Special Locator
     Select Window    main
     Title Should Be    Click link to show a popup window
 
+Maximize Window
+    [Documentation]    Maximizing the window does not change the window size
+    ...    in headlesschrome.
+    [Tags]    known issue headlesschrome
+    Set Window Size    301    302
+    ${width}    ${height}=    Get Window Size
+    Maximize Browser Window
+    ${max width}    ${max height}=    Get Window Size
+    Verify Window Size Does Not Equal
+    ...    ${width}    ${height}    ${max width}    ${max height}
+
+Minimize Window
+    [Documentation]    Minimizing the window does not change the window size
+    ...    in headlesschrome.
+    [Tags]    known issue headlesschrome
+    Set Window Size    301    302
+    Maximize Browser Window
+    ${width}    ${height}=    Get Window Size
+    Minimize Browser Window
+    ${min width}    ${min height}=    Get Window Size
+    Verify Window Size Does Not Equal
+    ...    ${width}    ${height}    ${min width}    ${min height}
+
+Fullscreen Window
+    [Documentation]    Fullscreening the window does not change the window size
+    ...    in headlesschrome.
+    [Tags]    known issue headlesschrome
+    Set Window Size    301    302
+    ${width}    ${height}=    Get Window Size
+    Fullscreen Browser Window
+    ${full width}    ${full height}=    Get Window Size
+    Verify Window Size Does Not Equal
+    ...    ${width}    ${height}    ${full width}    ${full height}
+
 *** Keywords ***
 Open Popup Window, Select It And Verify
     [Arguments]    ${window_id}
@@ -221,3 +255,8 @@ Wait Until New Window Is Open
 New Windows Should Be Open
     ${titles} =    Get Window Titles
     Should Be True    len(${titles}) > 1
+
+Verify Window Size Does Not Equal
+    [Arguments]    ${orig width}    ${orig height}    ${new width}    ${new height}
+    Should Not Be Equal As Numbers    ${orig width}    ${new width}
+    Should Not Be Equal As Numbers    ${orig height}    ${new height}

--- a/src/SeleniumLibrary/keywords/window.py
+++ b/src/SeleniumLibrary/keywords/window.py
@@ -156,6 +156,16 @@ class WindowKeywords(LibraryComponent):
         self.driver.maximize_window()
 
     @keyword
+    def minimize_browser_window(self):
+        """Minimizes current browser window."""
+        self.driver.minimize_window()
+
+    @keyword
+    def fullscreen_browser_window(self):
+        """Fullscreens current browser window."""
+        self.driver.fullscreen_window()
+
+    @keyword
     def get_window_size(self, inner=False):
         """Returns current window width and height as integers.
 

--- a/utest/test/api/test_plugins.py
+++ b/utest/test/api/test_plugins.py
@@ -22,7 +22,7 @@ class ExtendingSeleniumLibrary(unittest.TestCase):
     def test_no_libraries(self):
         for item in [None, 'None', '']:
             sl = SeleniumLibrary(plugins=item)
-            self.assertEqual(len(sl.get_keyword_names()), 170)
+            self.assertEqual(len(sl.get_keyword_names()), 172)
 
     def test_parse_library(self):
         plugin = 'path.to.MyLibrary'


### PR DESCRIPTION
Two new keywords for managing browser window size. Happy to add tests if there is a good idea how to implement those. :)

Maybe something like this:

    Maximize Window
        Set Window Size    200    400
        ${width}    ${height}=    Get Window Size
        Maximize Browser Window
        ${max width}    ${max height}=    Get Window Size
        Verify Window Size Does Not Equal
        ...    ${width}    ${height}    ${max width}    ${max height}

    Minimize Window 
        Set Window Size    200    400
        ${width}    ${height}=    Get Window Size
        Minimize Browser Window
        ${min width}    ${min height}=    Get Window Size
        Verify Window Size Does Not Equal
        ...    ${width}    ${height}    ${min width}    ${min height}

    Fullscreen Window
        Set Window Size    200    400
        ${width}    ${height}=    Get Window Size
        Fullscreen Browser Window
        ${full width}    ${full height}=    Get Window Size
        Verify Window Size Does Not Equal
        ...    ${width}    ${height}    ${full width}    ${full height}

Where Verify Window Size Does not Equal would be

    Verify Window Size Does Not Equal
        [Arguments]    ${orig width}    ${orig height}    ${new width}    ${new height}
        Should Not Be Equal As Numbers    ${orig width}    ${new width}
        Should Not Be Equal As Numbers    ${orig height}    ${new height}