### PR TITLE
Chromium-based app example

### DIFF
--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -189,6 +189,21 @@ class BrowserManagementKeywords(LibraryComponent):
         Then the `${options}` variable can be used as an argument to
         ``options``.
 
+        The ``options`` argument also makes it easy to test Chomium-based
+        applications which utilize the Chromium Embedded Framework (aka CEF)
+        such as those created using QtWebEngine. This is accomplished
+        using the ChromeDriver webdriver included with Selenium.
+        All that is needed is a binary location of the application under
+        test and a remote debugging port for ChromeDriver to interface
+        with.
+        (https://bitbucket.org/chromiumembedded/cef/wiki/UsingChromeDriver)
+
+        Example:
+        | `Open Browser` | browser=Chrome | options=binary_location="<path/to/binary>";add_argument("remote-debugging-port=<port>") |
+
+        Once opened, the user can interact with the embedded web-content of
+        the application under test.
+
         Optional ``service_log_path`` argument defines the name of the
         file where to write the browser driver logs. If the
         ``service_log_path``  argument contain a  marker ``{index}``, it

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -189,20 +189,14 @@ class BrowserManagementKeywords(LibraryComponent):
         Then the `${options}` variable can be used as an argument to
         ``options``.
 
-        The ``options`` argument also makes it easy to test Chomium-based
-        applications which utilize the Chromium Embedded Framework (aka CEF)
-        such as those created using QtWebEngine. This is accomplished
-        using the ChromeDriver webdriver included with Selenium.
-        All that is needed is a binary location of the application under
-        test and a remote debugging port for ChromeDriver to interface
-        with.
-        (https://bitbucket.org/chromiumembedded/cef/wiki/UsingChromeDriver)
-
-        Example:
-        | `Open Browser` | browser=Chrome | options=binary_location="<path/to/binary>";add_argument("remote-debugging-port=<port>") |
-
-        Once opened, the user can interact with the embedded web-content of
-        the application under test.
+        Example the ``options`` argument can be used to launch Chomium-based
+        applications which utilize the 
+        [https://bitbucket.org/chromiumembedded/cef/wiki/UsingChromeDriver|Chromium Embedded Framework]
+        . To lauch Chomium-based application, use ``options`` to define
+        `binary_location` attribute and use `add_argument` method to define
+        `remote-debugging-port` port for the application. Once the browser
+        is opened, the test can interact with the embedded web-content of
+        the system under test.
 
         Optional ``service_log_path`` argument defines the name of the
         file where to write the browser driver logs. If the
@@ -231,9 +225,10 @@ class BrowserManagementKeywords(LibraryComponent):
         Example when using
         [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_chrome/selenium.webdriver.chrome.options.html#selenium.webdriver.chrome.options.Options|Chrome options]
         method:
-        | `Open Browser` | http://example.com | Chrome | options=add_argument("--disable-popup-blocking"); add_argument("--ignore-certificate-errors") | # Sting format              |
-        |  ${options} =  |     Get Options    |        |                                                                                               | # Selenium options instance |
-        | `Open Browser` | http://example.com | Chrome | options=${options}                                                                            |                             |
+        | `Open Browser` | http://example.com | Chrome | options=add_argument("--disable-popup-blocking"); add_argument("--ignore-certificate-errors") | # Sting format                    |
+        |  ${options} =  |     Get Options    |        |                                                                                               | # Selenium options instance       |
+        | `Open Browser` | http://example.com | Chrome | options=${options}                                                                            |                                   |
+        | `Open Browser` | None               | Chrome | options=binary_location="/path/to/binary";add_argument("remote-debugging-port=port")          | # Start Chomium-based application |
 
         Example for FirefoxProfile
         | `Open Browser` | http://example.com | Firefox | ff_profile_dir=/path/to/profile                                                  | # Using profile from disk                       |


### PR DESCRIPTION
Adds an example of how to open up an application built with the Chromium Embedded Framework instead of an internet browser. In response to issue #1461 