### PR TITLE
Fixes "path too long for Windows" in Execute JavaScript keyword

### DIFF
--- a/src/SeleniumLibrary/keywords/javascript.py
+++ b/src/SeleniumLibrary/keywords/javascript.py
@@ -115,7 +115,7 @@ class JavaScriptKeywords(LibraryComponent):
             raise ValueError('JavaScript code was not found from code argument.')
         js_code = ''.join(js_code)
         path = js_code.replace('/', os.sep)
-        if os.path.isfile(path):
+        if os.path.isabs(path) and os.path.isfile(path):
             js_code = self._read_javascript_from_file(path)
         return js_code, js_args
 


### PR DESCRIPTION
On Windows 7, the "Execute Javascript" keywords can throw exception in case the code body exceed 32K characters.
The reason is inside the implementation of the "Execute Javascript" keyword, where it tries to detect if a js path is passed as argument, instead of javascript source code.

The regression was introduced with commit 8edce40cd069172fe3478c42300f65c06c466f8a.
Previously, the check was more robust:
```
if os.path.isabs(path) and os.path.isfile(path):
``` 
and now only
```
if os.path.isfile(path):
```

The `os.path.isfile()` fails with a path longer than 32768 characters on Windows 7 (not replicable on Windows 10). The `os.path.isabs()` call is not failing with long paths, and correctly returns False.

```
os.path.isabs("x" * 40000)  # Returns False
os.path.isfile("x" * 40000)   # Crashes with "stat: path too long for Windows" on Win7
```

Tested on Python 3.7 64-bit.
Thanks, Luciano