### PR TITLE
Fix link to SeleniumHQ from current README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -264,7 +264,7 @@ Going forward, all new development will happen in the new SeleniumLibrary
 project.
 
 .. _Robot Framework: https://robotframework.org
-.. _Selenium: https://seleniumhq.org
+.. _Selenium: https://www.seleniumhq.org/
 .. _SeleniumLibrary: https://github.com/robotframework/SeleniumLibrary
 .. _Selenium2Library: https://github.com/robotframework/Selenium2Library
 .. _Old SeleniumLibrary: https://github.com/robotframework/OldSeleniumLibrary


### PR DESCRIPTION
Opening the SeleniumHQ link with Firefox from the current README.rst leads to this error page from Firefox:

```
Secure Connection Failed

An error occurred during a connection to seleniumhq.org. PR_END_OF_FILE_ERROR

    The page you are trying to view cannot be shown because the authenticity of the received data could not be verified.
    Please contact the website owners to inform them of this problem.
```

This should fix the link.