### PR TITLE
Rename New in SeleniumLibrary 5.0 -> 4.3

### DIFF
--- a/src/SeleniumLibrary/keywords/waiting.py
+++ b/src/SeleniumLibrary/keywords/waiting.py
@@ -87,7 +87,7 @@ class WaitingKeywords(LibraryComponent):
         The ``message`` argument can be used to override the default error
         message.
 
-        New in SeleniumLibrary 5.0
+        New in SeleniumLibrary 4.3
         """
         location = str(location)
         self._wait_until(lambda: location != self.driver.current_url,
@@ -127,7 +127,7 @@ class WaitingKeywords(LibraryComponent):
         The ``message`` argument can be used to override the default error
         message.
 
-        New in SeleniumLibrary 5.0
+        New in SeleniumLibrary 4.3
         """
         location = str(location)
         self._wait_until(lambda: location not in self.driver.current_url,


### PR DESCRIPTION
Because next release is not 5.0 but it is 4.3 because of #1548 