### PR TITLE
Use correct directory for screenshots when EMBED is default

### DIFF
--- a/atest/acceptance/keywords/screenshots_embed.robot
+++ b/atest/acceptance/keywords/screenshots_embed.robot
@@ -33,6 +33,16 @@ Capture Element Screenshot EMBED As File Name
     Should Be Equal    ${file}    EMBED
     Verify That .png Files Do Not Exist
 
+Capture Page Screenshot Override EMBED
+    [Tags]    NoGrid
+    [Setup]    Remove .png Files
+    Set Screenshot Directory    EMBED
+    ${file}=    Capture Page Screenshot    override-embed-screenshot.png
+    Should Be Equal    ${file}    ${OUTPUTDIR}/override-embed-screenshot.png
+    File Should Exist    ${OUTPUTDIR}/override-embed-screenshot.png
+    File Should Not Exist    ${EXECDIR}/*.png
+    File Should Not Exist    ${EXECDIR}/EMBED/*.png
+
 *** Keywords ***
 Remove .png Files
     Remove Files     ${OUTPUTDIR}/*.png
@@ -42,4 +52,4 @@ Remove .png Files
 Verify That .png Files Do Not Exist
     File Should Not Exist    ${OUTPUTDIR}/*.png
     File Should Not Exist    ${EXECDIR}/*.png
-    File Should Not Exist    ${EXECDIR}/Embed/*.png
+    File Should Not Exist    ${EXECDIR}/EMBED/*.png

--- a/src/SeleniumLibrary/keywords/screenshot.py
+++ b/src/SeleniumLibrary/keywords/screenshot.py
@@ -185,7 +185,10 @@ class ScreenshotKeywords(LibraryComponent):
         return False
 
     def _get_screenshot_path(self, filename):
-        directory = self._screenshot_root_directory or self.log_dir
+        if self._screenshot_root_directory != EMBED:
+            directory = self._screenshot_root_directory or self.log_dir
+        else:
+            directory = self.log_dir
         filename = filename.replace('/', os.sep)
         index = 0
         while True:

--- a/utest/test/keywords/test_screen_shot.py
+++ b/utest/test/keywords/test_screen_shot.py
@@ -1,4 +1,4 @@
-from os.path import dirname, abspath
+from os.path import dirname, abspath, join
 
 import pytest
 from mockito import mock, unstub
@@ -40,6 +40,13 @@ def test_file_name_embeded(screen_shot):
     assert screen_shot._decide_embedded('other.psn') is False
     screen_shot.ctx.screenshot_root_directory = EMBED
     assert screen_shot._decide_embedded(EMBED) is True
+
+
+def test_screenshot_path_embedded(screen_shot):
+    screen_shot.ctx.screenshot_root_directory = EMBED
+    assert screen_shot._get_screenshot_path('override.png') == join(
+        screen_shot.log_dir, 'override.png'
+    )
 
 
 def test_sl_init_embed():


### PR DESCRIPTION
It's possible to set EMBED as the default option for screenshots and override it in a per keyword basis to actual file paths. It worked correctly by accident with absolute paths, because of how os.path.join() works, but created an 'EMBED' folder with relative paths.

Note: The acceptance test documentation fields seemed to contain some XML, but wasn't sure what the purpose was. Left it empty for now.