### PR TITLE
Remove Opera

### DIFF
--- a/atest/acceptance/create_webdriver.robot
+++ b/atest/acceptance/create_webdriver.robot
@@ -37,13 +37,13 @@ Set Driver Variables
     [Documentation]    Selects proper driver
     ${drivers}=    Create Dictionary    ff=Firefox    firefox=Firefox    ie=Ie
     ...    internetexplorer=Ie    googlechrome=Chrome    gc=Chrome
-    ...    chrome=Chrome    opera=Opera    phantomjs=PhantomJS    safari=Safari
+    ...    chrome=Chrome    phantomjs=PhantomJS    safari=Safari
     ...    headlesschrome=Chrome    headlessfirefox=Firefox
     ${name}=    Evaluate    "Remote" if "${REMOTE_URL}"!="None" else $drivers["${BROWSER}"]
     Set Test Variable    ${DRIVER_NAME}    ${name}
     ${dc names}=    Create Dictionary    ff=FIREFOX    firefox=FIREFOX    ie=INTERNETEXPLORER
     ...    internetexplorer=INTERNETEXPLORER    googlechrome=CHROME    gc=CHROME
-    ...    chrome=CHROME    opera=OPERA    phantomjs=PHANTOMJS    htmlunit=HTMLUNIT
+    ...    chrome=CHROME    phantomjs=PHANTOMJS    htmlunit=HTMLUNIT
     ...    htmlunitwithjs=HTMLUNITWITHJS    android=ANDROID    iphone=IPHONE
     ...    safari=SAFARI    headlessfirefox=FIREFOX    headlesschrome=CHROME
     ${dc name}=    Get From Dictionary    ${dc names}    ${BROWSER.lower().replace(' ', '')}

--- a/atest/acceptance/keywords/cookies.robot
+++ b/atest/acceptance/keywords/cookies.robot
@@ -35,15 +35,15 @@ Add Cookie When Secure Is False
     Should Be Equal    ${cookie.secure}       ${False}
 
 Add Cookie When Expiry Is Epoch
-    Add Cookie    Cookie1    value1    expiry=1822137695
+    Add Cookie    Cookie1    value1    expiry=1698601011
     ${cookie} =    Get Cookie    Cookie1
-    ${expiry} =    Convert Date    ${1822137695}    exclude_millis=True
+    ${expiry} =    Convert Date    ${1698601011}    exclude_millis=True
     Should Be Equal As Strings    ${cookie.expiry}    ${expiry}
 
 Add Cookie When Expiry Is Human Readable Data&Time
-    Add Cookie    Cookie12    value12    expiry=2027-09-28 16:21:35
+    Add Cookie    Cookie12    value12    expiry=2023-10-29 19:36:51
     ${cookie} =    Get Cookie    Cookie12
-    Should Be Equal As Strings    ${cookie.expiry}    2027-09-28 16:21:35
+    Should Be Equal As Strings    ${cookie.expiry}    2023-10-29 19:36:51
 
 Delete Cookie
     [Tags]    Known Issue Safari
@@ -71,12 +71,12 @@ Get Cookies As Dict When There Are None
 
 Test Get Cookie Object Expiry
     ${cookie} =    Get Cookie      another
-    Should Be Equal As Integers    ${cookie.expiry.year}           2027
-    Should Be Equal As Integers    ${cookie.expiry.month}          09
-    Should Be Equal As Integers    ${cookie.expiry.day}            28
-    Should Be Equal As Integers    ${cookie.expiry.hour}           16
-    Should Be Equal As Integers    ${cookie.expiry.minute}         21
-    Should Be Equal As Integers    ${cookie.expiry.second}         35
+    Should Be Equal As Integers    ${cookie.expiry.year}           2023
+    Should Be Equal As Integers    ${cookie.expiry.month}          10
+    Should Be Equal As Integers    ${cookie.expiry.day}            29
+    Should Be Equal As Integers    ${cookie.expiry.hour}           19
+    Should Be Equal As Integers    ${cookie.expiry.minute}         36
+    Should Be Equal As Integers    ${cookie.expiry.second}         51
     Should Be Equal As Integers    ${cookie.expiry.microsecond}    0
 
 Test Get Cookie Object Domain
@@ -112,11 +112,11 @@ Test Get Cookie Keyword Logging
     ...    domain=localhost
     ...    secure=False
     ...    httpOnly=False
-    ...    expiry=2027-09-28 16:21:35
+    ...    expiry=2023-10-29 19:36:51
     ${cookie} =    Get Cookie     another
 
 *** Keyword ***
 Add Cookies
     Delete All Cookies
     Add Cookie    test       seleniumlibrary
-    Add Cookie    another    value   expiry=2027-09-28 16:21:35
+    Add Cookie    another    value   expiry=2023-10-29 19:36:51

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-selenium >= 4.0.0
+selenium >= 4.0.0, <= 4.1.3
 robotframework >= 3.2.2
 robotframework-pythonlibcore >= 2.2.1

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -83,7 +83,6 @@ class BrowserManagementKeywords(LibraryComponent):
         | Internet Explorer | internetexplorer, ie     |
         | Edge              | edge                     |
         | Safari            | safari                   |
-        | Opera             | opera                    |
         | Android           | android                  |
         | Iphone            | iphone                   |
         | PhantomJS         | phantomjs                |
@@ -354,7 +353,7 @@ class BrowserManagementKeywords(LibraryComponent):
         the functionality provided by `Open Browser` is not adequate.
 
         ``driver_name`` must be a WebDriver implementation name like Firefox,
-        Chrome, Ie, Opera, Safari, PhantomJS, or Remote.
+        Chrome, Ie, Safari, PhantomJS, or Remote.
 
         The initialized WebDriver can be configured either with a Python
         dictionary ``kwargs`` or by using keyword arguments ``**init_kwargs``.

--- a/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
+++ b/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
@@ -45,7 +45,6 @@ class WebDriverCreator:
         "ie": "ie",
         "internetexplorer": "ie",
         "edge": "edge",
-        "opera": "opera",
         "safari": "safari",
         "phantomjs": "phantomjs",
         "htmlunit": "htmlunit",
@@ -305,29 +304,6 @@ class WebDriverCreator:
                 **desired_capabilities,
             )
         return webdriver.Edge(
-            service_log_path=service_log_path,
-            executable_path=executable_path,
-            **desired_capabilities,
-        )
-
-    def create_opera(
-        self,
-        desired_capabilities,
-        remote_url,
-        options=None,
-        service_log_path=None,
-        executable_path="operadriver",
-    ):
-        if remote_url:
-            defaul_caps = webdriver.DesiredCapabilities.OPERA.copy()
-            desired_capabilities = self._remote_capabilities_resolver(
-                desired_capabilities, defaul_caps
-            )
-            return self._remote(desired_capabilities, remote_url, options=options)
-        if not executable_path:
-            executable_path = self._get_executable_path(webdriver.Opera)
-        return webdriver.Opera(
-            options=options,
             service_log_path=service_log_path,
             executable_path=executable_path,
             **desired_capabilities,

--- a/utest/test/keywords/approved_files/test_selenium_options_parser.test_importer.approved.txt
+++ b/utest/test/keywords/approved_files/test_selenium_options_parser.test_importer.approved.txt
@@ -5,9 +5,8 @@ Selenium options import
 2) <class 'selenium.webdriver.chrome.options.Options'>
 3) <class 'selenium.webdriver.chrome.options.Options'>
 4) <class 'selenium.webdriver.ie.options.Options'>
-5) <class 'selenium.webdriver.opera.options.Options'>
-6) <class 'selenium.webdriver.edge.options.Options'>
-7) <class 'selenium.webdriver.safari.options.Options'>
-8) htmlunit No module named
-9) htmlunit_with_js No module named
-10) iphone No module named
+5) <class 'selenium.webdriver.edge.options.Options'>
+6) <class 'selenium.webdriver.safari.options.Options'>
+7) htmlunit No module named
+8) htmlunit_with_js No module named
+9) iphone No module named

--- a/utest/test/keywords/test_selenium_options_parser.py
+++ b/utest/test/keywords/test_selenium_options_parser.py
@@ -187,7 +187,6 @@ def test_importer(options, reporter):
     results.append(options._import_options("chrome"))
     results.append(options._import_options("headless_chrome"))
     results.append(options._import_options("ie"))
-    results.append(options._import_options("opera"))
     results.append(options._import_options("edge"))
     results.append(error_formatter(options._import_options, "safari"))
     results.append(error_formatter(options._import_options, "htmlunit"))
@@ -349,36 +348,7 @@ def test_has_options(creator):
     assert creator._has_options(webdriver.Firefox)
     assert creator._has_options(webdriver.Ie)
     assert creator._has_options(webdriver.Edge)
-    assert creator._has_options(webdriver.Opera)
     assert creator._has_options(webdriver.Safari)
-
-
-def test_create_opera_with_options(creator):
-    options = mock()
-    expected_webdriver = mock()
-    executable_path = "operadriver"
-    when(webdriver).Opera(
-        options=options, service_log_path=None, executable_path=executable_path
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({}, None, options=options)
-    assert driver == expected_webdriver
-
-
-def test_create_opera_with_options_and_remote_url(creator):
-    url = "http://localhost:4444/wd/hub"
-    caps = webdriver.DesiredCapabilities.OPERA.copy()
-    options = mock()
-    expected_webdriver = mock()
-    file_detector = mock_file_detector(creator)
-    when(webdriver).Remote(
-        command_executor=url,
-        desired_capabilities=caps,
-        browser_profile=None,
-        options=options,
-        file_detector=file_detector,
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({}, url, options=options)
-    assert driver == expected_webdriver
 
 
 def test_create_safari_no_options_support(creator):

--- a/utest/test/keywords/test_webdrivercreator.py
+++ b/utest/test/keywords/test_webdrivercreator.py
@@ -530,64 +530,6 @@ def test_edge_no_browser_name(creator):
     assert driver == expected_webdriver
 
 
-def test_opera(creator):
-    expected_webdriver = mock()
-    executable_path = "operadriver"
-    when(webdriver).Opera(
-        options=None, service_log_path=None, executable_path=executable_path
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({}, None)
-    assert driver == expected_webdriver
-
-
-def test_opera_remote_no_caps(creator):
-    url = "http://localhost:4444/wd/hub"
-    expected_webdriver = mock()
-    capabilities = webdriver.DesiredCapabilities.OPERA.copy()
-    file_detector = mock_file_detector(creator)
-    when(webdriver).Remote(
-        command_executor=url,
-        browser_profile=None,
-        desired_capabilities=capabilities,
-        options=None,
-        file_detector=file_detector,
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({}, url)
-    assert driver == expected_webdriver
-
-
-def test_opera_remote_caps(creator):
-    url = "http://localhost:4444/wd/hub"
-    expected_webdriver = mock()
-    capabilities = {"browserName": "opera"}
-    file_detector = mock_file_detector(creator)
-    when(webdriver).Remote(
-        command_executor=url,
-        browser_profile=None,
-        desired_capabilities=capabilities,
-        options=None,
-        file_detector=file_detector,
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({"desired_capabilities": capabilities}, url)
-    assert driver == expected_webdriver
-
-
-def test_opera_no_browser_name(creator):
-    url = "http://localhost:4444/wd/hub"
-    expected_webdriver = mock()
-    capabilities = {"browserName": "opera", "key": "value"}
-    file_detector = mock_file_detector(creator)
-    when(webdriver).Remote(
-        command_executor=url,
-        browser_profile=None,
-        desired_capabilities=capabilities,
-        options=None,
-        file_detector=file_detector,
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({"desired_capabilities": {"key": "value"}}, url)
-    assert driver == expected_webdriver
-
-
 def test_safari(creator):
     expected_webdriver = mock()
     executable_path = "/usr/bin/safaridriver"

--- a/utest/test/keywords/test_webdrivercreator_executable_path.py
+++ b/utest/test/keywords/test_webdrivercreator_executable_path.py
@@ -50,9 +50,6 @@ def test_get_executable_path(creator):
     executable_path = creator._get_executable_path(webdriver.Ie)
     assert executable_path == "IEDriverServer.exe"
 
-    executable_path = creator._get_executable_path(webdriver.Opera)
-    assert executable_path is None
-
     executable_path = creator._get_executable_path(webdriver.Edge)
     assert executable_path == "msedgedriver"
 
@@ -204,27 +201,6 @@ def test_create_edge_executable_path_not_set(creator):
         service_log_path=None, executable_path=executable_path
     ).thenReturn(expected_webdriver)
     driver = creator.create_edge({}, None, executable_path=None)
-    assert driver == expected_webdriver
-
-
-def test_create_opera_executable_path_set(creator):
-    executable_path = "/path/to/operadriver"
-    expected_webdriver = mock()
-    when(webdriver).Opera(
-        service_log_path=None, options=None, executable_path=executable_path
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({}, None, executable_path=executable_path)
-    assert driver == expected_webdriver
-
-
-def test_create_opera_executable_path_not_set(creator):
-    executable_path = "operadriver"
-    expected_webdriver = mock()
-    when(creator)._get_executable_path(ANY).thenReturn(executable_path)
-    when(webdriver).Opera(
-        service_log_path=None, options=None, executable_path=executable_path
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({}, None, executable_path=None)
     assert driver == expected_webdriver
 
 

--- a/utest/test/keywords/test_webdrivercreator_service_log_path.py
+++ b/utest/test/keywords/test_webdrivercreator_service_log_path.py
@@ -175,17 +175,6 @@ def test_create_edge_with_service_log_path_real_path(creator):
     assert driver == expected_webdriver
 
 
-def test_create_opera_with_service_log_path_real_path(creator):
-    executable_path = "operadriver"
-    log_file = os.path.join(creator.output_dir, "ie-1.log")
-    expected_webdriver = mock()
-    when(webdriver).Opera(
-        options=None, service_log_path=log_file, executable_path=executable_path
-    ).thenReturn(expected_webdriver)
-    driver = creator.creator.create_opera({}, None, service_log_path=log_file)
-    assert driver == expected_webdriver
-
-
 def test_create_safari_no_support_for_service_log_path(creator):
     log_file = os.path.join(creator.output_dir, "ie-1.log")
     expected_webdriver = mock()


### PR DESCRIPTION
Opera is [no longer supported](https://github.com/SeleniumHQ/selenium/blob/trunk/py/CHANGES) and causes unit tests to fail.
[Chrome limits cookie expiry to max 400 days](https://chromestatus.com/feature/4887741241229312) since version 104 so adjusted the expiry times in cookie tests. 

Also, Selenium version 4.1.4 changes logging slightly and that breaks some of the acceptance tests so I have limited the version to  `<= 4.1.3` for now.