### PR TITLE
Added action-chain click option

### DIFF
--- a/atest/acceptance/keywords/click_element.robot
+++ b/atest/acceptance/keywords/click_element.robot
@@ -40,7 +40,7 @@ Click Element Action Chain
     [Tags]    NoGrid
     [Documentation]
     ...    LOB 1:1 INFO        Clicking 'singleClickButton' using an action chain.
-    ...    LOG 2:5 DEBUG GLOB: *actions {"actions": [{"type": "pointer",*
+    ...    LOG 2:5 DEBUG GLOB: *actions {"actions": [{*
     Click Element    singleClickButton      action_chain=True
     Element Text Should Be    output    single clicked
 

--- a/atest/acceptance/keywords/click_element.robot
+++ b/atest/acceptance/keywords/click_element.robot
@@ -37,7 +37,9 @@ Double Click Element Error
     Double Click Element    id:öööö
 
 Click Element Action Chain
-    [Documentation]   LOG 2:5 DEBUG GLOB: *actions {"actions": [{"type": "pointer",*
+    [Documentation]
+    ...    LOB 1:1 INFO        Clicking 'singleClickButton' using an action chain.
+    ...    LOG 2:5 DEBUG GLOB: *actions {"actions": [{"type": "pointer",*
     Click Element    singleClickButton      action_chain=True
     Element Text Should Be    output    single clicked
 

--- a/atest/acceptance/keywords/click_element.robot
+++ b/atest/acceptance/keywords/click_element.robot
@@ -38,6 +38,7 @@ Double Click Element Error
 
 Click Element Action Chain
     [Documentation]   Clicks an element using the 'action_chain' argument without a modifier
+    ...               LOG 2     REGEXP: Clicking '.*' using an action chain.
     Click Element    singleClickButton      action_chain=True
     Element Text Should Be    output    single clicked
 

--- a/atest/acceptance/keywords/click_element.robot
+++ b/atest/acceptance/keywords/click_element.robot
@@ -37,6 +37,7 @@ Double Click Element Error
     Double Click Element    id:öööö
 
 Click Element Action Chain
+    [Tags]    NoGrid
     [Documentation]
     ...    LOB 1:1 INFO        Clicking 'singleClickButton' using an action chain.
     ...    LOG 2:5 DEBUG GLOB: *actions {"actions": [{"type": "pointer",*

--- a/atest/acceptance/keywords/click_element.robot
+++ b/atest/acceptance/keywords/click_element.robot
@@ -37,7 +37,7 @@ Double Click Element Error
     Double Click Element    id:öööö
 
 Click Element Action Chain
-    [Documentation]   LOG 2     REGEXP: Clicking '.*' using an action chain.
+    [Documentation]   LOG 2:5 DEBUG GLOB: *actions {"actions": [{"type": "pointer",*
     Click Element    singleClickButton      action_chain=True
     Element Text Should Be    output    single clicked
 

--- a/atest/acceptance/keywords/click_element.robot
+++ b/atest/acceptance/keywords/click_element.robot
@@ -37,8 +37,7 @@ Double Click Element Error
     Double Click Element    id:öööö
 
 Click Element Action Chain
-    [Documentation]   Clicks an element using the 'action_chain' argument without a modifier
-    ...               LOG 2     REGEXP: Clicking '.*' using an action chain.
+    [Documentation]   LOG 2     REGEXP: Clicking '.*' using an action chain.
     Click Element    singleClickButton      action_chain=True
     Element Text Should Be    output    single clicked
 

--- a/atest/acceptance/keywords/click_element.robot
+++ b/atest/acceptance/keywords/click_element.robot
@@ -36,6 +36,11 @@ Double Click Element Error
     [Setup]    Go To Page "javascript/click.html"
     Double Click Element    id:öööö
 
+Click Element Action Chain
+    [Documentation]   Clicks an element using the 'action_chain' argument without a modifier
+    Click Element    singleClickButton      action_chain=True
+    Element Text Should Be    output    single clicked
+
 *** Keywords ***
 Initialize Page
     [Documentation]    Initialize Page

--- a/atest/acceptance/keywords/click_element_modifier.robot
+++ b/atest/acceptance/keywords/click_element_modifier.robot
@@ -47,7 +47,6 @@ Click Element Action Chain and modifier
     Click Element    Button    modifier=CTRL    action_chain=True
     Element Text Should Be    output    CTRL click
     
-
 *** Keywords ***
 Initialize Page
     Reload Page

--- a/atest/acceptance/keywords/click_element_modifier.robot
+++ b/atest/acceptance/keywords/click_element_modifier.robot
@@ -43,7 +43,7 @@ Click Element Wrong Modifier
     ...    Click Element    Button    Foobar
 
 Click Element Action Chain and modifier
-    [Documentation]     LOG 2     REGEXP: Clicking .* '.*' with .*.
+    [Documentation]     LOG 2:1 INFO Clicking element 'Button' with CTRL.
     Click Element    Button    modifier=CTRL    action_chain=True
     Element Text Should Be    output    CTRL click
     

--- a/atest/acceptance/keywords/click_element_modifier.robot
+++ b/atest/acceptance/keywords/click_element_modifier.robot
@@ -42,6 +42,12 @@ Click Element Wrong Modifier
     ...    ValueError: 'FOOBAR' modifier does not match to Selenium Keys
     ...    Click Element    Button    Foobar
 
+Click Element Action Chain and modifier
+    [Documentation]   Clicks an element with both a valid modifier and action_chain argument. Modifier should should take precedent
+    Click Element    Button    modifier=CTRL    action_chain=True
+    Element Text Should Be    output    CTRL click
+    
+
 *** Keywords ***
 Initialize Page
     Reload Page

--- a/atest/acceptance/keywords/click_element_modifier.robot
+++ b/atest/acceptance/keywords/click_element_modifier.robot
@@ -43,8 +43,7 @@ Click Element Wrong Modifier
     ...    Click Element    Button    Foobar
 
 Click Element Action Chain and modifier
-    [Documentation]   Clicks an element with both a valid modifier and action_chain argument. Modifier should should take precedent
-    ...               LOG 2     REGEXP: Clicking .* '.*' with .*.
+    [Documentation]     LOG 2     REGEXP: Clicking .* '.*' with .*.
     Click Element    Button    modifier=CTRL    action_chain=True
     Element Text Should Be    output    CTRL click
     

--- a/atest/acceptance/keywords/click_element_modifier.robot
+++ b/atest/acceptance/keywords/click_element_modifier.robot
@@ -44,6 +44,7 @@ Click Element Wrong Modifier
 
 Click Element Action Chain and modifier
     [Documentation]   Clicks an element with both a valid modifier and action_chain argument. Modifier should should take precedent
+    ...               LOG 2     REGEXP: Clicking .* '.*' with .*.
     Click Element    Button    modifier=CTRL    action_chain=True
     Element Text Should Be    output    CTRL click
     

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -571,7 +571,7 @@ newDiv.parentNode.style.overflow = 'hidden';
             self._click_with_modifier(locator, ['link', 'link'], modifier)
 
     @keyword
-    def click_element(self, locator, modifier=False):
+    def click_element(self, locator, modifier=False, action_chain=False):
         """Click the element identified by ``locator``.
 
         See the `Locating elements` section for details about the locator
@@ -586,16 +586,29 @@ newDiv.parentNode.style.overflow = 'hidden';
         [https://seleniumhq.github.io/selenium/docs/api/py/webdriver/selenium.webdriver.common.keys.html#selenium.webdriver.common.keys.Keys.ALT|ALT key]
         . If ``modifier`` does not match to Selenium Keys, keyword fails.
 
+        The ``action_chain`` argument can be set to True to use an ActionChain
+        based click instead of the <web_element>.click() function. In this case,
+        an action chain is created which locates the element, moves the mouse to
+        that element, then clicks the mouse.
+
         Example:
         | Click Element | id:button | | # Would click element without any modifiers. |
         | Click Element | id:button | CTRL | # Would click element with CTLR key pressed down. |
         | Click Element | id:button | CTRL+ALT | # Would click element with CTLR and ALT keys pressed down. |
+        | Click Element | id:button | action_chain=True | # Clicks the button using an action chain |
 
         The ``modifier`` argument is new in SeleniumLibrary 3.2
         """
         if is_falsy(modifier):
-            self.info("Clicking element '%s'." % locator)
-            self.find_element(locator).click()
+            if is_falsy(action_chain):
+                self.info("Clicking element '%s'." % locator)
+                self.find_element(locator).click()
+            else:
+                action = ActionChains(self.driver)
+                element = self.find_element(locator)
+                action.move_to_element(element)
+                action.click()
+                action.perform()
         else:
             self._click_with_modifier(locator, [None, None], modifier)
 

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -590,7 +590,7 @@ newDiv.parentNode.style.overflow = 'hidden';
         based click instead of the <web_element>.click() function. In this case,
         an action chain is created which locates the element, moves the mouse to
         that element, then clicks the mouse. If both ``action_chain`` and ``modifier``
-        are valid, the click will be performed using ``modifier``, and ``action_chain``
+        are valid, the click will be performed using ``modifier`` and ``action_chain``
         will be ignored.
 
         Example:

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -589,7 +589,9 @@ newDiv.parentNode.style.overflow = 'hidden';
         The ``action_chain`` argument can be set to True to use an ActionChain
         based click instead of the <web_element>.click() function. In this case,
         an action chain is created which locates the element, moves the mouse to
-        that element, then clicks the mouse.
+        that element, then clicks the mouse. If both ``action_chain`` and ``modifier``
+        are valid, the click will be performed using ``modifier``, and ``action_chain``
+        will be ignored.
 
         Example:
         | Click Element | id:button | | # Would click element without any modifiers. |
@@ -599,18 +601,22 @@ newDiv.parentNode.style.overflow = 'hidden';
 
         The ``modifier`` argument is new in SeleniumLibrary 3.2
         """
-        if is_falsy(modifier):
-            if is_falsy(action_chain):
+        if is_truthy(modifier):
+            self._click_with_modifier(locator, [None, None], modifier)
+        else:
+            if is_truthy(action_chain):
+                self._click_with_action_chain(locator)
+            else:
                 self.info("Clicking element '%s'." % locator)
                 self.find_element(locator).click()
-            else:
-                action = ActionChains(self.driver)
-                element = self.find_element(locator)
-                action.move_to_element(element)
-                action.click()
-                action.perform()
-        else:
-            self._click_with_modifier(locator, [None, None], modifier)
+
+    def _click_with_action_chain(self, locator):
+        self.info("Clicking '%s' using an action chain." % locator)
+        action = ActionChains(self.driver)
+        element = self.find_element(locator)
+        action.move_to_element(element)
+        action.click()
+        action.perform()
 
     def _click_with_modifier(self, locator, tag, modifier):
         self.info("Clicking %s '%s' with %s." % (tag if tag[0] else 'element', locator, modifier))

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -586,18 +586,17 @@ newDiv.parentNode.style.overflow = 'hidden';
         [https://seleniumhq.github.io/selenium/docs/api/py/webdriver/selenium.webdriver.common.keys.html#selenium.webdriver.common.keys.Keys.ALT|ALT key]
         . If ``modifier`` does not match to Selenium Keys, keyword fails.
 
-        The ``action_chain`` argument can be set to True to use an ActionChain
-        based click instead of the <web_element>.click() function. In this case,
-        an action chain is created which locates the element, moves the mouse to
-        that element, then clicks the mouse. If both ``action_chain`` and ``modifier``
-        are valid, the click will be performed using ``modifier`` and ``action_chain``
-        will be ignored.
+        If ``action_chain`` argument is true, see `Boolean arguments` for more
+        details on how to set boolean argument, then keyword uses ActionChain
+        based click instead of the <web_element>.click() function. If both
+        ``action_chain`` and ``modifier`` are defined, the click will be
+        performed using ``modifier`` and ``action_chain`` will be ignored.
 
         Example:
-        | Click Element | id:button | | # Would click element without any modifiers. |
-        | Click Element | id:button | CTRL | # Would click element with CTLR key pressed down. |
-        | Click Element | id:button | CTRL+ALT | # Would click element with CTLR and ALT keys pressed down. |
-        | Click Element | id:button | action_chain=True | # Clicks the button using an action chain |
+        | Click Element | id:button |                   | # Would click element without any modifiers.               |
+        | Click Element | id:button | CTRL              | # Would click element with CTLR key pressed down.          |
+        | Click Element | id:button | CTRL+ALT          | # Would click element with CTLR and ALT keys pressed down. |
+        | Click Element | id:button | action_chain=True | # Clicks the button using an Selenium  ActionChains        |
 
         The ``modifier`` argument is new in SeleniumLibrary 3.2
         The ``action_chain`` argument is new in SeleniumLibrary 4.1

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -600,6 +600,7 @@ newDiv.parentNode.style.overflow = 'hidden';
         | Click Element | id:button | action_chain=True | # Clicks the button using an action chain |
 
         The ``modifier`` argument is new in SeleniumLibrary 3.2
+        The ``action_chain`` argument is new in SeleniumLibrary 4.1
         """
         if is_truthy(modifier):
             self._click_with_modifier(locator, [None, None], modifier)

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -603,12 +603,11 @@ newDiv.parentNode.style.overflow = 'hidden';
         """
         if is_truthy(modifier):
             self._click_with_modifier(locator, [None, None], modifier)
+        elif is_truthy(action_chain):
+            self._click_with_action_chain(locator)
         else:
-            if is_truthy(action_chain):
-                self._click_with_action_chain(locator)
-            else:
-                self.info("Clicking element '%s'." % locator)
-                self.find_element(locator).click()
+            self.info("Clicking element '%s'." % locator)
+            self.find_element(locator).click()
 
     def _click_with_action_chain(self, locator):
         self.info("Clicking '%s' using an action chain." % locator)


### PR DESCRIPTION
This PR introduces an option to `Click Element` which enables a user to use Selenium ActionChains to issue a click action on an element instead of using the <web_element>.click() function. This enables a more "native" click of any element in the UI. This is in response to issue #1463 