### PR TITLE
Drop support for EOL Python 2.7

### DIFF
--- a/atest/README.rst
+++ b/atest/README.rst
@@ -64,7 +64,7 @@ Examples
 Examples::
 
     run.py chrome
-    run.py --interpreter jython firefox --suite javascript
+    run.py --interpreter c:\Python38\python.exe firefox --suite javascript
     run.py headlesschrome --nounit --grid true
     run.py --interpreter "py -2" chrome --suite javascript
 

--- a/atest/acceptance/1-plugin/MyPlugin.py
+++ b/atest/acceptance/1-plugin/MyPlugin.py
@@ -4,7 +4,7 @@ from SeleniumLibrary.base import LibraryComponent, keyword
 from SeleniumLibrary.locators import ElementFinder
 
 
-class DummyFinder(object):
+class DummyFinder:
     def __init__(self, ctx):
         self.ctx = ctx
 

--- a/atest/acceptance/1-plugin/PluginWithAllArgs.py
+++ b/atest/acceptance/1-plugin/PluginWithAllArgs.py
@@ -14,8 +14,8 @@ class PluginWithAllArgs(LibraryComponent):
     def return_all_args_as_string(self):
         joined_str = "start: arg=%s," % self.arg
         for arg in self.varargs:
-            joined_str = "%s %s," % (joined_str, arg)
+            joined_str = f"{joined_str} {arg},"
         kwargs = OrderedDict(sorted(self.kwargs.items()))
         for key in kwargs:
-            joined_str = "%s %s=%s," % (joined_str, key, kwargs[key])
+            joined_str = "{} {}={},".format(joined_str, key, kwargs[key])
         return joined_str[:-1]

--- a/atest/acceptance/1-plugin/PluginWithArgs.py
+++ b/atest/acceptance/1-plugin/PluginWithArgs.py
@@ -9,4 +9,4 @@ class PluginWithArgs(LibraryComponent):
 
     @keyword
     def return_arg1_arg2_as_string(self):
-        return "%s %s" % (self.arg1, self.arg2)
+        return f"{self.arg1} {self.arg2}"

--- a/atest/acceptance/1-plugin/PluginWithKwArgs.py
+++ b/atest/acceptance/1-plugin/PluginWithKwArgs.py
@@ -13,5 +13,5 @@ class PluginWithKwArgs(LibraryComponent):
         kwargs = OrderedDict(sorted(self.kwargs.items()))
         joined_str = "start:"
         for key in kwargs:
-            joined_str = "%s %s=%s," % (joined_str, key, kwargs[key])
+            joined_str = "{} {}={},".format(joined_str, key, kwargs[key])
         return joined_str[:-1]

--- a/atest/acceptance/1-plugin/PluginWithVarArgs.py
+++ b/atest/acceptance/1-plugin/PluginWithVarArgs.py
@@ -10,5 +10,5 @@ class PluginWithVarArgs(LibraryComponent):
     def return_var_args_as_string(self):
         joined_str = "start:"
         for arg in self.args:
-            joined_str = "%s %s," % (joined_str, arg)
+            joined_str = f"{joined_str} {arg},"
         return joined_str[:-1]

--- a/atest/resources/testlibs/BigListOfNaughtyStrings.py
+++ b/atest/resources/testlibs/BigListOfNaughtyStrings.py
@@ -5,7 +5,7 @@ import platform
 from robot.api import logger
 
 
-class BigListOfNaughtyStrings(object):
+class BigListOfNaughtyStrings:
     """The  Big List of Naughty Strings is originally copied from here:
     https://github.com/minimaxir/big-list-of-naughty-strings
     """
@@ -17,5 +17,5 @@ class BigListOfNaughtyStrings(object):
             )
             return []
         cur_dir = os.path.dirname(os.path.abspath(__file__))
-        with open(os.path.join(cur_dir, "blns.json"), "r") as blns:
+        with open(os.path.join(cur_dir, "blns.json")) as blns:
             return json.load(blns)

--- a/atest/resources/testlibs/CustomSeleniumKeywords.py
+++ b/atest/resources/testlibs/CustomSeleniumKeywords.py
@@ -9,7 +9,7 @@ class CustomSeleniumKeywords(SeleniumLibrary):
         """Share `SeleniumLibrary`'s cache of browsers, so that
         we don't have to open a separate browser instance for the
         `Run On Failure Keyword Only Called Once` test."""
-        super(CustomSeleniumKeywords, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         sl = BuiltIn().get_library_instance("SeleniumLibrary")
         self._drivers = sl._drivers
 

--- a/atest/resources/testserver/testserver.py
+++ b/atest/resources/testserver/testserver.py
@@ -6,15 +6,9 @@ from __future__ import print_function
 import os
 import sys
 
-try:
-    from httplib import HTTPConnection
-    from BaseHTTPServer import HTTPServer
-    from SimpleHTTPServer import SimpleHTTPRequestHandler
-    from SocketServer import ThreadingMixIn
-except ImportError:  # Python 3
-    from http.client import HTTPConnection
-    from http.server import SimpleHTTPRequestHandler, HTTPServer
-    from socketserver import ThreadingMixIn
+from http.client import HTTPConnection
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
 
 
 class StoppableHttpRequestHandler(SimpleHTTPRequestHandler):

--- a/atest/resources/testserver/testserver.py
+++ b/atest/resources/testserver/testserver.py
@@ -1,8 +1,6 @@
 # Initially based on:
 # http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/336012
 
-from __future__ import print_function
-
 import os
 import sys
 

--- a/atest/run.py
+++ b/atest/run.py
@@ -34,7 +34,7 @@ Examples:
 
     run.py chrome
     run.py headlesschrome
-    run.py --interpreter jython firefox --suite javascript
+    run.py --interpreter c:\Python38\python.exe firefox --suite javascript
     run.py headlesschrome --nounit --grid true
 """
 
@@ -274,7 +274,7 @@ if __name__ == "__main__":
         help=textwrap.dedent(
             """\
                             Any Python interpreter supported by the library.
-                            E.g. `python`, `jython` or `c:\\Python27\\python.exe`.
+                            E.g. `python` or `c:\\Python38\\python.exe`.
                             By default set to `python`."""
         ),
     )

--- a/atest/run.py
+++ b/atest/run.py
@@ -38,8 +38,6 @@ Examples:
     run.py headlesschrome --nounit --grid true
 """
 
-from __future__ import print_function
-
 import platform
 import time
 import zipfile
@@ -251,7 +249,7 @@ def create_zip():
         shutil.rmtree(ZIP_DIR)
     os.mkdir(ZIP_DIR)
     python_version = platform.python_version()
-    zip_name = "rf-%s-python-%s.zip" % (robot_version, python_version)
+    zip_name = f"rf-{robot_version}-python-{python_version}.zip"
     zip_path = os.path.join(ZIP_DIR, zip_name)
     print("Zip created in: %s" % zip_path)
     zip_file = zipfile.ZipFile(zip_path, "w")

--- a/docs/extending/examples/decomposition/Decomposition.py
+++ b/docs/extending/examples/decomposition/Decomposition.py
@@ -10,7 +10,7 @@ class BrowserKeywords(LibraryComponent):
 
     @keyword
     def open_browser(self, host):
-        url = 'http://{}.com/'.format(host)
+        url = f'http://{host}.com/'
         browser_management = BrowserManagementKeywords(self.ctx)
         browser_management.open_browser(url, 'chrome')
 

--- a/docs/extending/examples/get_instance/GetSeleniumLibraryInstance.py
+++ b/docs/extending/examples/get_instance/GetSeleniumLibraryInstance.py
@@ -3,7 +3,7 @@ from robot.libraries.BuiltIn import BuiltIn
 
 
 def open_browser(host):
-    url = 'http://{}.com/'.format(host)
+    url = f'http://{host}.com/'
     sl = BuiltIn().get_library_instance('SeleniumLibrary')
     sl.open_browser(url, 'chrome')
 

--- a/docs/extending/examples/inheritance/InheritSeleniumLibrary.py
+++ b/docs/extending/examples/inheritance/InheritSeleniumLibrary.py
@@ -8,7 +8,7 @@ class InheritSeleniumLibrary(SeleniumLibrary):
 
     @keyword
     def open_browser(self, host):
-        url = 'http://{}.com/'.format(host)
+        url = f'http://{host}.com/'
         browser_management = BrowserManagementKeywords(self)
         browser_management.open_browser(url, 'chrome')
 

--- a/docs/extending/extending/decomposition/Decomposition.py
+++ b/docs/extending/extending/decomposition/Decomposition.py
@@ -10,7 +10,7 @@ class BrowserKeywords(LibraryComponent):
 
     @keyword
     def open_browser(self, host):
-        url = 'http://{}.com/'.format(host)
+        url = f'http://{host}.com/'
         browser_management = BrowserManagementKeywords(self.ctx)
         browser_management.open_browser(url, 'chrome')
 

--- a/docs/extending/extending/get_instance/GetSeleniumLibraryInstance.py
+++ b/docs/extending/extending/get_instance/GetSeleniumLibraryInstance.py
@@ -3,7 +3,7 @@ from robot.libraries.BuiltIn import BuiltIn
 
 
 def open_browser(host):
-    url = 'http://{}.com/'.format(host)
+    url = f'http://{host}.com/'
     sl = BuiltIn().get_library_instance('SeleniumLibrary')
     sl.open_browser(url, 'chrome')
 

--- a/docs/extending/extending/inheritance/InheritSeleniumLibrary.py
+++ b/docs/extending/extending/inheritance/InheritSeleniumLibrary.py
@@ -8,7 +8,7 @@ class InheritSeleniumLibrary(SeleniumLibrary):
 
     @keyword
     def open_browser(self, host):
-        url = 'http://{}.com/'.format(host)
+        url = f'http://{host}.com/'
         browser_management = BrowserManagementKeywords(self)
         browser_management.open_browser(url, 'chrome')
 

--- a/docs/extending/plugin_api/MyPlugin.py
+++ b/docs/extending/plugin_api/MyPlugin.py
@@ -4,7 +4,7 @@ from SeleniumLibrary.base import LibraryComponent, keyword
 from SeleniumLibrary.locators import ElementFinder
 
 
-class DummyFinder(object):
+class DummyFinder:
 
     def __init__(self, ctx):
         self.ctx = ctx

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,11 @@ Development Status :: 5 - Production/Stable
 License :: OSI Approved :: Apache Software License
 Operating System :: OS Independent
 Programming Language :: Python
-Programming Language :: Python :: 2
 Programming Language :: Python :: 3
+Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3 :: Only
 Topic :: Software Development :: Testing
 Framework :: Robot Framework
 Framework :: Robot Framework :: Library
@@ -37,7 +40,7 @@ setup(
     keywords         = 'robotframework testing testautomation selenium webdriver web',
     platforms        = 'any',
     classifiers      = CLASSIFIERS,
-    python_requires  = '>=2.7.*, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4',
+    python_requires  = '>=3.6, <4',
     install_requires = REQUIREMENTS,
     package_dir      = {'': 'src'},
     packages         = find_packages('src')

--- a/src/SeleniumLibrary/base/context.py
+++ b/src/SeleniumLibrary/base/context.py
@@ -17,7 +17,7 @@
 from SeleniumLibrary.utils import escape_xpath_value
 
 
-class ContextAware(object):
+class ContextAware:
     def __init__(self, ctx):
         """Base class exposing attributes from the common context.
 

--- a/src/SeleniumLibrary/base/librarycomponent.py
+++ b/src/SeleniumLibrary/base/librarycomponent.py
@@ -45,12 +45,12 @@ class LibraryComponent(ContextAware):
         if not self.find_element(locator, tag, required=False):
             self.log_source(loglevel)
             if is_noney(message):
-                message = "Page should have contained %s '%s' but did not." % (
+                message = "Page should have contained {} '{}' but did not.".format(
                     tag or "element",
                     locator,
                 )
             raise AssertionError(message)
-        logger.info("Current page contains %s '%s'." % (tag or "element", locator))
+        logger.info("Current page contains {} '{}'.".format(tag or "element", locator))
 
     def assert_page_not_contains(
         self, locator, tag=None, message=None, loglevel="TRACE"
@@ -58,13 +58,13 @@ class LibraryComponent(ContextAware):
         if self.find_element(locator, tag, required=False):
             self.log_source(loglevel)
             if is_noney(message):
-                message = "Page should not have contained %s '%s'." % (
+                message = "Page should not have contained {} '{}'.".format(
                     tag or "element",
                     locator,
                 )
             raise AssertionError(message)
         logger.info(
-            "Current page does not contain %s '%s'." % (tag or "element", locator)
+            "Current page does not contain {} '{}'.".format(tag or "element", locator)
         )
 
     def get_timeout(self, timeout=None):

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -51,7 +51,7 @@ class BrowserManagementKeywords(LibraryComponent):
         """Closes the current browser."""
         if self.drivers.current:
             self.debug(
-                "Closing browser with session id {}.".format(self.driver.session_id)
+                f"Closing browser with session id {self.driver.session_id}."
             )
             self.drivers.close()
 
@@ -319,7 +319,7 @@ class BrowserManagementKeywords(LibraryComponent):
                 "remote server at '%s'." % (browser, url, remote_url)
             )
         else:
-            self.info("Opening browser '%s' to base url '%s'." % (browser, url))
+            self.info(f"Opening browser '{browser}' to base url '{url}'.")
         driver = self._make_driver(
             browser,
             desired_capabilities,
@@ -578,7 +578,7 @@ class BrowserManagementKeywords(LibraryComponent):
         actual = self.get_title()
         if actual != title:
             if is_noney(message):
-                message = "Title should have been '%s' but was '%s'." % (title, actual)
+                message = f"Title should have been '{title}' but was '{actual}'."
             raise AssertionError(message)
         self.info("Page title is '%s'." % title)
 

--- a/src/SeleniumLibrary/keywords/cookie.py
+++ b/src/SeleniumLibrary/keywords/cookie.py
@@ -147,7 +147,7 @@ class CookieKeywords(LibraryComponent):
             return int(convert_date(expiry, result_format="epoch"))
 
 
-class CookieInformation(object):
+class CookieInformation:
     def __init__(
         self,
         name,
@@ -170,7 +170,7 @@ class CookieInformation(object):
 
     def __str__(self):
         items = "name value path domain secure httpOnly expiry".split()
-        string = "\n".join("%s=%s" % (item, getattr(self, item)) for item in items)
+        string = "\n".join("{}={}".format(item, getattr(self, item)) for item in items)
         if self.extra:
-            string = "%s\n%s=%s\n" % (string, "extra", self.extra)
+            string = "{}\n{}={}\n".format(string, "extra", self.extra)
         return string

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -80,7 +80,7 @@ class ElementKeywords(LibraryComponent):
                     "its text was '%s'." % (locator, expected_before, actual_before)
                 )
             raise AssertionError(message)
-        self.info("Element '%s' contains text '%s'." % (locator, expected_before))
+        self.info(f"Element '{locator}' contains text '{expected_before}'.")
 
     @keyword
     def element_should_not_contain(
@@ -112,7 +112,7 @@ class ElementKeywords(LibraryComponent):
                 )
             raise AssertionError(message)
         self.info(
-            "Element '%s' does not contain text '%s'." % (locator, expected_before)
+            f"Element '{locator}' does not contain text '{expected_before}'."
         )
 
     @keyword
@@ -167,7 +167,7 @@ class ElementKeywords(LibraryComponent):
         limit = int(limit)
         count = len(self.find_elements(locator))
         if count == limit:
-            self.info("Current page contains {} element(s).".format(count))
+            self.info(f"Current page contains {count} element(s).")
         else:
             if is_noney(message):
                 message = (
@@ -190,7 +190,7 @@ class ElementKeywords(LibraryComponent):
                 )
             self.ctx.log_source(loglevel)
             raise AssertionError(message)
-        self.info("Current page contains %s elements matching '%s'." % (count, locator))
+        self.info(f"Current page contains {count} elements matching '{locator}'.")
 
     @keyword
     def page_should_not_contain(self, text, loglevel="TRACE"):
@@ -231,7 +231,7 @@ class ElementKeywords(LibraryComponent):
         | `Assign ID to Element` | //ul[@class='example' and ./li[contains(., 'Stuff')]] | my id |
         | `Page Should Contain Element` | my id |
         """
-        self.info("Assigning temporary id '%s' to element '%s'." % (id, locator))
+        self.info(f"Assigning temporary id '{id}' to element '{locator}'.")
         element = self.find_element(locator)
         self.driver.execute_script("arguments[0].id = '%s';" % id, element)
 
@@ -340,7 +340,7 @@ class ElementKeywords(LibraryComponent):
         Use `Element Should Contain` if a substring match is desired.
         """
         self.info(
-            "Verifying element '%s' contains exact text '%s'." % (locator, expected)
+            f"Verifying element '{locator}' contains exact text '{expected}'."
         )
         text = before_text = self.find_element(locator).text
         if is_truthy(ignore_case):
@@ -382,7 +382,7 @@ class ElementKeywords(LibraryComponent):
             not_expected = not_expected.lower()
         if text == not_expected:
             if is_noney(message):
-                message = "The text of element '%s' was not supposed to be '%s'." % (
+                message = "The text of element '{}' was not supposed to be '{}'.".format(
                     locator,
                     before_not_expected,
                 )
@@ -923,7 +923,7 @@ return !element.dispatchEvent(evt);
         """
         parsed_keys = self._parse_keys(*keys)
         if is_truthy(locator):
-            self.info("Sending key(s) %s to %s element." % (keys, locator))
+            self.info(f"Sending key(s) {keys} to {locator} element.")
             element = self.find_element(locator)
             ActionChains(self.driver).click(element).perform()
         else:
@@ -940,7 +940,7 @@ return !element.dispatchEvent(evt);
             actions.perform()
 
     def _press_keys_normal_keys(self, actions, key):
-        self.info("Sending key%s %s" % (plural_or_not(key.converted), key.converted))
+        self.info("Sending key{} {}".format(plural_or_not(key.converted), key.converted))
         actions.send_keys(key.converted)
 
     def _press_keys_special_keys(self, actions, element, parsed_key, key):

--- a/src/SeleniumLibrary/keywords/formelement.py
+++ b/src/SeleniumLibrary/keywords/formelement.py
@@ -154,7 +154,7 @@ class FormElementKeywords(LibraryComponent):
         ``group_name`` is the ``name`` of the radio button group.
         """
         self.info(
-            "Verifying radio button '%s' has selection '%s'." % (group_name, value)
+            f"Verifying radio button '{group_name}' has selection '{value}'."
         )
         elements = self._get_radio_buttons(group_name)
         actual_value = self._get_value_from_radio_buttons(elements)
@@ -192,7 +192,7 @@ class FormElementKeywords(LibraryComponent):
         | `Select Radio Button` | size    | XL    |
         | `Select Radio Button` | contact | email |
         """
-        self.info("Selecting '%s' from radio button '%s'." % (value, group_name))
+        self.info(f"Selecting '{value}' from radio button '{group_name}'.")
         element = self._get_radio_button_with_value(group_name, value)
         if not element.is_selected():
             element.click()
@@ -274,7 +274,7 @@ class FormElementKeywords(LibraryComponent):
         Disabling the file upload the Selenium Grid node and the `clear`
         argument are new in SeleniumLibrary 4.0
         """
-        self.info("Typing text '%s' into text field '%s'." % (text, locator))
+        self.info(f"Typing text '{text}' into text field '{locator}'.")
         self._input_text_into_text_field(locator, text, clear)
 
     @keyword
@@ -320,7 +320,7 @@ class FormElementKeywords(LibraryComponent):
                     "but it contained '%s'." % (locator, expected, actual)
                 )
             raise AssertionError(message)
-        self.info("Text field '%s' contains text '%s'." % (locator, expected))
+        self.info(f"Text field '{locator}' contains text '{expected}'.")
 
     @keyword
     def textfield_value_should_be(self, locator, expected, message=None):
@@ -339,7 +339,7 @@ class FormElementKeywords(LibraryComponent):
                     "but was '%s'." % (locator, expected, actual)
                 )
             raise AssertionError(message)
-        self.info("Content of text field '%s' is '%s'." % (locator, expected))
+        self.info(f"Content of text field '{locator}' is '{expected}'.")
 
     @keyword
     def textarea_should_contain(self, locator, expected, message=None):
@@ -358,7 +358,7 @@ class FormElementKeywords(LibraryComponent):
                     "but it had '%s'." % (locator, expected, actual)
                 )
             raise AssertionError(message)
-        self.info("Text area '%s' contains text '%s'." % (locator, expected))
+        self.info(f"Text area '{locator}' contains text '{expected}'.")
 
     @keyword
     def textarea_value_should_be(self, locator, expected, message=None):
@@ -377,7 +377,7 @@ class FormElementKeywords(LibraryComponent):
                     "but it had '%s'." % (locator, expected, actual)
                 )
             raise AssertionError(message)
-        self.info("Content of text area '%s' is '%s'." % (locator, expected))
+        self.info(f"Content of text area '{locator}' is '{expected}'.")
 
     @keyword
     def page_should_contain_button(self, locator, message=None, loglevel="TRACE"):

--- a/src/SeleniumLibrary/keywords/frames.py
+++ b/src/SeleniumLibrary/keywords/frames.py
@@ -93,7 +93,7 @@ class FrameKeywords(LibraryComponent):
                 "Frame '%s' should have contained text '%s' "
                 "but did not." % (locator, text)
             )
-        self.info("Frame '%s' contains text '%s'." % (locator, text))
+        self.info(f"Frame '{locator}' contains text '{text}'.")
 
     def _frame_contains(self, locator, text):
         element = self.find_element(locator)

--- a/src/SeleniumLibrary/keywords/javascript.py
+++ b/src/SeleniumLibrary/keywords/javascript.py
@@ -101,9 +101,9 @@ class JavaScriptKeywords(LibraryComponent):
         return self.driver.execute_async_script(js_code, *js_args)
 
     def _js_logger(self, base, code, args):
-        message = "%s:\n%s\n" % (base, code)
+        message = f"{base}:\n{code}\n"
         if args:
-            message = "%sBy using argument%s:\n%s" % (
+            message = "{}By using argument{}:\n{}".format(
                 message,
                 plural_or_not(args),
                 seq2str(args),

--- a/src/SeleniumLibrary/keywords/screenshot.py
+++ b/src/SeleniumLibrary/keywords/screenshot.py
@@ -115,7 +115,7 @@ class ScreenshotKeywords(LibraryComponent):
         path = self._get_screenshot_path(filename)
         self._create_directory(path)
         if not self.driver.save_screenshot(path):
-            raise RuntimeError("Failed to save screenshot '{}'.".format(path))
+            raise RuntimeError(f"Failed to save screenshot '{path}'.")
         self._embed_to_log_as_file(path, 800)
         return path
 
@@ -159,7 +159,7 @@ class ScreenshotKeywords(LibraryComponent):
         path = self._get_screenshot_path(filename)
         self._create_directory(path)
         if not element.screenshot(path):
-            raise RuntimeError("Failed to save element screenshot '{}'.".format(path))
+            raise RuntimeError(f"Failed to save element screenshot '{path}'.")
         self._embed_to_log_as_file(path, 400)
         return path
 

--- a/src/SeleniumLibrary/keywords/selectelement.py
+++ b/src/SeleniumLibrary/keywords/selectelement.py
@@ -137,7 +137,7 @@ class SelectElementKeywords(LibraryComponent):
 
     def _format_selection(self, labels, values):
         return " | ".join(
-            "%s (%s)" % (label, value) for label, value in zip(labels, values)
+            f"{label} ({value})" for label, value in zip(labels, values)
         )
 
     @keyword

--- a/src/SeleniumLibrary/keywords/tableelement.py
+++ b/src/SeleniumLibrary/keywords/tableelement.py
@@ -206,7 +206,7 @@ class TableElementKeywords(LibraryComponent):
         if element is None:
             self.ctx.log_source(loglevel)
             raise AssertionError(
-                "Table '%s' did not contain text '%s'." % (locator, expected)
+                f"Table '{locator}' did not contain text '{expected}'."
             )
 
     def _find_by_content(self, table_locator, content):
@@ -220,12 +220,12 @@ class TableElementKeywords(LibraryComponent):
 
     def _find_by_row(self, table_locator, row, content):
         position = self._index_to_position(row)
-        locator = "//tr[{}]".format(position)
+        locator = f"//tr[{position}]"
         return self._find(table_locator, locator, content)
 
     def _find_by_column(self, table_locator, col, content):
         position = self._index_to_position(col)
-        locator = "//tr//*[self::td or self::th][{}]".format(position)
+        locator = f"//tr//*[self::td or self::th][{position}]"
         return self._find(table_locator, locator, content)
 
     def _index_to_position(self, index):

--- a/src/SeleniumLibrary/keywords/waiting.py
+++ b/src/SeleniumLibrary/keywords/waiting.py
@@ -327,7 +327,7 @@ class WaitingKeywords(LibraryComponent):
         """
         self._wait_until(
             lambda: text in self.find_element(locator).text,
-            "Element '%s' did not get text '%s' in <TIMEOUT>." % (locator, text),
+            f"Element '{locator}' did not get text '{text}' in <TIMEOUT>.",
             timeout,
             error,
         )
@@ -347,7 +347,7 @@ class WaitingKeywords(LibraryComponent):
         """
         self._wait_until(
             lambda: text not in self.find_element(locator).text,
-            "Element '%s' still had text '%s' after <TIMEOUT>." % (locator, text),
+            f"Element '{locator}' still had text '{text}' after <TIMEOUT>.",
             timeout,
             error,
         )

--- a/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
+++ b/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
@@ -33,7 +33,7 @@ from SeleniumLibrary.keywords.webdrivertools.sl_file_detector import (
 from SeleniumLibrary.utils.path_formatter import _format_path
 
 
-class WebDriverCreator(object):
+class WebDriverCreator:
 
     browser_names = {
         "googlechrome": "chrome",
@@ -101,7 +101,7 @@ class WebDriverCreator(object):
     def _get_creator_method(self, browser):
         if browser in self.browser_names:
             return getattr(self, "create_{}".format(self.browser_names[browser]))
-        raise ValueError("{} is not a supported browser.".format(browser))
+        raise ValueError(f"{browser} is not a supported browser.")
 
     def _parse_capabilities(self, capabilities, browser=None):
         if is_falsy(capabilities):
@@ -576,7 +576,7 @@ class WebDriverCache(ConnectionCache):
             return None
 
 
-class SeleniumOptions(object):
+class SeleniumOptions:
     def create(self, browser, options):
         if is_falsy(options):
             return None

--- a/src/SeleniumLibrary/keywords/window.py
+++ b/src/SeleniumLibrary/keywords/window.py
@@ -246,7 +246,7 @@ class WindowKeywords(LibraryComponent):
         height_offset = height - inner_height
         window_width = width + width_offset
         window_height = height + height_offset
-        self.info("Setting window size to %s %s" % (window_width, window_height))
+        self.info(f"Setting window size to {window_width} {window_height}")
         self.driver.set_window_size(window_width, window_height)
         result_width = int(self.driver.execute_script("return window.innerWidth;"))
         result_height = int(self.driver.execute_script("return window.innerHeight;"))
@@ -284,8 +284,8 @@ class WindowKeywords(LibraryComponent):
         self.driver.set_window_position(int(x), int(y))
 
     def _log_list(self, items, what="item"):
-        msg = ["Altogether %s %s%s." % (len(items), what, plural_or_not(items))]
+        msg = ["Altogether {} {}{}.".format(len(items), what, plural_or_not(items))]
         for index, item in enumerate(items):
-            msg.append("%s: %s" % (index + 1, item))
+            msg.append("{}: {}".format(index + 1, item))
         self.info("\n".join(msg))
         return items

--- a/src/SeleniumLibrary/locators/elementfinder.py
+++ b/src/SeleniumLibrary/locators/elementfinder.py
@@ -83,7 +83,7 @@ class ElementFinder(ContextAware):
         elements = strategy(criteria, tag, constraints, parent=parent or self.driver)
         if required and not elements:
             raise ElementNotFound(
-                "%s with locator '%s' not found." % (element_type, locator)
+                f"{element_type} with locator '{locator}' not found."
             )
         if first_only:
             if not elements:
@@ -195,9 +195,9 @@ class ElementFinder(ContextAware):
         xpath_criteria = escape_xpath_value(criteria)
         xpath_tag = tag if tag is not None else "*"
         xpath_constraints = self._get_xpath_constraints(constraints)
-        xpath_searchers = ["%s=%s" % (attr, xpath_criteria) for attr in key_attrs]
+        xpath_searchers = [f"{attr}={xpath_criteria}" for attr in key_attrs]
         xpath_searchers.extend(self._get_attrs_with_url(key_attrs, criteria))
-        xpath = "//%s[%s%s(%s)]" % (
+        xpath = "//{}[{}{}({})]".format(
             xpath_tag,
             " and ".join(xpath_constraints),
             " and " if xpath_constraints else "",
@@ -214,9 +214,9 @@ class ElementFinder(ContextAware):
 
     def _get_xpath_constraint(self, name, value):
         if isinstance(value, list):
-            return "@%s[. = '%s']" % (name, "' or . = '".join(value))
+            return "@{}[. = '{}']".format(name, "' or . = '".join(value))
         else:
-            return "@%s='%s'" % (name, value)
+            return f"@{name}='{value}'"
 
     def _get_tag_and_constraints(self, tag):
         if tag is None:
@@ -308,7 +308,7 @@ class ElementFinder(ContextAware):
                 if url is None or xpath_url is None:
                     url = self._get_base_url() + "/" + criteria
                     xpath_url = escape_xpath_value(url)
-                attrs.append("%s=%s" % (attr, xpath_url))
+                attrs.append(f"{attr}={xpath_url}")
         return attrs
 
     def _get_base_url(self):

--- a/src/SeleniumLibrary/utils/events/event.py
+++ b/src/SeleniumLibrary/utils/events/event.py
@@ -17,7 +17,7 @@
 import abc
 
 
-class Event(object):
+class Event:
     @abc.abstractmethod
     def trigger(self, *args, **kwargs):
         pass

--- a/src/SeleniumLibrary/utils/librarylistener.py
+++ b/src/SeleniumLibrary/utils/librarylistener.py
@@ -17,7 +17,7 @@
 from .events import dispatch
 
 
-class LibraryListener(object):
+class LibraryListener:
     ROBOT_LISTENER_API_VERSION = 2
 
     def start_suite(self, name, attrs):

--- a/utest/README.rst
+++ b/utest/README.rst
@@ -26,13 +26,8 @@ ApprovalTests
 For unit test, it is possible to use `ApprovalTests`_ framework. ApprovalTests
 provides an easy and visual way to compare strings in unit tests. For more
 details, please read `ApprovalTests`_ documentation and `ApprovalTests blog post`_.
-The downside of ApprovalTests is that it does not work when using `Jython`_
-as an interpreter. Therefore all unit tests using ApprovalTests imports
-must handled with `try/except ImportError:` and skipped with:
-`@unittest.skipIf(JYTHON, 'ApprovalTest does not work with Jython')`. The `JYTHON` is
-imported from `from robot.utils import JYTHON`
 
-Another downside of ApprovalTests is that SeleniumLibrary is mainly developed
+The downside of ApprovalTests is that SeleniumLibrary is mainly developed
 in Linux and therefore unit tests using ApprovalTests are skipped in Windows
 OS. This needs to be done until ApprovalTests issue `#41`_ is fixed.
 To skip tests, mark test as:
@@ -42,5 +37,4 @@ To skip tests, mark test as:
 .. _pytest: https://docs.pytest.org/en/latest/
 .. _ApprovalTests: https://github.com/approvals/ApprovalTests.Python
 .. _ApprovalTests blog post: http://blog.approvaltests.com/
-.. _Jython: http://www.jython.org/
 .. _#41: https://github.com/approvals/ApprovalTests.Python/issues/41

--- a/utest/test/api/my_lib_not_inherit.py
+++ b/utest/test/api/my_lib_not_inherit.py
@@ -1,7 +1,7 @@
 from SeleniumLibrary.base import keyword
 
 
-class my_lib_not_inherit(object):
+class my_lib_not_inherit:
     def __init__(self, ctx):
         self.ctx = ctx
 

--- a/utest/test/api/test_event_firing_webdriver.py
+++ b/utest/test/api/test_event_firing_webdriver.py
@@ -29,5 +29,5 @@ class EventFiringWebDriverSeleniumLibrary(unittest.TestCase):
     def test_too_many_event_firing_webdriver(self):
         with self.assertRaises(ValueError):
             SeleniumLibrary(
-                event_firing_webdriver="%s,%s" % (self.listener, self.listener)
+                event_firing_webdriver=f"{self.listener},{self.listener}"
             )

--- a/utest/test/api/test_plugin_documentation.py
+++ b/utest/test/api/test_plugin_documentation.py
@@ -29,17 +29,17 @@ class PluginDocumentation(unittest.TestCase):
 
     @unittest.skipIf(WINDOWS, reason="ApprovalTest do not support different line feeds")
     def test_parse_plugin_no_doc(self):
-        sl = SeleniumLibrary(plugins="{};arg1=Text1;arg2=Text2".format(self.plugin_3))
+        sl = SeleniumLibrary(plugins=f"{self.plugin_3};arg1=Text1;arg2=Text2")
         verify(sl.get_keyword_documentation("__intro__"), self.reporter)
 
     @unittest.skipIf(WINDOWS, reason="ApprovalTest do not support different line feeds")
     def test_many_plugins(self):
-        sl = SeleniumLibrary(plugins="%s, %s" % (self.plugin_1, self.plugin_2))
+        sl = SeleniumLibrary(plugins=f"{self.plugin_1}, {self.plugin_2}")
         verify(sl.get_keyword_documentation("__intro__"), self.reporter)
 
     @unittest.skipIf(WINDOWS, reason="ApprovalTest do not support different line feeds")
     def test_no_doc(self):
-        sl = SeleniumLibrary(plugins="{};arg1=Text1;arg2=Text2".format(self.plugin_3))
+        sl = SeleniumLibrary(plugins=f"{self.plugin_3};arg1=Text1;arg2=Text2")
         verify(sl.get_keyword_documentation("__intro__"), self.reporter)
 
     @unittest.skipIf(WINDOWS, reason="ApprovalTest do not support different line feeds")
@@ -49,10 +49,10 @@ class PluginDocumentation(unittest.TestCase):
 
     @unittest.skipIf(WINDOWS, reason="ApprovalTest do not support different line feeds")
     def test_parse_plugin_init_doc(self):
-        sl = SeleniumLibrary(plugins="{};arg1=Text1;arg2=Text2".format(self.plugin_3))
+        sl = SeleniumLibrary(plugins=f"{self.plugin_3};arg1=Text1;arg2=Text2")
         verify(sl.get_keyword_documentation("__init__"), self.reporter)
 
     @unittest.skipIf(WINDOWS, reason="ApprovalTest do not support different line feeds")
     def test_parse_plugin_kw_doc(self):
-        sl = SeleniumLibrary(plugins="{};arg1=Text1;arg2=Text2".format(self.plugin_3))
+        sl = SeleniumLibrary(plugins=f"{self.plugin_3};arg1=Text1;arg2=Text2")
         verify(sl.get_keyword_documentation("execute_javascript"), self.reporter)

--- a/utest/test/api/test_plugins.py
+++ b/utest/test/api/test_plugins.py
@@ -62,7 +62,7 @@ class ExtendingSeleniumLibrary(unittest.TestCase):
     def test_parse_library_with_args(self):
         plugin = "path.to.MyLibrary"
         plugin_args = "arg1;arg2"
-        parsed_plugins = self.sl._string_to_modules("%s;%s" % (plugin, plugin_args))
+        parsed_plugins = self.sl._string_to_modules(f"{plugin};{plugin_args}")
         parsed_plugin = parsed_plugins[0]
         self.assertEqual(len(parsed_plugins), 1)
         self.assertEqual(parsed_plugin.module, plugin)
@@ -72,7 +72,7 @@ class ExtendingSeleniumLibrary(unittest.TestCase):
     def test_parse_plugin_with_kw_args(self):
         plugin = "PluginWithKwArgs.py"
         plugin_args = "kw1=Text1;kw2=Text2"
-        parsed_plugins = self.sl._string_to_modules("%s;%s" % (plugin, plugin_args))
+        parsed_plugins = self.sl._string_to_modules(f"{plugin};{plugin_args}")
         parsed_plugin = parsed_plugins[0]
         self.assertEqual(len(parsed_plugins), 1)
         self.assertEqual(parsed_plugin.module, plugin)
@@ -91,7 +91,7 @@ class ExtendingSeleniumLibrary(unittest.TestCase):
         my_lib = os.path.join(self.root_dir, "my_lib.py")
         wrong_name = os.path.join(self.root_dir, "my_lib_wrong_name.py")
         with self.assertRaises(DataError):
-            SeleniumLibrary(plugins="%s, %s" % (my_lib, wrong_name))
+            SeleniumLibrary(plugins=f"{my_lib}, {wrong_name}")
 
     def test_sl_with_kw_args_plugin(self):
         kw_args_lib = os.path.join(

--- a/utest/test/keywords/test_firefox_profile_parsing.py
+++ b/utest/test/keywords/test_firefox_profile_parsing.py
@@ -57,7 +57,7 @@ class FireFoxProfileParsingTests(unittest.TestCase):
     def _parse_result(self, result):
         to_str = ""
         if "key1" in result.default_preferences:
-            to_str = "%s %s %s" % (to_str, "key1", result.default_preferences["key1"])
+            to_str = "{} {} {}".format(to_str, "key1", result.default_preferences["key1"])
         if "key2" in result.default_preferences:
-            to_str = "%s %s %s" % (to_str, "key2", result.default_preferences["key2"])
+            to_str = "{} {} {}".format(to_str, "key2", result.default_preferences["key2"])
         self.results.append(to_str)

--- a/utest/test/keywords/test_javascript.py
+++ b/utest/test/keywords/test_javascript.py
@@ -43,7 +43,7 @@ class JavaScriptKeywordsTest(unittest.TestCase):
     @unittest.skipIf(WINDOWS, reason="ApprovalTest do not support different line feeds")
     def test_get_javascript(self):
         code, args = self.js._get_javascript_to_execute(("code", "here"))
-        result = "%s + %s" % (code, args)
+        result = f"{code} + {args}"
         verify(result, self.reporter)
 
     @unittest.skipIf(WINDOWS, reason="ApprovalTest do not support different line feeds")

--- a/utest/test/keywords/test_selenium_options_parser.py
+++ b/utest/test/keywords/test_selenium_options_parser.py
@@ -207,8 +207,8 @@ def error_formatter(method, arg, full=False):
         return method(arg)
     except Exception as error:
         if full:
-            return "%s %s" % (arg, error)
-        return "%s %s" % (arg, error.__str__()[:15])
+            return f"{arg} {error}"
+        return "{} {}".format(arg, error.__str__()[:15])
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
For https://github.com/robotframework/SeleniumLibrary/issues/1444.

* Drop support for EOL Python 2.7
* Upgrade Python syntax with https://github.com/asottile/pyupgrade `--py36-plus`
* Update Trove classifiers and python_requires
* Remove Jython from docs