### PR TITLE
Improve run on failure functionality

### DIFF
--- a/atest/acceptance/keywords/run_on_failure.robot
+++ b/atest/acceptance/keywords/run_on_failure.robot
@@ -73,6 +73,13 @@ Run On Failure also fails
     ...    ${FAILURE MESSAGE}
     ...    Page Should Not Contain    needle    loglevel=None
 
+Run On Failure With Default Keyword And Conflight With Keyword Names
+    [Documentation]    LOG 2.1    INFO REGEXP:  .*<a href=\\"selenium-screenshot.*\\.png\\"><img src=\\"selenium-screenshot.*\\.png\\" width=\\"800px\\"></a>.*
+    Register Keyword To Run On Failure     Capture Page Screenshot
+    Run Keyword And Expect Error
+    ...    ${FAILURE MESSAGE}
+    ...    Page Should Not Contain    needle    loglevel=None
+
 *** Keywords ***
 On Fail
     ${count}=    Evaluate    ${ON FAIL COUNT} + 1
@@ -87,3 +94,6 @@ Open Browser To Front Page
 
 Failure During Run On failure
     Fail    Expected error.
+
+Capture Page Screenshot
+    Fail    This should not be never run

--- a/src/SeleniumLibrary/__init__.py
+++ b/src/SeleniumLibrary/__init__.py
@@ -544,7 +544,10 @@ class SeleniumLibrary(DynamicCore):
             return
         try:
             self._running_on_failure_keyword = True
-            BuiltIn().run_keyword(self.run_on_failure_keyword)
+            if self.run_on_failure_keyword.lower() == "capture page screenshot":
+                self.capture_page_screenshot()
+            else:
+                BuiltIn().run_keyword(self.run_on_failure_keyword)
         except Exception as err:
             logger.warn(
                 f"Keyword '{self.run_on_failure_keyword}' could not be run on failure: {err}"


### PR DESCRIPTION
When run on failure keyword is capture page screenshot execute is method and not as keyword

Fixes #1715