### PR TITLE
Fixed table *  should contains keywords

### DIFF
--- a/atest/acceptance/keywords/tables/footer_should_contain.robot
+++ b/atest/acceptance/keywords/tables/footer_should_contain.robot
@@ -13,3 +13,8 @@ Should Give Error Message When Content Not Found In Table Footer
     Run Keyword And Expect Error
     ...    Table 'withHeadAndFoot' footer did not contain text 'withHeadAndFoot_B2'.
     ...    Table Footer Should Contain    withHeadAndFoot    withHeadAndFoot_B2
+
+Should Give Error Message When Content Not Found In Table Footer But Is Other Table
+    Run Keyword And Expect Error
+    ...    Table 'tableWithSingleHeader' footer did not contain text 'SimpleWithHeadAndFoot_CF1'.
+    ...    Table Footer Should Contain    tableWithSingleHeader    SimpleWithHeadAndFoot_CF1

--- a/atest/acceptance/keywords/tables/header_should_contain.robot
+++ b/atest/acceptance/keywords/tables/header_should_contain.robot
@@ -17,3 +17,8 @@ Should Give Error Message When Content Not Found In Table Header
     Run Keyword And Expect Error
     ...    Table 'withHeadAndFoot' header did not contain text 'withHeadAndFoot_B2'.
     ...    Table Header Should Contain    withHeadAndFoot    withHeadAndFoot_B2
+
+Should Give Error Message When Content Not Found In Table Header But Is Other Table
+    Run Keyword And Expect Error
+    ...    Table 'tableWithSingleHeader' header did not contain text 'tableWithTwoHeaders_C1'.
+    ...    Table Header Should Contain    tableWithSingleHeader    tableWithTwoHeaders_C1

--- a/atest/acceptance/keywords/tables/negative_indexes.robot
+++ b/atest/acceptance/keywords/tables/negative_indexes.robot
@@ -27,4 +27,4 @@ Test negative index for XPath strategy in 'Table Cell Should Contain'
 
 Test negative index for CSS strategy in 'Table Cell Should Contain'
     Table Cell Should Contain    xpath=//*[@name='simpleTableName']
-    ...    -1    -2    simpleTableName_B3
+    ...    -1    -2    simpleTableName_B4

--- a/atest/acceptance/keywords/tables/table_should_contain.robot
+++ b/atest/acceptance/keywords/tables/table_should_contain.robot
@@ -30,3 +30,9 @@ Should Give Error Message When Content Not Found In Table
     Run Keyword And Expect Error
     ...    Table 'simpleTable' did not contain text 'Not here'.
     ...    Table Should Contain    simpleTable    Not here
+
+
+Should Give Error Message When Content Not Found In Table But Is In Table In Below
+    Run Keyword And Expect Error
+    ...    Table 'simpleTable' did not contain text 'impleTableName_C4'.
+    ...    Table Should Contain    simpleTable    impleTableName_C4

--- a/atest/resources/html/tables/tables.html
+++ b/atest/resources/html/tables/tables.html
@@ -41,6 +41,11 @@
     <td>simpleTableName_B3</td>
     <td>simpleTableName_C3</td>
   </tr>
+  <tr>
+    <td>simpleTableName_A4</td>
+    <td>simpleTableName_B4</td>
+    <td>simpleTableName_C4</td>
+  </tr>
 </table>
 
 <h2>Simple Table With Nested Table</h2>
@@ -162,6 +167,31 @@
       <td>withHeadAndFoot_A3</td>
       <td>withHeadAndFoot_B3</td>
       <td>withHeadAndFoot_C3</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>Another table with thead, tfoot and tbody sections</h2>
+<table id="SimpleWithHeadAndFoot" border="1" rules="groups">
+  <thead>
+    <tr>
+      <th>SimpleWithHeadAndFoot_AH1</th>
+      <th>SimpleWithHeadAndFoot_BH1</th>
+      <th>SimpleWithHeadAndFoot_CH1</th>
+    </tr>
+  </thead>
+  <tfoot>
+    <tr>
+      <td>SimpleWithHeadAndFoot_AF1</td>
+      <td>SimpleWithHeadAndFoot_BF1</td>
+      <td>SimpleWithHeadAndFoot_CF1</td>
+    </tr>
+  </tfoot>
+  <tbody>
+    <tr>
+      <td>SimpleWithHeadAndFoot_A1</td>
+      <td>SimpleWithHeadAndFoot_B1</td>
+      <td>SimpleWithHeadAndFoot_C1</td>
     </tr>
   </tbody>
 </table>

--- a/src/SeleniumLibrary/keywords/tableelement.py
+++ b/src/SeleniumLibrary/keywords/tableelement.py
@@ -194,13 +194,13 @@ class TableElementKeywords(LibraryComponent):
                                  % (locator, expected))
 
     def _find_by_content(self, table_locator, content):
-        return self._find(table_locator, '//*', content)
+        return self._find(table_locator, 'xpath:.//*', content)
 
     def _find_by_header(self, table_locator, content):
-        return self._find(table_locator, '//th', content)
+        return self._find(table_locator, 'xpath:.//th', content)
 
     def _find_by_footer(self, table_locator, content):
-        return self._find(table_locator, '//tfoot//td', content)
+        return self._find(table_locator, 'xpath:.//tfoot//td', content)
 
     def _find_by_row(self, table_locator, row, content):
         position = self._index_to_position(row)


### PR DESCRIPTION
Since SeleniumLibrary 3.0 release, `Table Should Contain`, `Table Header Should Contain` and `Table Footer Should Contain` have searched text not only from table but from the whole page. 

This PR fixes the problem, described in #1482 