### PR TITLE
fixed typos, punctuation, and formulation in Keyword/lib documentation.

### DIFF
--- a/src/SeleniumLibrary/__init__.py
+++ b/src/SeleniumLibrary/__init__.py
@@ -78,7 +78,7 @@ class SeleniumLibrary(DynamicCore):
 
     === Default locator strategy ===
 
-    By default locators are considered to use the keyword specific default
+    By default, locators are considered to use the keyword specific default
     locator strategy. All keywords support finding elements based on ``id``
     and ``name`` attributes, but some keywords support additional attributes
     or other values that make sense in their context. For example, `Click
@@ -106,7 +106,7 @@ class SeleniumLibrary(DynamicCore):
 
     The explicit locator strategy is specified with a prefix using either
     syntax ``strategy:value`` or ``strategy=value``. The former syntax
-    is preferred, because the latter is identical to Robot Framework's
+    is preferred because the latter is identical to Robot Framework's
     [http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#named-argument-syntax|
     named argument syntax] and that can cause problems. Spaces around
     the separator are ignored, so ``id:foo``, ``id: foo`` and ``id : foo``
@@ -138,7 +138,7 @@ class SeleniumLibrary(DynamicCore):
     Different locator strategies have different pros and cons. Using ids,
     either explicitly like ``id:foo`` or by using the `default locator
     strategy` simply like ``foo``, is recommended when possible, because
-    the syntax is simple and locating elements by an id is fast for browsers.
+    the syntax is simple and locating elements by id is fast for browsers.
     If an element does not have an id or the id is not stable, other
     solutions need to be used. If an element has a unique tag name or class,
     using ``tag``, ``class`` or ``css`` strategy like ``tag:h1``,
@@ -198,8 +198,8 @@ class SeleniumLibrary(DynamicCore):
 
     This keyword is a reimplementation of the basic functionality of the
     ``id`` locator where ``${browser}`` is a reference to a WebDriver
-    instance and ``${locator}`` is name of the locator strategy. To use
-    this locator it must first be registered by using the
+    instance and ``${locator}`` is the name of the locator strategy. To use
+    this locator, it must first be registered by using the
     `Add Location Strategy` keyword:
 
     | `Add Location Strategy` | custom | Custom Locator Strategy |
@@ -214,41 +214,41 @@ class SeleniumLibrary(DynamicCore):
 
     = Browser and Window =
 
-    There is different conseptual meaning when SeleniumLibrary talks
-    windows and browsers. This chapter explains those differences.
+    There is different conceptual meaning when SeleniumLibrary talks
+    about windows or browsers. This chapter explains those differences.
 
     == Browser ==
 
     When `Open Browser` or `Create WebDriver` keyword is called, it
     will create a new Selenium WebDriver instance by using the
     [https://www.seleniumhq.org/docs/03_webdriver.jsp|Selenium WebDriver]
-    API. In SeleniumLibrary terms, a new broser is created. It is
+    API. In SeleniumLibrary terms, a new browser is created. It is
     possible to start multiple independent browsers (Selenium Webdriver
     instances) at the same time, by calling `Open Browser` or
     `Create WebDriver` multiple times. These browsers are usually
-    independent to each other and do not share data like cookies,
-    sessions or profiles. Typicall when browser starts, it
-    creates a single window in the desktop.
-    
+    independent of each other and do not share data like cookies,
+    sessions or profiles. Typically when the browser starts, it
+    creates a single window which is shown to the user.
+
     == Window ==
 
     Windows are the part of a browser that loads the web site and presents
-    it to the user. All content of the site is content of the window.
-    Windows are children of a WebDriver instance, in SeleniumLibrary
-    WebDriver is referred as browser. One browser may have multiple
-    windows. Windows can appear as tabs or as separate windows with
-    different position and size. Windows belonning to the same browser
+    it to the user. All content of the site is the content of the window.
+    Windows are children of a browser. In SeleniumLibrary browser is a
+    synonym for WebDriver instance. One browser may have multiple
+    windows. Windows can appear as tabs, as separate windows or pop-ups with
+    different position and size. Windows belonging to the same browser
     typically share the sessions detail, like cookies. If there is a
     need to separate sessions detail, example login with two different
-    users, two browser (Selenium WebDriver instances) must be created.
+    users, two browsers (Selenium WebDriver instances) must be created.
     New windows can be opened example by the application under test or
     by example `Execute Javascript` keyword:
 
     | `Execute Javascript`    window.open()    # Opens a new window with location about:blank
 
-    In the example in below opens multiple browser and windows,
+    The example below opens multiple browsers and windows,
     to demonstrate how the different keywords can be used to interact
-    with a browser and windows attached to the browser.
+    with browsers, and windows attached to these browsers.
 
     Structure:
     | BrowserA
@@ -263,7 +263,7 @@ class SeleniumLibrary(DynamicCore):
     | `Open Browser`       | https://robotframework.org         | ${BROWSER}       | alias=BrowserA   | # BrowserA with first window is opened.                                       |
     | `Execute Javascript` | window.open()                      |                  |                  | # In BrowserA second window is opened.                                        |
     | `Switch Window`      | locator=NEW                        |                  |                  | # Switched to second window in BrowserA                                       |
-    | `Go To`              | https://robocon.io                 |                  |                  | # Second window navigates to to robocon site.                                 |
+    | `Go To`              | https://robocon.io                 |                  |                  | # Second window navigates to robocon site.                                    |
     | `Execute Javascript` | window.open()                      |                  |                  | # In BrowserA third window is opened.                                         |
     | ${handle}            | `Switch Window`                    | locator=NEW      |                  | # Switched to third window in BrowserA                                        |
     | `Go To`              | https://github.com/robotframework/ |                  |                  | # Third windows goes to robot framework github site.                          |
@@ -271,9 +271,9 @@ class SeleniumLibrary(DynamicCore):
     | ${location}          | `Get Location`                     |                  |                  | # ${location} is: https://www.github.com                                      |
     | `Switch Window`      | ${handle}                          | browser=BrowserA |                  | # BrowserA second windows is selected.                                        |
     | ${location}          | `Get Location`                     |                  |                  | # ${location} = https://robocon.io/                                           |
-    | @{locations 1}       | `Get Locations`                    |                  |                  | # By default lists locations under the currectly active browser.              |
+    | @{locations 1}       | `Get Locations`                    |                  |                  | # By default, lists locations under the currectly active browser (BrowserA).   |
     | @{locations 2}       | `Get Locations`                    |  browser=ALL     |                  | # By using browser=ALL argument keyword list all locations from all browsers. |
-    
+
     The above example, @{locations 1} contains the following items:
     https://robotframework.org/, https://robocon.io/ and
     https://github.com/robotframework/'. The @{locations 2}
@@ -281,12 +281,12 @@ class SeleniumLibrary(DynamicCore):
     https://robocon.io/, https://github.com/robotframework/'
     and 'https://github.com/.
 
-    = Timeouts, waits and delays =
+    = Timeouts, waits, and delays =
 
     This section discusses different ways how to wait for elements to
     appear on web pages and to slow down execution speed otherwise.
     It also explains the `time format` that can be used when setting various
-    timeouts, waits and delays.
+    timeouts, waits, and delays.
 
     == Timeout ==
 
@@ -294,8 +294,8 @@ class SeleniumLibrary(DynamicCore):
     ``timeout`` argument that specifies how long these keywords should
     wait for certain events or actions. These keywords include, for example,
     ``Wait ...`` keywords and keywords related to alerts. Additionally
-    `Execute Async Javascript`. although it does not have ``timeout``,
-    argument, uses timeout to define how long asynchronous JavaScript
+    `Execute Async Javascript`. Although it does not have ``timeout``,
+    argument, uses a timeout to define how long asynchronous JavaScript
     can run.
 
     The default timeout these keywords use can be set globally either by
@@ -318,7 +318,7 @@ class SeleniumLibrary(DynamicCore):
     Selenium execution speed can be slowed down globally by using `Set
     Selenium speed` keyword. This functionality is designed to be used for
     demonstrating or debugging purposes. Using it to make sure that elements
-    appear on a page is not a good idea, and the above explained timeouts
+    appear on a page is not a good idea. The above-explained timeouts
     and waits should be used instead.
 
     See `time format` below for supported syntax.
@@ -334,14 +334,14 @@ class SeleniumLibrary(DynamicCore):
     = Run-on-failure functionality =
 
     SeleniumLibrary has a handy feature that it can automatically execute
-    a keyword if any of its own keywords fails. By default it uses the
+    a keyword if any of its own keywords fails. By default, it uses the
     `Capture Page Screenshot` keyword, but this can be changed either by
     using the `Register Keyword To Run On Failure` keyword or with the
     ``run_on_failure`` argument when `importing` the library. It is
     possible to use any keyword from any imported library or resource file.
 
-    The run-on-failure functionality can be disabled by using a special
-    value ``NOTHING`` or anything considered false (see `Boolean arguments`)
+    The run-on-failure functionality can be disabled by using a special value
+    ``NOTHING`` or anything considered false (see `Boolean arguments`)
     such as ``NONE``.
 
     = Boolean arguments =
@@ -349,8 +349,8 @@ class SeleniumLibrary(DynamicCore):
     Some keywords accept arguments that are handled as Boolean values true or
     false. If such an argument is given as a string, it is considered false if
     it is either empty or case-insensitively equal to ``false``, ``no``, ``off``,
-     ``0`` or ``none``. Other strings are considered true regardless their value, and
-    other argument types are tested using same
+     ``0`` or ``none``. Other strings are considered true regardless of their value and
+    other argument types are tested using the same
     [https://docs.python.org/3/library/stdtypes.html#truth-value-testing|rules as in Python].
 
     True examples:
@@ -379,22 +379,22 @@ class SeleniumLibrary(DynamicCore):
     [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.event_firing_webdriver.html#module-selenium.webdriver.support.event_firing_webdriver|EventFiringWebDriver].
     See the Selenium and SeleniumLibrary
     [https://github.com/robotframework/SeleniumLibrary/blob/master/docs/extending/extending.rst#EventFiringWebDriver|EventFiringWebDriver support]
-    documentation for futher details.
+    documentation for further details.
 
     EventFiringWebDriver is new in SeleniumLibrary 4.0
 
     = Thread support =
 
-    SeleniumLibrary is not thread safe. This is mainly due because the underlying
+    SeleniumLibrary is not thread-safe. This is mainly due because the underlying
     [https://github.com/SeleniumHQ/selenium/wiki/Frequently-Asked-Questions#q-is-webdriver-thread-safe|
-    Selenium tool is not thread safe] within one browser/driver instance.
+    Selenium tool is not thread-safe] within one browser/driver instance.
     Because of the limitation in the Selenium side, the keywords or the
-    API provided by the SeleniumLibrary is not thread safe.
+    API provided by the SeleniumLibrary is not thread-safe.
 
     = Plugins =
 
     SeleniumLibrary offers plugins as a way to modify and add library keywords and modify some of the internal
-    functionality without creating new library or hacking the source code. See
+    functionality without creating a new library or hacking the source code. See
     [https://github.com/robotframework/SeleniumLibrary/blob/master/docs/extending/extending.rst#Plugins|plugin API]
     documentation for further details.
 
@@ -519,7 +519,7 @@ class SeleniumLibrary(DynamicCore):
     def failure_occurred(self):
         """Method that is executed when a SeleniumLibrary keyword fails.
 
-        By default executes the registered run-on-failure keyword.
+        By default, executes the registered run-on-failure keyword.
         Libraries extending SeleniumLibrary can overwrite this hook
         method if they want to provide custom functionality instead.
         """
@@ -552,7 +552,7 @@ class SeleniumLibrary(DynamicCore):
             See library documentation for the supported locator syntax.
         :type locator: str or selenium.webdriver.remote.webelement.WebElement
         :param parent: Optional parent `WebElememt` to search child elements
-            from. By default search starts from the root using `WebDriver`.
+            from. By default, search starts from the root using `WebDriver`.
         :type parent: selenium.webdriver.remote.webelement.WebElement
         :return: Found `WebElement`.
         :rtype: selenium.webdriver.remote.webelement.WebElement
@@ -567,7 +567,7 @@ class SeleniumLibrary(DynamicCore):
             See library documentation for the supported locator syntax.
         :type locator: str or selenium.webdriver.remote.webelement.WebElement
         :param parent: Optional parent `WebElememt` to search child elements
-            from. By default search starts from the root using `WebDriver`.
+            from. By default, search starts from the root using `WebDriver`.
         :type parent: selenium.webdriver.remote.webelement.WebElement
         :return: list of found `WebElement` or e,mpty if elements are not found.
         :rtype: list[selenium.webdriver.remote.webelement.WebElement]

--- a/src/SeleniumLibrary/base/context.py
+++ b/src/SeleniumLibrary/base/context.py
@@ -63,7 +63,7 @@ class ContextAware(object):
             true, return `None` otherwise.
         :type required: True or False
         :param parent: Optional parent `WebElememt` to search child elements
-            from. By default search starts from the root using `WebDriver`.
+            from. By default, search starts from the root using `WebDriver`.
         :type parent: selenium.webdriver.remote.webelement.WebElement
         :return: Found `WebElement` or `None` if element not found and
             `required` is false.
@@ -82,7 +82,7 @@ class ContextAware(object):
         :param tag: Limit searching only to these elements.
         :type tag: str
         :param parent: Optional parent `WebElememt` to search child elements
-            from. By default search starts from the root using `WebDriver`.
+            from. By default, search starts from the root using `WebDriver`.
         :type parent: selenium.webdriver.remote.webelement.WebElement
         :return: list of found `WebElement` or empty if elements are not found.
         :rtype: list[selenium.webdriver.remote.webelement.WebElement]

--- a/src/SeleniumLibrary/keywords/alert.py
+++ b/src/SeleniumLibrary/keywords/alert.py
@@ -46,7 +46,7 @@ class AlertKeywords(LibraryComponent):
 
     @keyword
     def alert_should_be_present(self, text='', action=ACCEPT, timeout=None):
-        """Verifies that an alert is present and, by default, accepts it.
+        """Verifies that an alert is present and by default, accepts it.
 
         Fails if no alert is present. If ``text`` is a non-empty string,
         then it is used to verify alert's message. The alert is accepted
@@ -57,8 +57,8 @@ class AlertKeywords(LibraryComponent):
         If it is not given, the global default `timeout` is used instead.
 
         ``action`` and ``timeout`` arguments are new in SeleniumLibrary 3.0.
-        In earlier versions the alert was always accepted and timeout was
-        hard coded to one second.
+        In earlier versions, the alert was always accepted and a timeout was
+        hardcoded to one second.
         """
         message = self.handle_alert(action, timeout)
         if text and text != message:
@@ -70,12 +70,12 @@ class AlertKeywords(LibraryComponent):
         """Verifies that no alert is present.
 
         If the alert actually exists, the ``action`` argument determines
-        how it should be handled. By default the alert is accepted, but
+        how it should be handled. By default, the alert is accepted, but
         it can be also dismissed or left open the same way as with the
         `Handle Alert` keyword.
 
         ``timeout`` specifies how long to wait for the alert to appear.
-        By default the alert is not waited at all, but a custom time can
+        By default, is not waited for the alert at all, but a custom time can
         be given if alert may be delayed. See the `time format` section
         for information about the syntax.
 
@@ -92,7 +92,7 @@ class AlertKeywords(LibraryComponent):
     def handle_alert(self, action=ACCEPT, timeout=None):
         """Handles the current alert and returns its message.
 
-        By default the alert is accepted, but this can be controlled
+        By default, the alert is accepted, but this can be controlled
         with the ``action`` argument that supports the following
         case-insensitive values:
 

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -38,7 +38,7 @@ class BrowserManagementKeywords(LibraryComponent):
     def close_all_browsers(self):
         """Closes all open browsers and resets the browser cache.
 
-        After this keyword new indexes returned from `Open Browser` keyword
+        After this keyword, new indexes returned from `Open Browser` keyword
         are reset to 1.
 
         This keyword should be used in test or suite teardown to make sure
@@ -61,8 +61,8 @@ class BrowserManagementKeywords(LibraryComponent):
                      ff_profile_dir=None, options=None, service_log_path=None):
         """Opens a new browser instance to the given ``url``.
 
-        The ``browser`` argument specifies which browser to use, and the
-        supported browser are listed in the table below. The browser names
+        The ``browser`` argument specifies which browser to use. The
+        supported browsers are listed in the table below. The browser names
         are case-insensitive and some browsers have multiple supported names.
 
         |    = Browser =    |        = Name(s) =       |
@@ -90,11 +90,11 @@ class BrowserManagementKeywords(LibraryComponent):
         Optional ``alias`` is an alias given for this browser instance and
         it can be used for switching between browsers. When same ``alias``
         is given with two `Open Browser` keywords, the first keyword will
-        open new browser. But the second one will switch to the already
-        opened browser and will not open new browser. The ``alias``
+        open a new browser, but the second one will switch to the already
+        opened browser and will not open a new browser. The ``alias``
         definition overrules ``browser`` definition. When same ``alias``
-        is used but different ``browser`` is defined, then switch to
-        browser with same alias is done and new browser is not opened.
+        is used but a different ``browser`` is defined, then switch to
+        a browser with same alias is done and new browser is not opened.
         An alternative approach for switching is using an index returned
         by this keyword. These indices start from 1, are incremented when new
         browsers are opened, and reset back to 1 when `Close All Browsers`
@@ -106,7 +106,7 @@ class BrowserManagementKeywords(LibraryComponent):
         Optional ``desired_capabilities`` can be used to configure, for example,
         logging preferences for a browser or a browser and operating system
         when using [http://saucelabs.com|Sauce Labs]. Desired capabilities can
-        be given either as a Python dictionary or as a string in format
+        be given either as a Python dictionary or as a string in the format
         ``key1:value1,key2:value2``.
         [https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities|
         Selenium documentation] lists possible capabilities that can be
@@ -116,22 +116,22 @@ class BrowserManagementKeywords(LibraryComponent):
         directory if you wish to overwrite the default profile Selenium
         uses. Notice that prior to SeleniumLibrary 3.0, the library
         contained its own profile that was used by default. The
-        ``ff_profile_dir`` can also be instance of the
+        ``ff_profile_dir`` can also be an instance of the
         [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_firefox/selenium.webdriver.firefox.firefox_profile.html|selenium.webdriver.FirefoxProfile]
-        . As third option, it possible to use `FirefoxProfile` methods
-        and attributes to define the profile. Using method and attributes
-        in same way as with ``options`` argument. Example it is possible
+        . As a third option, it is possible to use `FirefoxProfile` methods
+        and attributes to define the profile using methods and attributes
+        in the same way as with ``options`` argument. Example: It is possible
         to use FirefoxProfile `set_preference` to define different
         profile settings.
 
-        Optional ``options`` argument allows to define browser specific
+        Optional ``options`` argument allows defining browser specific
         Selenium options. Example for Chrome, the ``options`` argument
         allows defining the following
         [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_chrome/selenium.webdriver.chrome.options.html#selenium.webdriver.chrome.options.Options|methods and attributes]
         and for Firefox these
         [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_firefox/selenium.webdriver.firefox.options.html?highlight=firefox#selenium.webdriver.firefox.options.Options|methods and attributes]
-        are available. Please note that not all browsers supported by the
-        SeleniumLibrary have Selenium options available. Therefore please
+        are available. Please note that not all browsers, supported by the
+        SeleniumLibrary, have Selenium options available. Therefore please
         consult the Selenium documentation which browsers do support
         the Selenium options. If ``browser`` argument is `android` then
         [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_chrome/selenium.webdriver.chrome.options.html#selenium.webdriver.chrome.options.Options|Chrome options]
@@ -142,31 +142,31 @@ class BrowserManagementKeywords(LibraryComponent):
         options in two different formats: as a string and as Python object
         which is an instance of the Selenium options class.
 
-        The string format allows to define Selenium options methods
+        The string format allows defining Selenium options methods
         or attributes and their arguments in Robot Framework test data.
         The method and attributes names are case and space sensitive and
         must match to the Selenium options methods and attributes names.
-        When defining a method, is must defined in similar way as in
+        When defining a method, it must be defined in a similar way as in
         python: method name, opening parenthesis, zero to many arguments
-        and closing parenthesis. If there is need to define multiple
+        and closing parenthesis. If there is a need to define multiple
         arguments for a single method, arguments must be separated with
         comma, just like in Python. Example: `add_argument("--headless")`
         or `add_experimental_option("key", "value")`. Attributes are
-        defined in similar way as in Python: attribute name, equal sing
+        defined in a similar way as in Python: attribute name, equal sign,
         and attribute value. Example, `headless=True`. Multiple methods
-        and attributes must separated by a semicolon, example:
+        and attributes must be separated by a semicolon. Example:
         `add_argument("--headless");add_argument("--start-maximized")`.
 
         Arguments allow defining Python data types and arguments are
         evaluated by using Python
         [https://docs.python.org/3/library/ast.html#ast.literal_eval|ast.literal_eval].
         Strings must be quoted with single or double quotes, example "value"
-        or 'value'. It is also possible define other Python builtin
+        or 'value'. It is also possible to define other Python builtin
         data types, example `True` or `None`, by not using quotes
         around the arguments.
 
-        The string format is space friendly and usually spaces do not alter
-        the defining the methods or attributes. There are two exceptions.
+        The string format is space friendly. Usually, spaces do not alter
+        the defining methods or attributes. There are two exceptions.
         In some Robot Framework test data formats, two or more spaces are
         considered as cell separator and instead of defining a single
         argument, two or more arguments may be defined. Spaces in string
@@ -176,9 +176,9 @@ class BrowserManagementKeywords(LibraryComponent):
         not same same as `add_argument ( "--headless" )`, because
         spaces inside of quotes are not removed.
 
-        As last format ``options`` argument also support receiving
+        As last format, ``options`` argument also supports receiving
         the Selenium options as Python class instance. In this case, the
-        instance is used as is and the SeleniumLibrary will not convert
+        instance is used as-is and the SeleniumLibrary will not convert
         the instance to other formats.
         For example, if the following code return value is saved to
         `${options}` variable in the Robot Framework data:
@@ -186,7 +186,7 @@ class BrowserManagementKeywords(LibraryComponent):
         | options.add_argument('--disable-dev-shm-usage')
         | return options
 
-        Then the `${options}` variable can be used as argument to
+        Then the `${options}` variable can be used as an argument to
         ``options``.
 
         Optional ``service_log_path`` argument defines the name of the
@@ -199,9 +199,10 @@ class BrowserManagementKeywords(LibraryComponent):
         format string syntax].
 
         Examples:
-        | `Open Browser` | http://example.com | Chrome  |
-        | `Open Browser` | http://example.com | Firefox | alias=Firefox |
+        | `Open Browser` | http://example.com | Chrome  |                                         |
+        | `Open Browser` | http://example.com | Firefox | alias=Firefox                           |
         | `Open Browser` | http://example.com | Edge    | remote_url=http://127.0.0.1:4444/wd/hub |
+        | `Open Browser` | about:blank        |         |                                         |
 
         Alias examples:
         | ${1_index} =    | `Open Browser` | http://example.com | Chrome  | alias=Chrome     | # Opens new browser because alias is new.         |
@@ -234,7 +235,7 @@ class BrowserManagementKeywords(LibraryComponent):
         Using ``alias`` to decide, is the new browser opened is new
         in SeleniumLibrary 4.0. The ``options`` and ``service_log_path``
         are new in SeleniumLibrary 4.0. Support for ``ff_profile_dir``
-        accepting instance of the `selenium.webdriver.FirefoxProfile`
+        accepting an instance of the `selenium.webdriver.FirefoxProfile`
         and support defining FirefoxProfile with methods and
         attributes are new in SeleniumLibrary 4.0.
         """
@@ -277,9 +278,9 @@ class BrowserManagementKeywords(LibraryComponent):
 
         Like `Open Browser`, but allows passing arguments to the created
         WebDriver instance directly. This keyword should only be used if
-        functionality provided by `Open Browser` is not adequate.
+        the functionality provided by `Open Browser` is not adequate.
 
-        ``driver_name`` must be an WebDriver implementation name like Firefox,
+        ``driver_name`` must be a WebDriver implementation name like Firefox,
         Chrome, Ie, Opera, Safari, PhantomJS, or Remote.
 
         The initialized WebDriver can be configured either with a Python
@@ -414,7 +415,7 @@ class BrowserManagementKeywords(LibraryComponent):
 
     @keyword
     def get_title(self):
-        """Returns the title of current page."""
+        """Returns the title of the current page."""
         return self.driver.title
 
     @keyword
@@ -424,14 +425,14 @@ class BrowserManagementKeywords(LibraryComponent):
 
     @keyword
     def location_should_be(self, url, message=None):
-        """Verifies that current URL is exactly ``url``.
+        """Verifies that the current URL is exactly ``url``.
 
         The ``url`` argument contains the exact url that should exist in browser.
 
         The ``message`` argument can be used to override the default error
         message.
 
-        ``message`` argument new in SeleniumLibrary 3.2.0.
+        ``message`` argument is new in SeleniumLibrary 3.2.0.
         """
         actual = self.get_location()
         if actual != url:
@@ -443,14 +444,14 @@ class BrowserManagementKeywords(LibraryComponent):
 
     @keyword
     def location_should_contain(self, expected, message=None):
-        """Verifies that current URL contains ``expected``.
+        """Verifies that the current URL contains ``expected``.
 
         The ``expected`` argument contains the expected value in url.
 
         The ``message`` argument can be used to override the default error
         message.
 
-        ``message`` argument new in SeleniumLibrary 3.2.0.
+        ``message`` argument is new in SeleniumLibrary 3.2.0.
         """
         actual = self.get_location()
         if expected not in actual:
@@ -481,14 +482,14 @@ class BrowserManagementKeywords(LibraryComponent):
 
     @keyword
     def log_title(self):
-        """Logs and returns the title of current page."""
+        """Logs and returns the title of the current page."""
         title = self.get_title()
         self.info(title)
         return title
 
     @keyword
     def title_should_be(self, title, message=None):
-        """Verifies that current page title equals ``title``.
+        """Verifies that the current page title equals ``title``.
 
         The ``message`` argument can be used to override the default error
         message.
@@ -522,7 +523,7 @@ class BrowserManagementKeywords(LibraryComponent):
     def get_selenium_speed(self):
         """Gets the delay that is waited after each Selenium command.
 
-        The value is returned as a human readable string like ``1 second``.
+        The value is returned as a human-readable string like ``1 second``.
 
         See the `Selenium Speed` section above for more information.
         """
@@ -532,7 +533,7 @@ class BrowserManagementKeywords(LibraryComponent):
     def get_selenium_timeout(self):
         """Gets the timeout that is used by various keywords.
 
-        The value is returned as a human readable string like ``1 second``.
+        The value is returned as a human-readable string like ``1 second``.
 
         See the `Timeout` section above for more information.
         """
@@ -542,7 +543,7 @@ class BrowserManagementKeywords(LibraryComponent):
     def get_selenium_implicit_wait(self):
         """Gets the implicit wait value used by Selenium.
 
-        The value is returned as a human readable string like ``1 second``.
+        The value is returned as a human-readable string like ``1 second``.
 
         See the `Implicit wait` section above for more information.
         """
@@ -553,7 +554,7 @@ class BrowserManagementKeywords(LibraryComponent):
         """Sets the delay that is waited after each Selenium command.
 
         The value can be given as a number that is considered to be
-        seconds or as a human readable string like ``1 second``.
+        seconds or as a human-readable string like ``1 second``.
         The previous value is returned and can be used to restore
         the original value later if needed.
 
@@ -573,7 +574,7 @@ class BrowserManagementKeywords(LibraryComponent):
         """Sets the timeout that is used by various keywords.
 
         The value can be given as a number that is considered to be
-        seconds or as a human readable string like ``1 second``.
+        seconds or as a human-readable string like ``1 second``.
         The previous value is returned and can be used to restore
         the original value later if needed.
 
@@ -595,7 +596,7 @@ class BrowserManagementKeywords(LibraryComponent):
         """Sets the implicit wait value used by Selenium.
 
         The value can be given as a number that is considered to be
-        seconds or as a human readable string like ``1 second``.
+        seconds or as a human-readable string like ``1 second``.
         The previous value is returned and can be used to restore
         the original value later if needed.
 

--- a/src/SeleniumLibrary/keywords/cookie.py
+++ b/src/SeleniumLibrary/keywords/cookie.py
@@ -33,7 +33,7 @@ class CookieKeywords(LibraryComponent):
 
     @keyword
     def delete_cookie(self, name):
-        """Deletes cookie matching ``name``.
+        """Deletes the cookie matching ``name``.
 
         If the cookie is not found, nothing happens.
         """
@@ -78,9 +78,9 @@ class CookieKeywords(LibraryComponent):
         | name          | The name of a cookie.                                      |
         | value         | Value of the cookie.                                       |
         | path          | Indicates a URL path, for example ``/``.                   |
-        | domain        | The domain the cookie is visible to.                       |
-        | secure        | When true, cookie is only used with HTTPS connections.     |
-        | httpOnly      | When true, cookie is not accessible via JavaScript.        |
+        | domain        | The domain, the cookie is visible to.                      |
+        | secure        | When true, the cookie is only used with HTTPS connections. |
+        | httpOnly      | When true, the cookie is not accessible via JavaScript.    |
         | expiry        | Python datetime object indicating when the cookie expires. |
         | extra         | Possible attributes outside of the WebDriver specification |
 
@@ -91,10 +91,10 @@ class CookieKeywords(LibraryComponent):
         [https://docs.python.org/3/library/datetime.html#datetime.datetime|datetime object],
         not as seconds since Unix Epoch like WebDriver natively does.
 
-        In some cases, example when running browser in the cloud, it is possible that
-        cookie contains other attributes than is defined in the
+        In some cases, example when running a browser in the cloud, it is possible that
+        the cookie contains other attributes than is defined in the
         [https://w3c.github.io/webdriver/#cookies|WebDriver specification].
-        These other attributes are available in a ``extra`` attribute in the cookie
+        These other attributes are available in an ``extra`` attribute in the cookie
         object and it contains a dictionary of the other attributes. The ``extra``
         attribute is new in SeleniumLibrary 4.0.
 
@@ -120,7 +120,7 @@ class CookieKeywords(LibraryComponent):
         ``name`` and ``value`` are required, ``path``, ``domain``, ``secure``
         and ``expiry`` are optional.  Expiry supports the same formats as
         the [http://robotframework.org/robotframework/latest/libraries/DateTime.html|DateTime]
-        library or an epoch time stamp.
+        library or an epoch timestamp.
 
         Example:
         | `Add Cookie` | foo | bar |                            |

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -39,13 +39,13 @@ class ElementKeywords(LibraryComponent):
 
     @keyword(name='Get WebElements')
     def get_webelements(self, locator):
-        """Returns list of WebElement objects matching the ``locator``.
+        """Returns a list of WebElement objects matching the ``locator``.
 
         See the `Locating elements` section for details about the locator
         syntax.
 
         Starting from SeleniumLibrary 3.0, the keyword returns an empty
-        list if there are no matching elements. In previous releases the
+        list if there are no matching elements. In previous releases, the
         keyword failed in this case.
         """
         return self.find_elements(locator)
@@ -63,7 +63,7 @@ class ElementKeywords(LibraryComponent):
         The ``ignore_case`` argument can be set to True to compare case
         insensitive, default is False. New in SeleniumLibrary 3.1.
 
-        ``ignore_case`` argument new in SeleniumLibrary 3.1.
+        ``ignore_case`` argument is new in SeleniumLibrary 3.1.
 
         Use `Element Text Should Be` if you want to match the exact text,
         not a substring.
@@ -82,7 +82,7 @@ class ElementKeywords(LibraryComponent):
 
     @keyword
     def element_should_not_contain(self, locator, expected, message=None, ignore_case=False):
-        """Verifies that element ``locator`` does not contains text ``expected``.
+        """Verifies that element ``locator`` does not contain text ``expected``.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -140,7 +140,7 @@ class ElementKeywords(LibraryComponent):
         contain one or more elements. When limit is a number, page must
         contain same number of elements.
 
-        See `Page Should Contain` for explanation about the ``loglevel``
+        See `Page Should Contain` for an explanation about the ``loglevel``
         argument.
 
         Examples assumes that locator matches to two elements.
@@ -185,7 +185,7 @@ class ElementKeywords(LibraryComponent):
     def page_should_not_contain(self, text, loglevel='TRACE'):
         """Verifies the current page does not contain ``text``.
 
-        See `Page Should Contain` for explanation about the ``loglevel``
+        See `Page Should Contain` for an explanation about the ``loglevel``
         argument.
         """
         if self._page_contains(text):
@@ -201,7 +201,7 @@ class ElementKeywords(LibraryComponent):
         See the `Locating elements` section for details about the locator
         syntax.
 
-        See `Page Should Contain` for explanation about ``message`` and
+        See `Page Should Contain` for an explanation about ``message`` and
         ``loglevel`` arguments.
         """
         self.assert_page_not_contains(locator, message=message,
@@ -209,7 +209,7 @@ class ElementKeywords(LibraryComponent):
 
     @keyword
     def assign_id_to_element(self, locator, id):
-        """Assigns temporary ``id`` to element specified by ``locator``.
+        """Assigns a temporary ``id`` to the element specified by ``locator``.
 
         This is mainly useful if the locator is complicated and/or slow XPath
         expression and it is needed multiple times. Identifier expires when
@@ -228,7 +228,7 @@ class ElementKeywords(LibraryComponent):
 
     @keyword
     def element_should_be_disabled(self, locator):
-        """Verifies that element identified with ``locator`` is disabled.
+        """Verifies that element identified by ``locator`` is disabled.
 
         This keyword considers also elements that are read-only to be
         disabled.
@@ -241,7 +241,7 @@ class ElementKeywords(LibraryComponent):
 
     @keyword
     def element_should_be_enabled(self, locator):
-        """Verifies that element identified with ``locator`` is enabled.
+        """Verifies that element identified by ``locator`` is enabled.
 
         This keyword considers also elements that are read-only to be
         disabled.
@@ -254,7 +254,7 @@ class ElementKeywords(LibraryComponent):
 
     @keyword
     def element_should_be_focused(self, locator):
-        """Verifies that element identified with ``locator`` is focused.
+        """Verifies that element identified by ``locator`` is focused.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -295,7 +295,7 @@ class ElementKeywords(LibraryComponent):
     def element_should_not_be_visible(self, locator, message=None):
         """Verifies that the element identified by ``locator`` is NOT visible.
 
-        Passes if element does not exists. See `Element Should Be Visible`
+        Passes if the element does not exists. See `Element Should Be Visible`
         for more information about visibility and supported arguments.
         """
         element = self.find_element(locator, required=False)
@@ -311,7 +311,7 @@ class ElementKeywords(LibraryComponent):
 
     @keyword
     def element_text_should_be(self, locator, expected, message=None, ignore_case=False):
-        """Verifies that element ``locator`` contains exact text ``expected``.
+        """Verifies that element ``locator`` contains exact the text ``expected``.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -322,7 +322,7 @@ class ElementKeywords(LibraryComponent):
         The ``ignore_case`` argument can be set to True to compare case
         insensitive, default is False.
 
-        ``ignore_case`` argument new in SeleniumLibrary 3.1.
+        ``ignore_case`` argument is new in SeleniumLibrary 3.1.
 
         Use `Element Should Contain` if a substring match is desired.
         """
@@ -341,7 +341,7 @@ class ElementKeywords(LibraryComponent):
 
     @keyword
     def element_text_should_not_be(self, locator, not_expected, message=None, ignore_case=False):
-        """Verifies that element ``locator`` does not contain exact text ``not_expected``.
+        """Verifies that element ``locator`` does not contain exact the text ``not_expected``.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -354,7 +354,7 @@ class ElementKeywords(LibraryComponent):
 
         New in SeleniumLibrary 3.1.1
         """
-        self.info("Verifying element '%s' does not contains exact text '%s'."
+        self.info("Verifying element '%s' does not contain exact text '%s'."
                   % (locator, not_expected))
         text = self.find_element(locator).text
         before_not_expected = not_expected
@@ -369,7 +369,7 @@ class ElementKeywords(LibraryComponent):
 
     @keyword
     def get_element_attribute(self, locator, attribute):
-        """Returns value of ``attribute`` from element ``locator``.
+        """Returns the value of ``attribute`` from the element ``locator``.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -405,7 +405,7 @@ class ElementKeywords(LibraryComponent):
 
     @keyword
     def get_horizontal_position(self, locator):
-        """Returns horizontal position of element identified by ``locator``.
+        """Returns the horizontal position of the element identified by ``locator``.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -419,7 +419,7 @@ class ElementKeywords(LibraryComponent):
 
     @keyword
     def get_element_size(self, locator):
-        """Returns width and height of element identified by ``locator``.
+        """Returns width and height of the element identified by ``locator``.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -467,7 +467,7 @@ newDiv.parentNode.style.overflow = 'hidden';
 
     @keyword
     def get_value(self, locator):
-        """Returns the value attribute of element identified by ``locator``.
+        """Returns the value attribute of the element identified by ``locator``.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -476,7 +476,7 @@ newDiv.parentNode.style.overflow = 'hidden';
 
     @keyword
     def get_text(self, locator):
-        """Returns the text value of element identified by ``locator``.
+        """Returns the text value of the element identified by ``locator``.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -485,7 +485,7 @@ newDiv.parentNode.style.overflow = 'hidden';
 
     @keyword
     def clear_element_text(self, locator):
-        """Clears the value of text entry element identified by ``locator``.
+        """Clears the value of the text-input-element identified by ``locator``.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -494,7 +494,7 @@ newDiv.parentNode.style.overflow = 'hidden';
 
     @keyword
     def get_vertical_position(self, locator):
-        """Returns vertical position of element identified by ``locator``.
+        """Returns the vertical position of the element identified by ``locator``.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -508,11 +508,11 @@ newDiv.parentNode.style.overflow = 'hidden';
 
     @keyword
     def click_button(self, locator, modifier=False):
-        """Clicks button identified by ``locator``.
+        """Clicks the button identified by ``locator``.
 
         See the `Locating elements` section for details about the locator
         syntax. When using the default locator strategy, buttons are
-        searched using ``id``, ``name`` and ``value``.
+        searched using ``id``, ``name``, and ``value``.
 
         See the `Click Element` keyword for details about the
         ``modifier`` argument.
@@ -572,7 +572,7 @@ newDiv.parentNode.style.overflow = 'hidden';
 
     @keyword
     def click_element(self, locator, modifier=False):
-        """Click element identified by ``locator``.
+        """Click the element identified by ``locator``.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -581,7 +581,7 @@ newDiv.parentNode.style.overflow = 'hidden';
         [https://seleniumhq.github.io/selenium/docs/api/py/webdriver/selenium.webdriver.common.keys.html#selenium.webdriver.common.keys.Keys|Selenium Keys]
         when clicking the element. The `+` can be used as a separator
         for different Selenium Keys. The `CTRL` is internally translated to
-        `CONTROL` key. The ``modifier`` is space and case insensitive, example
+        the `CONTROL` key. The ``modifier`` is space and case insensitive, example
         "alt" and " aLt " are supported formats to
         [https://seleniumhq.github.io/selenium/docs/api/py/webdriver/selenium.webdriver.common.keys.html#selenium.webdriver.common.keys.Keys.ALT|ALT key]
         . If ``modifier`` does not match to Selenium Keys, keyword fails.
@@ -615,9 +615,9 @@ newDiv.parentNode.style.overflow = 'hidden';
 
     @keyword
     def click_element_at_coordinates(self, locator, xoffset, yoffset):
-        """Click element ``locator`` at ``xoffset/yoffset``.
+        """Click the element ``locator`` at ``xoffset/yoffset``.
 
-        Cursor is moved and the center of the element and x/y coordinates are
+        The Cursor is moved and the center of the element and x/y coordinates are
         calculated from that point.
 
         See the `Locating elements` section for details about the locator
@@ -640,7 +640,7 @@ newDiv.parentNode.style.overflow = 'hidden';
 
     @keyword
     def double_click_element(self, locator):
-        """Double click element identified by ``locator``.
+        """Double clicks the element identified by ``locator``.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -652,7 +652,7 @@ newDiv.parentNode.style.overflow = 'hidden';
 
     @keyword
     def set_focus_to_element(self, locator):
-        """Sets focus to element identified by ``locator``.
+        """Sets the focus to the element identified by ``locator``.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -664,7 +664,7 @@ newDiv.parentNode.style.overflow = 'hidden';
 
     @keyword
     def scroll_element_into_view(self, locator):
-        """Scrolls an element identified by ``locator`` into view.
+        """Scrolls the element identified by ``locator`` into view.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -682,7 +682,7 @@ newDiv.parentNode.style.overflow = 'hidden';
 
     @keyword
     def drag_and_drop(self, locator, target):
-        """Drags element identified by ``locator`` into ``target`` element.
+        """Drags the element identified by ``locator`` into the ``target`` element.
 
         The ``locator`` argument is the locator of the dragged element
         and the ``target`` is the locator of the target. See the
@@ -698,12 +698,12 @@ newDiv.parentNode.style.overflow = 'hidden';
 
     @keyword
     def drag_and_drop_by_offset(self, locator, xoffset, yoffset):
-        """Drags element identified with ``locator`` by ``xoffset/yoffset``.
+        """Drags the element identified with ``locator`` by ``xoffset/yoffset``.
 
         See the `Locating elements` section for details about the locator
         syntax.
 
-        Element will be moved by ``xoffset`` and ``yoffset``, each of which
+        The element will be moved by ``xoffset`` and ``yoffset``, each of which
         is a negative or positive number specifying the offset.
 
         Example:
@@ -733,7 +733,7 @@ newDiv.parentNode.style.overflow = 'hidden';
 
     @keyword
     def mouse_out(self, locator):
-        """Simulates moving mouse away from the element ``locator``.
+        """Simulates moving the mouse away from the element ``locator``.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -756,7 +756,7 @@ newDiv.parentNode.style.overflow = 'hidden';
 
     @keyword
     def mouse_over(self, locator):
-        """Simulates hovering mouse over the element ``locator``.
+        """Simulates hovering the mouse over the element ``locator``.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -785,14 +785,14 @@ newDiv.parentNode.style.overflow = 'hidden';
 
     @keyword
     def open_context_menu(self, locator):
-        """Opens context menu on element identified by ``locator``."""
+        """Opens the context menu on the element identified by ``locator``."""
         element = self.find_element(locator)
         action = ActionChains(self.driver)
         action.context_click(element).perform()
 
     @keyword
     def simulate_event(self, locator, event):
-        """Simulates ``event`` on element identified by ``locator``.
+        """Simulates ``event`` on the element identified by ``locator``.
 
         This keyword is useful if element has ``OnEvent`` handler that
         needs to be explicitly invoked.
@@ -825,7 +825,7 @@ return !element.dispatchEvent(evt);
 
     @keyword
     def press_keys(self, locator=None, *keys):
-        """Simulates user pressing key(s) to an element or on the active browser.
+        """Simulates the user pressing key(s) to an element or on the active browser.
 
 
         If ``locator`` evaluates as false, see `Boolean arguments` for more
@@ -947,7 +947,7 @@ return !element.dispatchEvent(evt);
         syntax. When using the default locator strategy, links are searched
         using ``id``, ``name``, ``href`` and the link text.
 
-        See `Page Should Contain Element` for explanation about ``message``
+        See `Page Should Contain Element` for an explanation about ``message``
         and ``loglevel`` arguments.
         """
         self.assert_page_contains(locator, 'link', message, loglevel)
@@ -960,7 +960,7 @@ return !element.dispatchEvent(evt);
         syntax. When using the default locator strategy, links are searched
         using ``id``, ``name``, ``href`` and the link text.
 
-        See `Page Should Contain Element` for explanation about ``message``
+        See `Page Should Contain Element` for an explanation about ``message``
         and ``loglevel`` arguments.
         """
         self.assert_page_not_contains(locator, 'link', message, loglevel)
@@ -985,7 +985,7 @@ return !element.dispatchEvent(evt);
         syntax. When using the default locator strategy, images are searched
         using ``id``, ``name``, ``src`` and ``alt``.
 
-        See `Page Should Contain Element` for explanation about ``message``
+        See `Page Should Contain Element` for an explanation about ``message``
         and ``loglevel`` arguments.
         """
         self.assert_page_contains(locator, 'image', message, loglevel)
@@ -998,14 +998,14 @@ return !element.dispatchEvent(evt);
         syntax. When using the default locator strategy, images are searched
         using ``id``, ``name``, ``src`` and ``alt``.
 
-        See `Page Should Contain Element` for explanation about ``message``
+        See `Page Should Contain Element` for an explanation about ``message``
         and ``loglevel`` arguments.
         """
         self.assert_page_not_contains(locator, 'image', message, loglevel)
 
     @keyword
     def get_element_count(self, locator):
-        """Returns number of elements matching ``locator``.
+        """Returns the number of elements matching ``locator``.
 
         If you wish to assert the number of matching elements, use
         `Page Should Contain Element` with ``limit`` argument. Keyword will
@@ -1023,7 +1023,7 @@ return !element.dispatchEvent(evt);
     def add_location_strategy(self, strategy_name, strategy_keyword, persist=False):
         """Adds a custom location strategy.
 
-        See `Custom locators` for information how to create and use
+        See `Custom locators` for information on how to create and use
         custom strategies. `Remove Location Strategy` can be used to
         remove a registered strategy.
 
@@ -1038,7 +1038,7 @@ return !element.dispatchEvent(evt);
     def remove_location_strategy(self, strategy_name):
         """Removes a previously added custom location strategy.
 
-        See `Custom locators` for information how to create and use
+        See `Custom locators` for information on how to create and use
         custom strategies.
         """
         self.element_finder.unregister(strategy_name)

--- a/src/SeleniumLibrary/keywords/formelement.py
+++ b/src/SeleniumLibrary/keywords/formelement.py
@@ -56,7 +56,7 @@ class FormElementKeywords(LibraryComponent):
         """Verifies checkbox ``locator`` is not selected/checked.
 
         See the `Locating elements` section for details about the locator
-        syntax..
+        syntax.
         """
         self.info("Verifying checkbox '%s' is not selected." % locator)
         element = self._get_checkbox(locator)
@@ -66,9 +66,9 @@ class FormElementKeywords(LibraryComponent):
 
     @keyword
     def page_should_contain_checkbox(self, locator, message=None, loglevel='TRACE'):
-        """Verifies checkbox ``locator`` is found from current page.
+        """Verifies checkbox ``locator`` is found from the current page.
 
-        See `Page Should Contain Element` for explanation about ``message``
+        See `Page Should Contain Element` for an explanation about ``message``
         and ``loglevel`` arguments.
 
         See the `Locating elements` section for details about the locator
@@ -78,9 +78,9 @@ class FormElementKeywords(LibraryComponent):
 
     @keyword
     def page_should_not_contain_checkbox(self, locator, message=None, loglevel='TRACE'):
-        """Verifies checkbox ``locator`` is not found from current page.
+        """Verifies checkbox ``locator`` is not found from the current page.
 
-        See `Page Should Contain Element` for explanation about ``message``
+        See `Page Should Contain Element` for an explanation about ``message``
         and ``loglevel`` arguments.
 
         See the `Locating elements` section for details about the locator
@@ -90,7 +90,7 @@ class FormElementKeywords(LibraryComponent):
 
     @keyword
     def select_checkbox(self, locator):
-        """Selects checkbox identified by ``locator``.
+        """Selects the checkbox identified by ``locator``.
 
         Does nothing if checkbox is already selected.
 
@@ -104,7 +104,7 @@ class FormElementKeywords(LibraryComponent):
 
     @keyword
     def unselect_checkbox(self, locator):
-        """Removes selection of checkbox identified by ``locator``.
+        """Removes the selection of checkbox identified by ``locator``.
 
         Does nothing if the checkbox is not selected.
 
@@ -120,7 +120,7 @@ class FormElementKeywords(LibraryComponent):
     def page_should_contain_radio_button(self, locator, message=None, loglevel='TRACE'):
         """Verifies radio button ``locator`` is found from current page.
 
-        See `Page Should Contain Element` for explanation about ``message``
+        See `Page Should Contain Element` for an explanation about ``message``
         and ``loglevel`` arguments.
 
         See the `Locating elements` section for details about the locator
@@ -133,7 +133,7 @@ class FormElementKeywords(LibraryComponent):
     def page_should_not_contain_radio_button(self, locator, message=None, loglevel='TRACE'):
         """Verifies radio button ``locator`` is not found from current page.
 
-        See `Page Should Contain Element` for explanation about ``message``
+        See `Page Should Contain Element` for an explanation about ``message``
         and ``loglevel`` arguments.
 
         See the `Locating elements` section for details about the locator
@@ -174,7 +174,7 @@ class FormElementKeywords(LibraryComponent):
 
     @keyword
     def select_radio_button(self, group_name, value):
-        """Sets radio button group ``group_name`` to ``value``.
+        """Sets the radio button group ``group_name`` to ``value``.
 
         The radio button to be selected is located by two arguments:
         - ``group_name`` is the name of the radio button group.
@@ -193,19 +193,19 @@ class FormElementKeywords(LibraryComponent):
 
     @keyword
     def choose_file(self, locator, file_path):
-        """Inputs the ``file_path`` into file input field ``locator``.
+        """Inputs the ``file_path`` into the file input field ``locator``.
 
         This keyword is most often used to input files into upload forms.
-        Keyword  does not check ``file_path`` is the file or folder
-        available on machine where tests are executed. If the ``file_path``
-        point sot a file and when using Selenium Grid, Selenium will,
+        The keyword does not check ``file_path`` is the file or folder
+        available on the machine where tests are executed. If the ``file_path``
+        points at a file and when using Selenium Grid, Selenium will
         [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_remote/selenium.webdriver.remote.command.html?highlight=upload#selenium.webdriver.remote.command.Command.UPLOAD_FILE|magically],
-        transfer the file from the machine where test are executed
+        transfer the file from the machine where the tests are executed
         to the Selenium Grid node where the browser is running. 
-        Then Selenium will send the file path, from to node file 
+        Then Selenium will send the file path, from the nodes file
         system, to the browser.
 
-        ``file_path`` is not checked is new in SeleniumLibrary 4.0
+        That ``file_path`` is not checked, is new in SeleniumLibrary 4.0.
 
         Example:
         | `Choose File` | my_upload_field | ${CURDIR}/trades.csv |
@@ -215,7 +215,7 @@ class FormElementKeywords(LibraryComponent):
 
     @keyword
     def input_password(self, locator, password, clear=True):
-        """Types the given password into text field identified by ``locator``.
+        """Types the given password into the text field identified by ``locator``.
 
         See the `Locating elements` section for details about the locator
         syntax. See `Input Text` for ``clear`` argument details.
@@ -233,9 +233,9 @@ class FormElementKeywords(LibraryComponent):
 
         Notice also that SeleniumLibrary logs all the communication with
         browser drivers using the DEBUG level, and the actual password can
-        be seen there. Additionally Robot Framework logs all arguments using
+        be seen there. Additionally, Robot Framework logs all arguments using
         the TRACE level. Tests must thus not be executed using level below
-        INFO if password should not be logged in any format.
+        INFO if the password should not be logged in any format.
 
         The `clear` argument is new in SeleniumLibrary 4.0
         """
@@ -244,18 +244,18 @@ class FormElementKeywords(LibraryComponent):
 
     @keyword
     def input_text(self, locator, text, clear=True):
-        """Types the given ``text`` into text field identified by ``locator``.
+        """Types the given ``text`` into the text field identified by ``locator``.
 
         When ``clear`` is true, the input element is cleared before
-        text is typed to the element. When false, the previous text
+        the text is typed into the element. When false, the previous text
         is not cleared from the element. Use `Input Password` if you
         do not want the given ``text`` to be logged.
 
         If [https://github.com/SeleniumHQ/selenium/wiki/Grid2|Selenium Grid]
         is used and the ``text`` argument points to a file in the file system,
         then this keyword prevents the Selenium to transfer the file to the
-        Selenium Grid hub. Instead this keyword will send the ``text`` string
-        as is to the element. If file should be transferred to the hub and
+        Selenium Grid hub. Instead, this keyword will send the ``text`` string
+        as is to the element. If a file should be transferred to the hub and
         upload should be performed, please use `Choose File` keyword.
 
         See the `Locating elements` section for details about the locator
@@ -272,7 +272,7 @@ class FormElementKeywords(LibraryComponent):
     def page_should_contain_textfield(self, locator, message=None, loglevel='TRACE'):
         """Verifies text field ``locator`` is found from current page.
 
-        See `Page Should Contain Element` for explanation about ``message``
+        See `Page Should Contain Element` for an explanation about ``message``
         and ``loglevel`` arguments.
 
         See the `Locating elements` section for details about the locator
@@ -284,7 +284,7 @@ class FormElementKeywords(LibraryComponent):
     def page_should_not_contain_textfield(self, locator, message=None, loglevel='TRACE'):
         """Verifies text field ``locator`` is not found from current page.
 
-        See `Page Should Contain Element` for explanation about ``message``
+        See `Page Should Contain Element` for an explanation about ``message``
         and ``loglevel`` arguments.
 
         See the `Locating elements` section for details about the locator
@@ -364,12 +364,12 @@ class FormElementKeywords(LibraryComponent):
     def page_should_contain_button(self, locator, message=None, loglevel='TRACE'):
         """Verifies button ``locator`` is found from current page.
 
-        See `Page Should Contain Element` for explanation about ``message``
+        See `Page Should Contain Element` for an explanation about ``message``
         and ``loglevel`` arguments.
 
         See the `Locating elements` section for details about the locator
         syntax. When using the default locator strategy, buttons are
-        searched using ``id``, ``name`` and ``value``.
+        searched using ``id``, ``name``, and ``value``.
         """
         try:
             self.assert_page_contains(locator, 'input', message, loglevel)
@@ -380,12 +380,12 @@ class FormElementKeywords(LibraryComponent):
     def page_should_not_contain_button(self, locator, message=None, loglevel='TRACE'):
         """Verifies button ``locator`` is not found from current page.
 
-        See `Page Should Contain Element` for explanation about ``message``
+        See `Page Should Contain Element` for an explanation about ``message``
         and ``loglevel`` arguments.
 
         See the `Locating elements` section for details about the locator
         syntax. When using the default locator strategy, buttons are
-        searched using ``id``, ``name`` and ``value``.
+        searched using ``id``, ``name``, and ``value``.
         """
         self.assert_page_not_contains(locator, 'button', message, loglevel)
         self.assert_page_not_contains(locator, 'input', message, loglevel)

--- a/src/SeleniumLibrary/keywords/frames.py
+++ b/src/SeleniumLibrary/keywords/frames.py
@@ -49,9 +49,9 @@ class FrameKeywords(LibraryComponent):
 
     @keyword
     def current_frame_should_contain(self, text, loglevel='TRACE'):
-        """Verifies that current frame contains ``text``.
+        """Verifies that the current frame contains ``text``.
 
-        See `Page Should Contain` for explanation about the ``loglevel``
+        See `Page Should Contain` for an explanation about the ``loglevel``
         argument.
 
         Prior to SeleniumLibrary 3.0 this keyword was named
@@ -65,9 +65,9 @@ class FrameKeywords(LibraryComponent):
 
     @keyword
     def current_frame_should_not_contain(self, text, loglevel='TRACE'):
-        """Verifies that current frame does not contains ``text``.
+        """Verifies that the current frame does not contain ``text``.
 
-        See `Page Should Contain` for explanation about the ``loglevel``
+        See `Page Should Contain` for an explanation about the ``loglevel``
         argument.
         """
         if self.is_text_present(text):
@@ -83,7 +83,7 @@ class FrameKeywords(LibraryComponent):
         See the `Locating elements` section for details about the locator
         syntax.
 
-        See `Page Should Contain` for explanation about the ``loglevel``
+        See `Page Should Contain` for an explanation about the ``loglevel``
         argument.
         """
         if not self._frame_contains(locator, text):

--- a/src/SeleniumLibrary/keywords/javascript.py
+++ b/src/SeleniumLibrary/keywords/javascript.py
@@ -53,10 +53,10 @@ class JavaScriptKeywords(LibraryComponent):
         [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_remote/selenium.webdriver.remote.webdriver.html#selenium.webdriver.remote.webdriver.WebDriver.execute_script|
         arguments] as part of ``code`` argument. The JavaScript code and
         arguments must be separated with `JAVASCRIPT` and `ARGUMENTS` markers
-        and must used exactly with this format. If the Javascript code is
+        and must be used exactly with this format. If the Javascript code is
         first, then the `JAVASCRIPT` marker is optional. The order of
-        `JAVASCRIPT` and `ARGUMENTS` markers can swapped, but if `ARGUMENTS`
-        is first marker, then `JAVASCRIPT` marker is mandatory. It is only
+        `JAVASCRIPT` and `ARGUMENTS` markers can be swapped, but if `ARGUMENTS`
+        is the first marker, then `JAVASCRIPT` marker is mandatory. It is only
         allowed to use `JAVASCRIPT` and `ARGUMENTS` markers only one time in the
         ``code`` argument.
 

--- a/src/SeleniumLibrary/keywords/runonfailure.py
+++ b/src/SeleniumLibrary/keywords/runonfailure.py
@@ -22,7 +22,7 @@ class RunOnFailureKeywords(LibraryComponent):
 
     @keyword
     def register_keyword_to_run_on_failure(self, keyword):
-        """Sets the keyword to execute when a SeleniumLibrary keyword fails.
+        """Sets the keyword to execute, when a SeleniumLibrary keyword fails.
 
         ``keyword`` is the name of a keyword that will be executed if a
         SeleniumLibrary keyword fails. It is possible to use any available

--- a/src/SeleniumLibrary/keywords/screenshot.py
+++ b/src/SeleniumLibrary/keywords/screenshot.py
@@ -52,7 +52,7 @@ class ScreenshotKeywords(LibraryComponent):
 
     @keyword
     def capture_page_screenshot(self, filename='selenium-screenshot-{index}.png'):
-        """Takes screenshot of the current page and embeds it into log file.
+        """Takes a screenshot of the current page and embeds it into a log file.
 
         ``filename`` argument specifies the name of the file to write the
         screenshot into. The directory where screenshots are saved can be
@@ -62,8 +62,8 @@ class ScreenshotKeywords(LibraryComponent):
         written.
 
         Starting from SeleniumLibrary 1.8, if ``filename`` contains marker
-        ``{index}``, it will be automatically replaced with unique running
-        index preventing files to be overwritten. Indices start from 1,
+        ``{index}``, it will be automatically replaced with an unique running
+        index, preventing files to be overwritten. Indices start from 1,
         and how they are represented can be customized using Python's
         [https://docs.python.org/3/library/string.html#format-string-syntax|
         format string syntax].
@@ -95,7 +95,7 @@ class ScreenshotKeywords(LibraryComponent):
 
     @keyword
     def capture_element_screenshot(self, locator, filename='selenium-element-screenshot-{index}.png'):
-        """Captures screenshot from the element identified by ``locator`` and embeds it into log file.
+        """Captures a screenshot from the element identified by ``locator`` and embeds it into log file.
 
         See `Capture Page Screenshot` for details about ``filename`` argument.
         See the `Locating elements` section for details about the locator
@@ -103,9 +103,9 @@ class ScreenshotKeywords(LibraryComponent):
 
         An absolute path to the created element screenshot is returned.
 
-        Support for capturing the screenshot from a element has limited support
+        Support for capturing the screenshot from an element has limited support
         among browser vendors. Please check the browser vendor driver documentation
-        does the browser support capturing a screenshot from a element.
+        does the browser support capturing a screenshot from an element.
 
         New in SeleniumLibrary 3.3
 

--- a/src/SeleniumLibrary/keywords/selectelement.py
+++ b/src/SeleniumLibrary/keywords/selectelement.py
@@ -48,9 +48,9 @@ class SelectElementKeywords(LibraryComponent):
 
     @keyword
     def get_selected_list_label(self, locator):
-        """Returns label of selected option from selection list ``locator``.
+        """Returns the label of selected option from selection list ``locator``.
 
-        If there are multiple selected options, label of the first option
+        If there are multiple selected options, the label of the first option
         is returned.
 
         See the `Locating elements` section for details about the locator
@@ -64,7 +64,7 @@ class SelectElementKeywords(LibraryComponent):
         """Returns labels of selected options from selection list ``locator``.
 
         Starting from SeleniumLibrary 3.0, returns an empty list if there
-        are no selections. In earlier versions this caused an error.
+        are no selections. In earlier versions, this caused an error.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -74,9 +74,9 @@ class SelectElementKeywords(LibraryComponent):
 
     @keyword
     def get_selected_list_value(self, locator):
-        """Returns value of selected option from selection list ``locator``.
+        """Returns the value of selected option from selection list ``locator``.
 
-        If there are multiple selected options, value of the first option
+        If there are multiple selected options, the value of the first option
         is returned.
 
         See the `Locating elements` section for details about the locator
@@ -90,7 +90,7 @@ class SelectElementKeywords(LibraryComponent):
         """Returns values of selected options from selection list ``locator``.
 
         Starting from SeleniumLibrary 3.0, returns an empty list if there
-        are no selections. In earlier versions this caused an error.
+        are no selections. In earlier versions, this caused an error.
 
         See the `Locating elements` section for details about the locator
         syntax.
@@ -154,7 +154,7 @@ class SelectElementKeywords(LibraryComponent):
     def page_should_contain_list(self, locator, message=None, loglevel='TRACE'):
         """Verifies selection list ``locator`` is found from current page.
 
-        See `Page Should Contain Element` for explanation about ``message``
+        See `Page Should Contain Element` for an explanation about ``message``
         and ``loglevel`` arguments.
 
         See the `Locating elements` section for details about the locator
@@ -166,7 +166,7 @@ class SelectElementKeywords(LibraryComponent):
     def page_should_not_contain_list(self, locator, message=None, loglevel='TRACE'):
         """Verifies selection list ``locator`` is not found from current page.
 
-        See `Page Should Contain Element` for explanation about ``message``
+        See `Page Should Contain Element` for an explanation about ``message``
         and ``loglevel`` arguments.
 
         See the `Locating elements` section for details about the locator

--- a/src/SeleniumLibrary/keywords/tableelement.py
+++ b/src/SeleniumLibrary/keywords/tableelement.py
@@ -21,7 +21,7 @@ class TableElementKeywords(LibraryComponent):
 
     @keyword
     def get_table_cell(self, locator, row, column, loglevel='TRACE'):
-        """Returns contents of table cell.
+        """Returns contents of a table cell.
 
         The table is located using the ``locator`` argument and its cell
         found using ``row`` and ``column``. See the `Locating elements`
@@ -35,7 +35,7 @@ class TableElementKeywords(LibraryComponent):
         All ``<th>`` and ``<td>`` elements anywhere in the table are
         considered to be cells.
 
-        See `Page Should Contain` for explanation about the ``loglevel``
+        See `Page Should Contain` for an explanation about the ``loglevel``
         argument.
         """
         row = int(row)
@@ -80,7 +80,7 @@ class TableElementKeywords(LibraryComponent):
         """Verifies table cell contains text ``expected``.
 
         See `Get Table Cell` that this keyword uses internally for
-        explanation about accepted arguments.
+        an explanation about accepted arguments.
         """
         content = self.get_table_cell(locator, row, column, loglevel)
         if expected not in content:
@@ -106,7 +106,7 @@ class TableElementKeywords(LibraryComponent):
         If a table contains cells that span multiple columns, those merged
         cells count as a single column.
 
-        See `Page Should Contain Element` for explanation about the
+        See `Page Should Contain Element` for an explanation about the
         ``loglevel`` argument.
         """
         element = self._find_by_column(locator, column, expected)
@@ -125,7 +125,7 @@ class TableElementKeywords(LibraryComponent):
         The table is located using the ``locator`` argument. See the
         `Locating elements` section for details about the locator syntax.
 
-        See `Page Should Contain Element` for explanation about the
+        See `Page Should Contain Element` for an explanation about the
         ``loglevel`` argument.
         """
         element = self._find_by_footer(locator, expected)
@@ -144,7 +144,7 @@ class TableElementKeywords(LibraryComponent):
         The table is located using the ``locator`` argument. See the
         `Locating elements` section for details about the locator syntax.
 
-        See `Page Should Contain Element` for explanation about the
+        See `Page Should Contain Element` for an explanation about the
         ``loglevel`` argument.
         """
         element = self._find_by_header(locator, expected)
@@ -168,7 +168,7 @@ class TableElementKeywords(LibraryComponent):
         If a table contains cells that span multiple rows, a match
         only occurs for the uppermost row of those merged cells.
 
-        See `Page Should Contain Element` for explanation about the
+        See `Page Should Contain Element` for an explanation about the
         ``loglevel`` argument.
         """
         element = self._find_by_row(locator, row, expected)
@@ -184,7 +184,7 @@ class TableElementKeywords(LibraryComponent):
         The table is located using the ``locator`` argument. See the
         `Locating elements` section for details about the locator syntax.
 
-        See `Page Should Contain Element` for explanation about the
+        See `Page Should Contain Element` for an explanation about the
         ``loglevel`` argument.
         """
         element = self._find_by_content(locator, expected)

--- a/src/SeleniumLibrary/keywords/waiting.py
+++ b/src/SeleniumLibrary/keywords/waiting.py
@@ -55,7 +55,7 @@ class WaitingKeywords(LibraryComponent):
 
     @keyword
     def wait_until_location_is(self, expected, timeout=None, message=None):
-        """Wait until that current URL is ``expected``.
+        """Waits until the current URL is ``expected``.
 
         The ``expected`` argument is the expected value in url.
 
@@ -76,7 +76,7 @@ class WaitingKeywords(LibraryComponent):
 
     @keyword
     def wait_until_location_contains(self, expected, timeout=None, message=None):
-        """Wait until that current URL contains ``expected``.
+        """Waits until the current URL contains ``expected``.
 
         The ``expected`` argument contains the expected value in url.
 
@@ -97,7 +97,7 @@ class WaitingKeywords(LibraryComponent):
 
     @keyword
     def wait_until_page_contains(self, text, timeout=None, error=None):
-        """Waits until ``text`` appears on current page.
+        """Waits until ``text`` appears on the current page.
 
         Fails if ``timeout`` expires before the text appears. See
         the `Timeouts` section for more information about using timeouts
@@ -112,7 +112,7 @@ class WaitingKeywords(LibraryComponent):
     @keyword
     def wait_until_page_does_not_contain(self, text, timeout=None,
                                          error=None):
-        """Waits until ``text`` disappears from current page.
+        """Waits until ``text`` disappears from the current page.
 
         Fails if ``timeout`` expires before the text disappears. See
         the `Timeouts` section for more information about using timeouts
@@ -127,7 +127,7 @@ class WaitingKeywords(LibraryComponent):
     @keyword
     def wait_until_page_contains_element(self, locator, timeout=None,
                                          error=None):
-        """Waits until element ``locator`` appears on current page.
+        """Waits until the element ``locator`` appears on the current page.
 
         Fails if ``timeout`` expires before the element appears. See
         the `Timeouts` section for more information about using timeouts and
@@ -145,7 +145,7 @@ class WaitingKeywords(LibraryComponent):
     @keyword
     def wait_until_page_does_not_contain_element(self, locator, timeout=None,
                                                  error=None):
-        """Waits until element ``locator`` disappears from current page.
+        """Waits until the element ``locator`` disappears from the current page.
 
         Fails if ``timeout`` expires before the element disappears. See
         the `Timeouts` section for more information about using timeouts and
@@ -163,7 +163,7 @@ class WaitingKeywords(LibraryComponent):
     @keyword
     def wait_until_element_is_visible(self, locator, timeout=None,
                                       error=None):
-        """Waits until element ``locator`` is visible.
+        """Waits until the element ``locator`` is visible.
 
         Fails if ``timeout`` expires before the element is visible. See
         the `Timeouts` section for more information about using timeouts and
@@ -181,7 +181,7 @@ class WaitingKeywords(LibraryComponent):
     @keyword
     def wait_until_element_is_not_visible(self, locator, timeout=None,
                                           error=None):
-        """Waits until element ``locator`` is not visible.
+        """Waits until the element ``locator`` is not visible.
 
         Fails if ``timeout`` expires before the element is not visible. See
         the `Timeouts` section for more information about using timeouts and
@@ -199,7 +199,7 @@ class WaitingKeywords(LibraryComponent):
     @keyword
     def wait_until_element_is_enabled(self, locator, timeout=None,
                                       error=None):
-        """Waits until element ``locator`` is enabled.
+        """Waits until the element ``locator`` is enabled.
 
         Element is considered enabled if it is not disabled nor read-only.
 
@@ -222,7 +222,7 @@ class WaitingKeywords(LibraryComponent):
     @keyword
     def wait_until_element_contains(self, locator, text, timeout=None,
                                     error=None):
-        """Waits until element ``locator`` contains ``text``.
+        """Waits until the element ``locator`` contains ``text``.
 
         Fails if ``timeout`` expires before the text appears. See
         the `Timeouts` section for more information about using timeouts and
@@ -240,7 +240,7 @@ class WaitingKeywords(LibraryComponent):
     @keyword
     def wait_until_element_does_not_contain(self, locator, text, timeout=None,
                                             error=None):
-        """Waits until element ``locator`` does not contain ``text``.
+        """Waits until the element ``locator`` does not contain ``text``.
 
         Fails if ``timeout`` expires before the text disappears. See
         the `Timeouts` section for more information about using timeouts and

--- a/src/SeleniumLibrary/keywords/window.py
+++ b/src/SeleniumLibrary/keywords/window.py
@@ -40,8 +40,8 @@ class WindowKeywords(LibraryComponent):
 
         If the window is found, all subsequent commands use the selected
         window, until this keyword is used again. If the window is not
-        found, this keyword fails. The previous window handle is returned,
-        and can be used to return back to it later.
+        found, this keyword fails. The previous windows handle is returned
+        and can be used to switch back to it later.
 
         Notice that alerts should be handled with
         `Handle Alert` or other alert related keywords.
@@ -49,14 +49,14 @@ class WindowKeywords(LibraryComponent):
         The ``locator`` can be specified using different strategies somewhat
         similarly as when `locating elements` on pages.
 
-        - By default the ``locator`` is matched against window handle, name,
-          title, and URL. Matching is done in that order and the the first
+        - By default, the ``locator`` is matched against window handle, name,
+          title, and URL. Matching is done in that order and the first
           matching window is selected.
 
-        - The ``locator`` can specify an explicit strategy by using format
+        - The ``locator`` can specify an explicit strategy by using the format
           ``strategy:value`` (recommended) or ``strategy=value``. Supported
-          strategies are ``name``, ``title`` and ``url``, which match windows
-          using name, title, and URL, respectively. Additionally, ``default``
+          strategies are ``name``, ``title``, and ``url``. These matches windows
+          using their name, title, or URL, respectively. Additionally, ``default``
           can be used to explicitly use the default strategy explained above.
 
         - If the ``locator`` is ``NEW`` (case-insensitive), the latest
@@ -71,7 +71,7 @@ class WindowKeywords(LibraryComponent):
 
         - If the ``locator`` is not a string, it is expected to be a list
           of window handles _to exclude_. Such a list of excluded windows
-          can be get from `Get Window Handles` prior to doing an action that
+          can be got from `Get Window Handles` before doing an action that
           opens a new window.
 
         The ``timeout`` is used to specify how long keyword will poll to select
@@ -107,7 +107,7 @@ class WindowKeywords(LibraryComponent):
           and URL was case-insensitive.
         - Earlier versions supported aliases ``None``, ``null`` and the
           empty string for selecting the main window, and alias ``self``
-          for selecting the current window. Support for these aliases were
+          for selecting the current window. Support for these aliases was
           removed in SeleniumLibrary 3.2.
         """
         epoch = time.time()
@@ -194,7 +194,7 @@ class WindowKeywords(LibraryComponent):
 
         If ``inner`` parameter is set to True, keyword returns
         HTML DOM window.innerWidth and window.innerHeight properties.
-        See `Boolean arguments` for more details how to set boolean
+        See `Boolean arguments` for more details on how to set boolean
         arguments. The ``inner`` is new in SeleniumLibrary 4.0.
 
         Example:
@@ -215,15 +215,16 @@ class WindowKeywords(LibraryComponent):
         Values can be given using strings containing numbers or by using
         actual numbers. See also `Get Window Size`.
 
-        Browsers have a limit how small they can be set. Trying to set them
+        Browsers have a limit on their minimum size. Trying to set them
         smaller will cause the actual size to be bigger than the requested
         size.
 
         If ``inner`` parameter is set to True, keyword sets the necessary
-        window width and height to have the desired HTML DOM window.innerWidth
-        and window.innerHeight The ``inner`` is new in SeleniumLibrary 4.0.
-        See `Boolean arguments` for more details how to set boolean
+        window width and height to have the desired HTML DOM _window.innerWidth_
+        and _window.innerHeight_. See `Boolean arguments` for more details on how to set boolean
         arguments.
+
+        The ``inner`` argument is new since SeleniumLibrary 4.0.
 
         This ``inner`` argument does not support Frames. If a frame is selected,
         switch to default before running this.
@@ -254,7 +255,7 @@ class WindowKeywords(LibraryComponent):
     def get_window_position(self):
         """Returns current window position.
 
-        Position is relative to the top left corner of the screen. Returned
+        The position is relative to the top left corner of the screen. Returned
         values are integers. See also `Set Window Position`.
 
         Example:


### PR DESCRIPTION
Hi Tatu,

I did some fixes. Mostly typos or punctuation.
Only some rare formulations.

a lot of missing "the" "a" or "an".

cheers