### PR TITLE
execute_javascript code type changed to Union

### DIFF
--- a/atest/acceptance/keywords/javascript.robot
+++ b/atest/acceptance/keywords/javascript.robot
@@ -61,6 +61,18 @@ Execute Javascript With ARGUMENTS Marker Only
     ...  0987
     Alert Should Be Present    123    timeout=10 s
 
+Execute Javascript With ARGUMENTS Marker And WebElement
+    [Documentation]
+    ...    Checks if the body (WebElement)
+    ...    is parsed correctly as script argument
+    ...    then compare its tagName to 'body'
+    ${body_webelement}  Get WebElement  css:body
+    ${tag_name}  Execute Javascript
+    ...  return arguments[0].tagName;
+    ...  ARGUMENTS
+    ...  ${body_webelement}
+    Should Be Equal As Strings  ${tag_name}  body  ignore_case=True
+
 Execute Javascript from File
     [Documentation]
     ...    LOG 2:1 REGEXP: Reading JavaScript from file .*executed_by_execute_javascript.*

--- a/src/SeleniumLibrary/keywords/javascript.py
+++ b/src/SeleniumLibrary/keywords/javascript.py
@@ -16,10 +16,11 @@
 
 import os
 from collections import namedtuple
-from typing import Any
+from typing import Any, Union
 
 from robot.utils import plural_or_not, seq2str
 
+from selenium.webdriver.remote.webelement import WebElement
 from SeleniumLibrary.base import LibraryComponent, keyword
 
 
@@ -29,7 +30,7 @@ class JavaScriptKeywords(LibraryComponent):
     arg_marker = "ARGUMENTS"
 
     @keyword
-    def execute_javascript(self, *code: str) -> Any:
+    def execute_javascript(self, *code:  Union[WebElement, str]) -> Any:
         """Executes the given JavaScript code with possible arguments.
 
         ``code`` may be divided into multiple cells in the test data and


### PR DESCRIPTION
I'm facing an issue after the RF4 release. The keyword `execute_javascript` treats WebElements passed after ARGUMENTS as str, by changing the type declaration `def execute_javascript(self, *code: str) -> Any` in SeleniumLibrary/keywords/javascript.py with `Union[WebElement, str] `the problem seems to be solved