### PR TITLE
Fix close browser not delete alias

### DIFF
--- a/atest/acceptance/open_and_close.robot
+++ b/atest/acceptance/open_and_close.robot
@@ -35,10 +35,9 @@ Switch to closed browser is possible
     Close Browser
     Switch Browser    Browser 3
     Page Should Contain    Name:
-    Switch Browser    Browser 2
     Run Keyword And Expect Error
-    ...    *
-    ...    Page Should Contain    Name:
+    ...    No browser with index or alias 'Browser 2' found.
+    ...    Switch Browser    Browser 2
     Close All Browsers
 
 Closing all browsers clears cache

--- a/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
+++ b/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
@@ -337,6 +337,9 @@ class WebDriverCache(ConnectionCache):
         if self.current:
             driver = self.current
             error = self._quit(driver, None)
+            for alias in self._aliases:
+                if self._aliases[alias] == self.current_index:
+                    del self._aliases[alias]
             self.current = self._no_current
             self._closed.add(driver)
             if error:


### PR DESCRIPTION
I make a workaround to remove the index in the alias cache. If there is a better way to get the alias of the current index, please let me know.

Fix #1416 

Signed-off-by: Jia-wei Yu <art96962006@gmail.com>