### PR TITLE
update Edge driver name from legacy to current

### DIFF
--- a/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
+++ b/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
@@ -285,7 +285,7 @@ class WebDriverCreator:
         remote_url,
         options=None,
         service_log_path=None,
-        executable_path="MicrosoftWebDriver.exe",
+        executable_path="msedgedriver.exe",
     ):
         if remote_url:
             defaul_caps = webdriver.DesiredCapabilities.EDGE.copy()

--- a/utest/test/keywords/test_webdrivercreator.py
+++ b/utest/test/keywords/test_webdrivercreator.py
@@ -472,7 +472,7 @@ def test_ie_no_browser_name(creator):
 
 
 def test_edge(creator):
-    executable_path = "MicrosoftWebDriver.exe"
+    executable_path = "msedgedriver.exe"
     expected_webdriver = mock()
     when(webdriver).Edge(
         service_log_path=None, executable_path=executable_path


### PR DESCRIPTION
According to https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/, "MicrosoftWebDriver.exe" is a legacy now, new name is "msedgedriver.exe"