### PR TITLE
fix `StringIO` import as it was removed in robot 5.0

### DIFF
--- a/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
+++ b/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
@@ -19,10 +19,11 @@ import inspect
 import os
 import token
 import warnings
+from io import StringIO
 from tokenize import generate_tokens
 
 from robot.api import logger
-from robot.utils import ConnectionCache, StringIO
+from robot.utils import ConnectionCache
 from selenium import webdriver
 from selenium.webdriver import FirefoxProfile
 


### PR DESCRIPTION
fixes #1752 