### PR TITLE
 Add API to set page load timeout (#1535) 

### DIFF
--- a/atest/acceptance/2-event_firing_webdriver/event_firing_webdriver.robot
+++ b/atest/acceptance/2-event_firing_webdriver/event_firing_webdriver.robot
@@ -12,8 +12,8 @@ ${event_firing_or_none}     ${NONE}
 Open Browser To Start Page
     [Tags]    NoGrid
     [Documentation]
-    ...    LOG 1:16 DEBUG  Wrapping driver to event_firing_webdriver.
-    ...    LOG 1:18 INFO  Got driver also from SeleniumLibrary.
+    ...    LOG 1:20 DEBUG  Wrapping driver to event_firing_webdriver.
+    ...    LOG 1:22 INFO  Got driver also from SeleniumLibrary.
     Open Browser    ${FRONT PAGE}    ${BROWSER}    remote_url=${REMOTE_URL}
     ...    desired_capabilities=${DESIRED_CAPABILITIES}
 

--- a/atest/acceptance/keywords/__init__.robot
+++ b/atest/acceptance/keywords/__init__.robot
@@ -1,4 +1,4 @@
 *** Settings ***
 Resource    ../resource.robot
-Suite Setup    Open Browser To Start Page
+Suite Setup    Open Browser To Start Page    keywords
 Suite Teardown    Close All Browsers

--- a/atest/acceptance/keywords/page_load_timeout.robot
+++ b/atest/acceptance/keywords/page_load_timeout.robot
@@ -7,7 +7,7 @@ Test Teardown     Close Browser And Reset Page Load Timeout
 *** Test Cases ***
 Should Open Browser With Default Page Load Timeout
     [Documentation]    Verify that 'Open Browser' changes the page load timeout.
-    ...    LOG 1.1.1:16 DEBUG REGEXP: POST http://localhost:\\d{2,5}/session/[a-f0-9-]+/timeouts {"pageLoad": 10000}
+    ...    LOG 1.1.1:16 DEBUG REGEXP: POST http://localhost:\\d{2,5}/session/[a-f0-9-]+/timeouts {"pageLoad": 300000}
     ...    LOG 1.1.1:18 DEBUG STARTS: Remote response: status=200
     Open Browser To Start Page
 
@@ -28,7 +28,7 @@ Should Set Page Load Timeout For All Opened Browsers
 *** Keywords ***
 Close Browser And Reset Page Load Timeout
     Close Browser
-    Set Selenium Page Load Timeout    10 s
+    Set Selenium Page Load Timeout    5 minutes
 
 Switch Back To Suite Browser
     Switch Browser    keywords

--- a/atest/acceptance/keywords/page_load_timeout.robot
+++ b/atest/acceptance/keywords/page_load_timeout.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+Resource          ../resource.robot
+
+Test Teardown     Close Browser And Reset Page Load Timeout
+
+*** Test Cases ***
+Should Open Browser With Default Page Load Timeout
+    [Documentation]    Verify that 'Open Browser' changes the page load timeout.
+    ...    LOG 1.1.1:16 DEBUG REGEXP: POST http://localhost:\\d{2,5}/session/[a-f0-9-]+/timeouts {"pageLoad": 10000}
+    ...    LOG 1.1.1:18 DEBUG STARTS: Remote response: status=200
+    Open Browser To Start Page
+
+Should Run Into Timeout Exception
+    [Documentation]
+    ...    FAIL REGEXP: TimeoutException: Message: (timeout: Timed out receiving message from renderer|TimedPromise timed out).*
+    Open Browser To Start Page
+    Set Selenium Page Load Timeout    1 ms
+    Reload Page
+
+Should Set Page Load Timeout For All Opened Browsers
+    [Documentation]    One browser is already opened as global suite setup.
+    ...    LOG 2:1 DEBUG REGEXP: POST http://localhost:\\d{2,5}/session/[a-f0-9-]+/timeouts {"pageLoad": 5000}
+    ...    LOG 2:5 DEBUG REGEXP: POST http://localhost:\\d{2,5}/session/[a-f0-9-]+/timeouts {"pageLoad": 5000}
+    Open Browser To Start Page
+    Set Selenium Page Load Timeout    5 s
+
+*** Keywords ***
+Close Browser And Reset Page Load Timeout
+    Close Browser
+    Set Selenium Page Load Timeout    10 s

--- a/atest/acceptance/keywords/page_load_timeout.robot
+++ b/atest/acceptance/keywords/page_load_timeout.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Resource          ../resource.robot
 
+Suite Teardown    Switch Back To Suite Browser
 Test Teardown     Close Browser And Reset Page Load Timeout
 
 *** Test Cases ***
@@ -28,3 +29,6 @@ Should Set Page Load Timeout For All Opened Browsers
 Close Browser And Reset Page Load Timeout
     Close Browser
     Set Selenium Page Load Timeout    10 s
+
+Switch Back To Suite Browser
+    Switch Browser    keywords

--- a/atest/acceptance/open_and_close.robot
+++ b/atest/acceptance/open_and_close.robot
@@ -16,8 +16,8 @@ Close Browser Does Nothing When No Browser Is Opened
 
 Browser Open With Not Well-Formed URL Should Close
     [Documentation]    Verify after incomplete 'Open Browser' browser closes
-    ...    LOG 1.1:20 DEBUG STARTS: Opened browser with session id
-    ...    LOG 1.1:20 DEBUG REGEXP: .*but failed to open url.*
+    ...    LOG 1.1:24 DEBUG STARTS: Opened browser with session id
+    ...    LOG 1.1:24 DEBUG REGEXP: .*but failed to open url.*
     ...    LOG 2:2 DEBUG STARTS: DELETE
     ...    LOG 2:5 DEBUG STARTS: Finished Request
     Run Keyword And Expect Error    *    Open Browser    bad.url.bad    ${BROWSER}

--- a/atest/acceptance/resource.robot
+++ b/atest/acceptance/resource.robot
@@ -17,7 +17,9 @@ ${SPEED}=          0
 Open Browser To Start Page
     [Documentation]    This keyword also tests 'Set Selenium Speed' and 'Set Selenium Timeout'
     ...    against all reason.
+    [Arguments]    ${alias}=${None}
     ${default speed}    ${default timeout}=    Open Browser To Start Page Without Testing Default Options
+    ...    ${alias}
     # FIXME: We shouldn't test anything here. If this stuff isn't tested elsewhere, new *tests* needs to be added.
     # FIXME: The second test below verifies a hard coded return value!!?!
     Should Be Equal    ${default speed}    0 seconds
@@ -25,8 +27,9 @@ Open Browser To Start Page
 
 Open Browser To Start Page Without Testing Default Options
     [Documentation]    Open Browser To Start Page Without Testing Default Options
+    [Arguments]    ${alias}=${None}
     Open Browser    ${FRONT PAGE}    ${BROWSER}    remote_url=${REMOTE_URL}
-    ...    desired_capabilities=${DESIRED_CAPABILITIES}
+    ...    desired_capabilities=${DESIRED_CAPABILITIES}    alias=${alias}
     ${orig speed} =    Set Selenium Speed    ${SPEED}
     ${orig timeout} =    Set Selenium Timeout    10 seconds
     [Return]    ${orig speed}    5 seconds

--- a/docs/extending/extending.rst
+++ b/docs/extending/extending.rst
@@ -73,16 +73,17 @@ failure_occurred  Method that is executed when a SeleniumLibrary keyword fails.
 
 Also there are the following public attributes available:
 
-=========================  ================================================================
+=========================  ======================================================================
    Attribute                         Description
-=========================  ================================================================
+=========================  ======================================================================
 driver                     Current active driver.
 event_firing_webdriver     Reference to a class implementing event firing selenium support.
 timeout                    Default value for ``timeouts`` used with ``Wait ...`` keywords.
+page_load_timeout          Default value to wait for page load to complete until error is raised.
 implicit_wait              Default value for ``implicit wait`` used when locating elements.
 run_on_failure_keyword     Default action for the `run-on-failure functionality`.
 screenshot_root_directory  Location where possible screenshots are created
-=========================  ================================================================
+=========================  ======================================================================
 
 For more details about the methods, please read the individual method documentation and many
 of the attributes are explained in the library `keyword documentation`_. please note that

--- a/src/SeleniumLibrary/__init__.py
+++ b/src/SeleniumLibrary/__init__.py
@@ -355,6 +355,17 @@ class SeleniumLibrary(DynamicCore):
 
     See `time format` below for supported syntax.
 
+    == Page load ==
+    Page load timeout is the amount of time to wait for page load to complete until error is raised.
+
+    The default page load timeout can be set globally
+    when `importing` the library with the ``page_load_timeout`` argument
+    or by using the `Set Selenium Page Load Timeout` keyword.
+
+    See `time format` below for supported timeout syntax.
+
+    Support for page load is new in SeleniumLibrary 6.1
+
     == Selenium speed ==
 
     Selenium execution speed can be slowed down globally by using `Set
@@ -431,6 +442,7 @@ class SeleniumLibrary(DynamicCore):
         self,
         timeout=timedelta(seconds=5),
         implicit_wait=timedelta(seconds=0),
+        page_load_timeout=timedelta(seconds=10),
         run_on_failure="Capture Page Screenshot",
         screenshot_root_directory: Optional[str] = None,
         plugins: Optional[str] = None,
@@ -442,6 +454,8 @@ class SeleniumLibrary(DynamicCore):
           Default value for `timeouts` used with ``Wait ...`` keywords.
         - ``implicit_wait``:
           Default value for `implicit wait` used when locating elements.
+        - ``page_load_timeout``:
+          Default value to wait for page load to complete until error is raised.
         - ``run_on_failure``:
           Default action for the `run-on-failure functionality`.
         - ``screenshot_root_directory``:
@@ -456,6 +470,7 @@ class SeleniumLibrary(DynamicCore):
         """
         self.timeout = _convert_timeout(timeout)
         self.implicit_wait = _convert_timeout(implicit_wait)
+        self.page_load_timeout = _convert_timeout(page_load_timeout)
         self.speed = 0.0
         self.run_on_failure_keyword = RunOnFailureKeywords.resolve_keyword(
             run_on_failure

--- a/src/SeleniumLibrary/__init__.py
+++ b/src/SeleniumLibrary/__init__.py
@@ -442,11 +442,11 @@ class SeleniumLibrary(DynamicCore):
         self,
         timeout=timedelta(seconds=5),
         implicit_wait=timedelta(seconds=0),
-        page_load_timeout=timedelta(seconds=10),
         run_on_failure="Capture Page Screenshot",
         screenshot_root_directory: Optional[str] = None,
         plugins: Optional[str] = None,
         event_firing_webdriver: Optional[str] = None,
+        page_load_timeout=timedelta(minutes=5),
     ):
         """SeleniumLibrary can be imported with several optional arguments.
 
@@ -454,8 +454,6 @@ class SeleniumLibrary(DynamicCore):
           Default value for `timeouts` used with ``Wait ...`` keywords.
         - ``implicit_wait``:
           Default value for `implicit wait` used when locating elements.
-        - ``page_load_timeout``:
-          Default value to wait for page load to complete until error is raised.
         - ``run_on_failure``:
           Default action for the `run-on-failure functionality`.
         - ``screenshot_root_directory``:
@@ -467,6 +465,8 @@ class SeleniumLibrary(DynamicCore):
         - ``event_firing_webdriver``:
           Class for wrapping Selenium with
           [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.event_firing_webdriver.html#module-selenium.webdriver.support.event_firing_webdriver|EventFiringWebDriver]
+        - ``page_load_timeout``:
+          Default value to wait for page load to complete until error is raised.
         """
         self.timeout = _convert_timeout(timeout)
         self.implicit_wait = _convert_timeout(implicit_wait)

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -730,9 +730,9 @@ class BrowserManagementKeywords(LibraryComponent):
         See the `Page load` section above for more information.
 
         Example:
-        | ${orig pl timeout} = | `Set Selenium Page Load Timeout` | 30 seconds |
+        | ${orig page load timeout} = | `Set Selenium Page Load Timeout` | 30 seconds |
         | `Open page that loads slowly` |
-        | `Set Selenium Page Load Timeout` | ${orig pl timeout} |
+        | `Set Selenium Page Load Timeout` | ${orig page load timeout} |
 
         New in SeleniumLibrary 6.1
         """

--- a/utest/test/api/approved_files/PluginDocumentation.test_many_plugins.approved.txt
+++ b/utest/test/api/approved_files/PluginDocumentation.test_many_plugins.approved.txt
@@ -298,6 +298,17 @@ Selenium documentation] for more information about this functionality.
 
 See `time format` below for supported syntax.
 
+== Page load ==
+Page load timeout is the amount of time to wait for page load to complete until error is raised.
+
+The default page load timeout can be set globally
+when `importing` the library with the ``page_load_timeout`` argument
+or by using the `Set Selenium Page Load Timeout` keyword.
+
+See `time format` below for supported timeout syntax.
+
+Support for page load is new in SeleniumLibrary 6.1
+
 == Selenium speed ==
 
 Selenium execution speed can be slowed down globally by using `Set

--- a/utest/test/api/approved_files/PluginDocumentation.test_parse_plugin_init_doc.approved.txt
+++ b/utest/test/api/approved_files/PluginDocumentation.test_parse_plugin_init_doc.approved.txt
@@ -4,8 +4,6 @@ SeleniumLibrary can be imported with several optional arguments.
   Default value for `timeouts` used with ``Wait ...`` keywords.
 - ``implicit_wait``:
   Default value for `implicit wait` used when locating elements.
-- ``page_load_timeout``:
-  Default value to wait for page load to complete until error is raised.
 - ``run_on_failure``:
   Default action for the `run-on-failure functionality`.
 - ``screenshot_root_directory``:
@@ -17,3 +15,5 @@ SeleniumLibrary can be imported with several optional arguments.
 - ``event_firing_webdriver``:
   Class for wrapping Selenium with
   [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.event_firing_webdriver.html#module-selenium.webdriver.support.event_firing_webdriver|EventFiringWebDriver]
+- ``page_load_timeout``:
+  Default value to wait for page load to complete until error is raised.

--- a/utest/test/api/approved_files/PluginDocumentation.test_parse_plugin_init_doc.approved.txt
+++ b/utest/test/api/approved_files/PluginDocumentation.test_parse_plugin_init_doc.approved.txt
@@ -4,6 +4,8 @@ SeleniumLibrary can be imported with several optional arguments.
   Default value for `timeouts` used with ``Wait ...`` keywords.
 - ``implicit_wait``:
   Default value for `implicit wait` used when locating elements.
+- ``page_load_timeout``:
+  Default value to wait for page load to complete until error is raised.
 - ``run_on_failure``:
   Default action for the `run-on-failure functionality`.
 - ``screenshot_root_directory``:

--- a/utest/test/api/test_plugins.py
+++ b/utest/test/api/test_plugins.py
@@ -22,7 +22,7 @@ class ExtendingSeleniumLibrary(unittest.TestCase):
     def test_no_libraries(self):
         for item in [None, "None", ""]:
             sl = SeleniumLibrary(plugins=item)
-            self.assertEqual(len(sl.get_keyword_names()), 173)
+            self.assertEqual(len(sl.get_keyword_names()), 175)
 
     def test_parse_library(self):
         plugin = "path.to.MyLibrary"

--- a/utest/test/keywords/test_browsermanagement.py
+++ b/utest/test/keywords/test_browsermanagement.py
@@ -54,6 +54,34 @@ def test_selenium_implicit_wait_get():
     assert org_value == "3 seconds"
 
 
+def test_selenium_page_load_timeout_with_default():
+    sl = SeleniumLibrary()
+    assert sl.page_load_timeout == 10.0, "Page load timeout should be 10.0"
+
+
+def test_set_selenium_page_load_timeout():
+    sl = SeleniumLibrary()
+    sl.set_selenium_page_load_timeout("5.0")
+    assert sl.page_load_timeout == 5.0
+
+    sl.set_selenium_page_load_timeout("1 min")
+    assert sl.page_load_timeout == 60.0
+
+
+def test_set_selenium_page_load_timeout_returns_orig_page_load_timeout():
+    sl = SeleniumLibrary(page_load_timeout="20")
+    orig_page_load_timeout = sl.set_selenium_page_load_timeout("1 second")
+
+    assert orig_page_load_timeout == "20 seconds"
+    assert sl.page_load_timeout == 1.0
+
+
+def test_get_selenium_page_load_timeout():
+    sl = SeleniumLibrary(page_load_timeout="15 seconds")
+
+    assert sl.get_selenium_page_load_timeout() == "15 seconds"
+
+
 def test_bad_browser_name():
     ctx = mock()
     bm = BrowserManagementKeywords(ctx)

--- a/utest/test/keywords/test_browsermanagement.py
+++ b/utest/test/keywords/test_browsermanagement.py
@@ -56,7 +56,7 @@ def test_selenium_implicit_wait_get():
 
 def test_selenium_page_load_timeout_with_default():
     sl = SeleniumLibrary()
-    assert sl.page_load_timeout == 10.0, "Page load timeout should be 10.0"
+    assert sl.page_load_timeout == 300.0, "Default page load timeout should be 5 minutes"
 
 
 def test_set_selenium_page_load_timeout():


### PR DESCRIPTION
Hi there,

this PR addresses [issue 1535](https://github.com/robotframework/SeleniumLibrary/issues/1535).

The issue requested there be an api to set selenium page load timeout.

Currently, SeleniumLibrary supports 
  - a global timeout, which is used mostly as a poll for assertions
  - implicit_wait, which is the time to wait for locators

In addition to that, the selenium project offers a page load timeout, which is the amount of time to wait for page to complete loading before an error is thrown.

As @aaltat argued

> At least we should add keyword to set the page load timeout, in similar functionality Set Selenium Timeout. But should page load timeout be also library level import? It is question which does not have clear answer. Page load timeout is not needed that often than other timeouts, but for consistency reason it would be good to have in the library init. I would say that consistency is good thing in this matter and lets add it in the library init too. [1]

Therefore, I created both the init argument as well as two new keywords, ``Set Selenium Page Load Timeout`` and ``Get Selenium Page Load Timeout``.

Note that this is my first contribution to this project, and while I tried to follow the instructions with due diligence, there are most certainly things that I have forgotten or misunderstood.

So please reach out in case there are any questions or suggestions.

Regards,
Robin


[1] https://github.com/robotframework/SeleniumLibrary/issues/1535#issuecomment-572144557