### PR TITLE
Native click action

### DIFF
--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -639,6 +639,28 @@ newDiv.parentNode.style.overflow = 'hidden';
         action.perform()
 
     @keyword
+    def click_element_native(self, locator):
+        """Click the element ``locator`` using native mouse click (ActionChain).
+
+        The Cursor is moved and the center of the element and a click is issued.
+
+        See the `Locating elements` section for details about the locator
+        syntax.
+        """
+        self.info("Clicking element '%s'" % (locator))
+        element = self.find_element(locator)
+        action = ActionChains(self.driver)
+        # Try/except can be removed when minimum required Selenium is 4.0 or greater.
+        try:
+            action.move_to_element(element)
+        except AttributeError:
+            self.debug('Workaround for Selenium 3 bug.')
+            element = element.wrapped_element
+            action.move_to_element(element)
+        action.click()
+        action.perform()
+        
+    @keyword
     def double_click_element(self, locator):
         """Double clicks the element identified by ``locator``.
 

--- a/utest/test/api/test_plugins.py
+++ b/utest/test/api/test_plugins.py
@@ -22,7 +22,7 @@ class ExtendingSeleniumLibrary(unittest.TestCase):
     def test_no_libraries(self):
         for item in [None, 'None', '']:
             sl = SeleniumLibrary(plugins=item)
-            self.assertEqual(len(sl.get_keyword_names()), 173)
+            self.assertEqual(len(sl.get_keyword_names()), 174)
 
     def test_parse_library(self):
         plugin = 'path.to.MyLibrary'


### PR DESCRIPTION
Allows a user to click an element using a native (ActionChain) click without the need to specify coordinates. Keyword is:

`| Click Element Native | <locator> |`