### PR TITLE
Feature/support chromium apps

### DIFF
--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -254,11 +254,11 @@ class BrowserManagementKeywords(LibraryComponent):
                           alias=None, desired_capabilities=None,
                           options=None, service_log_path=None):
         """
-        Similar to Open Browser except opens a specified chromium_based application
+        Similar to Open Browser except opens a specified chromium_app application
         instead of a browser. The desired_capabilities, remote_url, alias,
         options, and service_log_path arguments are the same and are all optional.
 
-        ``app_binary`` is the path to the desired chromium_based desktop
+        ``app_binary`` is the path to the desired chromium_app desktop
         application. This includes Qt-based applications with QtWebEngine content
         from Qt versions >= 5.6.
 
@@ -269,7 +269,7 @@ class BrowserManagementKeywords(LibraryComponent):
         | Open Chromium App | /path/to/custom/application | 9001 |
         """
         return self._make_new_browser(url='',
-                                      browser='chromium_based',
+                                      browser='chromium_app',
                                       remote_url=remote_url,
                                       desired_capabilities=desired_capabilities,
                                       options=options, alias=alias,
@@ -281,7 +281,7 @@ class BrowserManagementKeywords(LibraryComponent):
                           remote_url=False, desired_capabilities=None,
                           ff_profile_dir=None, options=None, service_log_path=None,
                           app_binary=None, debug_port=None):
-        if browser == 'chromium_based':
+        if browser == 'chromium_app':
             if is_truthy(app_binary) and is_truthy(debug_port):
                 if is_truthy(remote_url):
                     self.info("Opening chromium-based application '{}' "

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -305,7 +305,7 @@ class BrowserManagementKeywords(LibraryComponent):
                                    debug_port)
         driver = self._wrap_event_firing_webdriver(driver)
         index = self.ctx.register_driver(driver, alias)
-        if is_truthy(url):
+        if browser != 'chromium_app':
             try:
                 driver.get(url)
             except Exception:

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -250,12 +250,13 @@ class BrowserManagementKeywords(LibraryComponent):
                                       options, service_log_path)
 
     @keyword
-    def open_chromium_app(self, app_binary, debug_port, desired_capabilities=None,
+    def open_chromium_app(self, app_binary, debug_port, remote_url=False,
+                          alias=None, desired_capabilities=None,
                           options=None, service_log_path=None):
         """
         Similar to Open Browser except opens a specified chromium_based application
-        instead of a browser. The desired_capabilities, options, and service_log_path
-        arguments are the same and are all optional.
+        instead of a browser. The desired_capabilities, remote_url, alias,
+        options, and service_log_path arguments are the same and are all optional.
 
         ``app_binary`` is the path to the desired chromium_based desktop
         application. This includes Qt-based applications with QtWebEngine content
@@ -269,8 +270,9 @@ class BrowserManagementKeywords(LibraryComponent):
         """
         return self._make_new_browser(url='',
                                       browser='chromium_based',
+                                      remote_url=remote_url,
                                       desired_capabilities=desired_capabilities,
-                                      options=options,
+                                      options=options, alias=alias,
                                       service_log_path=service_log_path,
                                       app_binary=app_binary,
                                       debug_port=debug_port)
@@ -281,8 +283,13 @@ class BrowserManagementKeywords(LibraryComponent):
                           app_binary=None, debug_port=None):
         if browser == 'chromium_based':
             if is_truthy(app_binary) and is_truthy(debug_port):
-                self.info("Opening chromium-based application '{}'"
-                          .format(app_binary))
+                if is_truthy(remote_url):
+                    self.info("Opening chromium-based application '{}' "
+                              "on port '{}' through remote server at '{}'."
+                              .format(app_binary, debug_port, remote_url))
+                else:
+                    self.info("Opening chromium-based application '{}' "
+                              "on port '{}'.".format(app_binary, debug_port))
             else:
                 self.info("Need to have an application binary and debug port "
                           "for chromium-based apps")

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -653,11 +653,12 @@ class BrowserManagementKeywords(LibraryComponent):
         self.driver.implicitly_wait(timestr_to_secs(value))
 
     def _make_driver(self, browser, desired_capabilities=None, profile_dir=None,
-                     remote=None, options=None, service_log_path=None, app_binary=None):
+                     remote=None, options=None, service_log_path=None,
+                     app_binary=None, debug_port=None):
         driver = WebDriverCreator(self.log_dir).create_driver(
             browser=browser, desired_capabilities=desired_capabilities, remote_url=remote,
             profile_dir=profile_dir, options=options, service_log_path=service_log_path,
-            app_binary=app_binary)
+            app_binary=app_binary, debug_port=debug_port)
         driver.set_script_timeout(self.ctx.timeout)
         driver.implicitly_wait(self.ctx.implicit_wait)
         if self.ctx.speed:

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -257,11 +257,11 @@ class BrowserManagementKeywords(LibraryComponent):
         instead of a browser. The desired_capabilities, options, and service_log_path
         arguments are the same and are all optional.
 
-        The 'app_binary' argument is the path to the desired chromium_based desktop
+        ``app_binary`` is the path to the desired chromium_based desktop
         application. This includes Qt-based applications with QtWebEngine content
         from Qt versions >= 5.6.
 
-        'debug-port' - In order to hook into the process, ChromeDriver requires
+        ``debug-port`` - In order to hook into the process, ChromeDriver requires
         that a --remote-debugging-port is specified.
 
         Examples:

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -79,7 +79,6 @@ class BrowserManagementKeywords(LibraryComponent):
         | PhantomJS         | phantomjs                |
         | HTMLUnit          | htmlunit                 |
         | HTMLUnit with Javascript | htmlunitwithjs    |
-        | Chromium-Based App | chromium_based          |
 
         To be able to actually use one of these browsers, you need to have
         a matching Selenium browser driver available. See the
@@ -254,7 +253,19 @@ class BrowserManagementKeywords(LibraryComponent):
     def open_chromium_app(self, app_binary, debug_port, desired_capabilities=None,
                           options=None, service_log_path=None):
         """
-        Opens a chromium-based application instead of a browser
+        Similar to Open Browser except opens a specified chromium_based application
+        instead of a browser. The desired_capabilities, options, and service_log_path
+        arguments are the same and are all optional.
+
+        The 'app_binary' argument is the path to the desired chromium_based desktop
+        application. This includes Qt-based applications with QtWebEngine content
+        from Qt versions >= 5.6.
+
+        'debug-port' - In order to hook into the process, ChromeDriver requires
+        that a --remote-debugging-port is specified.
+
+        Examples:
+        | Open Chromium App | /path/to/custom/application | 9001 |
         """
         return self._make_new_browser(url='',
                                       browser='chromium_based',

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -639,6 +639,28 @@ newDiv.parentNode.style.overflow = 'hidden';
         action.perform()
 
     @keyword
+    def click_element_native(self, locator):
+        """Click the element ``locator`` using native mouse click (ActionChain).
+
+        The Cursor is moved and the center of the element and a click is issued.
+
+        See the `Locating elements` section for details about the locator
+        syntax.
+        """
+        self.info("Clicking element '%s'" % (locator))
+        element = self.find_element(locator)
+        action = ActionChains(self.driver)
+        # Try/except can be removed when minimum required Selenium is 4.0 or greater.
+        try:
+            action.move_to_element(element)
+        except AttributeError:
+            self.debug('Workaround for Selenium 3 bug.')
+            element = element.wrapped_element
+            action.move_to_element(element)
+        action.click()
+        action.perform()
+
+    @keyword
     def double_click_element(self, locator):
         """Double clicks the element identified by ``locator``.
 

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -639,28 +639,6 @@ newDiv.parentNode.style.overflow = 'hidden';
         action.perform()
 
     @keyword
-    def click_element_native(self, locator):
-        """Click the element ``locator`` using native mouse click (ActionChain).
-
-        The Cursor is moved and the center of the element and a click is issued.
-
-        See the `Locating elements` section for details about the locator
-        syntax.
-        """
-        self.info("Clicking element '%s'" % (locator))
-        element = self.find_element(locator)
-        action = ActionChains(self.driver)
-        # Try/except can be removed when minimum required Selenium is 4.0 or greater.
-        try:
-            action.move_to_element(element)
-        except AttributeError:
-            self.debug('Workaround for Selenium 3 bug.')
-            element = element.wrapped_element
-            action.move_to_element(element)
-        action.click()
-        action.perform()
-
-    @keyword
     def double_click_element(self, locator):
         """Double clicks the element identified by ``locator``.
 

--- a/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
+++ b/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
@@ -75,8 +75,8 @@ class WebDriverCreator(object):
             return creation_method(desired_capabilities, remote_url, profile_dir,
                                    options=options, service_log_path=service_log_path)
         elif (creation_method == self.create_chromium_based):
-            return creation_method(app_binary, debug_port, desired_capabilities, options,
-                                   service_log_path)
+            return creation_method(app_binary, debug_port, desired_capabilities,
+                                   remote_url, options, service_log_path)
         return creation_method(desired_capabilities, remote_url, options=options,
                                service_log_path=service_log_path)
 
@@ -127,16 +127,13 @@ class WebDriverCreator(object):
         options.set_headless()
         return self.create_chrome(desired_capabilities, remote_url, options, service_log_path)
 
-    def create_chromium_based(self, app_binary, debug_port, desired_capabilities, options=None,
-                              service_log_path=None):
-        """
-        TODO: Incorporate remote execution
-        """
+    def create_chromium_based(self, app_binary, debug_port, desired_capabilities, remote_url,
+                              options=None, service_log_path=None):
         if not options:
             options = webdriver.ChromeOptions()
         options.binary_location = app_binary
         options.add_argument("remote-debugging-port={}".format(debug_port))
-        return self.create_chrome(desired_capabilities, None, options, service_log_path)
+        return self.create_chrome(desired_capabilities, remote_url, options, service_log_path)
 
     def create_firefox(self, desired_capabilities, remote_url, ff_profile_dir, options=None, service_log_path=None):
         profile = self._get_ff_profile(ff_profile_dir)

--- a/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
+++ b/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
@@ -51,7 +51,8 @@ class WebDriverCreator(object):
         'htmlunit': 'htmlunit',
         'htmlunitwithjs': 'htmlunit_with_js',
         'android': 'android',
-        'iphone': 'iphone'
+        'iphone': 'iphone',
+        'chromium_based': 'chromium_based'
     }
 
     def __init__(self, log_dir):
@@ -59,7 +60,8 @@ class WebDriverCreator(object):
         self.selenium_options = SeleniumOptions()
 
     def create_driver(self, browser, desired_capabilities, remote_url,
-                      profile_dir=None, options=None, service_log_path=None):
+                      profile_dir=None, options=None, service_log_path=None,
+                      app_binary=None, debug_port=None):
         browser = self._normalise_browser_name(browser)
         creation_method = self._get_creator_method(browser)
         desired_capabilities = self._parse_capabilities(desired_capabilities, browser)
@@ -72,6 +74,9 @@ class WebDriverCreator(object):
                 or creation_method == self.create_headless_firefox):
             return creation_method(desired_capabilities, remote_url, profile_dir,
                                    options=options, service_log_path=service_log_path)
+        elif (creation_method == self.create_chromium_based):
+            return creation_method(app_binary, debug_port, desired_capabilities, options,
+                                   service_log_path)
         return creation_method(desired_capabilities, remote_url, options=options,
                                service_log_path=service_log_path)
 
@@ -121,6 +126,17 @@ class WebDriverCreator(object):
         # Can be changed to options.headless = True when minimum Selenium version is 3.12.0 or greater.
         options.set_headless()
         return self.create_chrome(desired_capabilities, remote_url, options, service_log_path)
+
+    def create_chromium_based(self, app_binary, debug_port, desired_capabilities, options=None,
+                              service_log_path=None):
+        """
+        TODO: Incorporate remote execution
+        """
+        if not options:
+            options = webdriver.ChromeOptions()
+        options.binary_location = app_binary
+        options.add_argument("remote-debugging-port={}".format(debug_port))
+        return self.create_chrome(desired_capabilities, options, service_log_path, remote_url=None)
 
     def create_firefox(self, desired_capabilities, remote_url, ff_profile_dir, options=None, service_log_path=None):
         profile = self._get_ff_profile(ff_profile_dir)

--- a/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
+++ b/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
@@ -52,7 +52,7 @@ class WebDriverCreator(object):
         'htmlunitwithjs': 'htmlunit_with_js',
         'android': 'android',
         'iphone': 'iphone',
-        'chromium_based': 'chromium_based'
+        'chromium_app': 'chromium_app'
     }
 
     def __init__(self, log_dir):
@@ -74,7 +74,7 @@ class WebDriverCreator(object):
                 or creation_method == self.create_headless_firefox):
             return creation_method(desired_capabilities, remote_url, profile_dir,
                                    options=options, service_log_path=service_log_path)
-        elif (creation_method == self.create_chromium_based):
+        elif (creation_method == self.create_chromium_app):
             return creation_method(app_binary, debug_port, desired_capabilities,
                                    remote_url, options, service_log_path)
         return creation_method(desired_capabilities, remote_url, options=options,
@@ -127,7 +127,7 @@ class WebDriverCreator(object):
         options.set_headless()
         return self.create_chrome(desired_capabilities, remote_url, options, service_log_path)
 
-    def create_chromium_based(self, app_binary, debug_port, desired_capabilities, remote_url,
+    def create_chromium_app(self, app_binary, debug_port, desired_capabilities, remote_url,
                               options=None, service_log_path=None):
         if not options:
             options = webdriver.ChromeOptions()

--- a/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
+++ b/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
@@ -136,7 +136,7 @@ class WebDriverCreator(object):
             options = webdriver.ChromeOptions()
         options.binary_location = app_binary
         options.add_argument("remote-debugging-port={}".format(debug_port))
-        return self.create_chrome(desired_capabilities, options, service_log_path, remote_url=None)
+        return self.create_chrome(desired_capabilities, None, options, service_log_path)
 
     def create_firefox(self, desired_capabilities, remote_url, ff_profile_dir, options=None, service_log_path=None):
         profile = self._get_ff_profile(ff_profile_dir)

--- a/utest/test/api/test_plugins.py
+++ b/utest/test/api/test_plugins.py
@@ -22,7 +22,7 @@ class ExtendingSeleniumLibrary(unittest.TestCase):
     def test_no_libraries(self):
         for item in [None, 'None', '']:
             sl = SeleniumLibrary(plugins=item)
-            self.assertEqual(len(sl.get_keyword_names()), 173)
+            self.assertEqual(len(sl.get_keyword_names()), 174)
 
     def test_parse_library(self):
         plugin = 'path.to.MyLibrary'

--- a/utest/test/keywords/test_keyword_arguments_browsermanagement.py
+++ b/utest/test/keywords/test_keyword_arguments_browsermanagement.py
@@ -22,12 +22,14 @@ class KeywordArgumentsElementTest(unittest.TestCase):
         remote_url = '"http://localhost:4444/wd/hub"'
         browser = mock()
         when(self.brorser)._make_driver('firefox', None,
-                                        None, False, None, None).thenReturn(browser)
+                                        None, False, None, None,
+                                        None, None).thenReturn(browser)
         alias = self.brorser.open_browser(url)
         self.assertEqual(alias, None)
 
         when(self.brorser)._make_driver('firefox', None,
-                                        None, remote_url, None, None).thenReturn(browser)
+                                        None, remote_url, None, None,
+                                        None, None).thenReturn(browser)
         alias = self.brorser.open_browser(url, alias='None',
                                           remote_url=remote_url)
         self.assertEqual(alias, None)


### PR DESCRIPTION
Adds a keyword to allow users to open up Chromium-based applications easier.

To open up an application instead of a normal browser, you can use:
`| Open Chromium App | /path/to/app | remote-debugging-port`

The remote debugging port is how ChromeDriver interacts with the application. See:
https://bitbucket.org/chromiumembedded/cef/wiki/UsingChromeDriver