### PR TITLE
Remove deprecated opera support

### DIFF
--- a/atest/acceptance/2-event_firing_webdriver/event_firing_webdriver.robot
+++ b/atest/acceptance/2-event_firing_webdriver/event_firing_webdriver.robot
@@ -12,8 +12,8 @@ ${event_firing_or_none}     ${NONE}
 Open Browser To Start Page
     [Tags]    NoGrid
     [Documentation]
-    ...    LOG 1:12 DEBUG  Wrapping driver to event_firing_webdriver.
-    ...    LOG 1:14 INFO  Got driver also from SeleniumLibrary.
+    ...    LOG 1:15 DEBUG  Wrapping driver to event_firing_webdriver.
+    ...    LOG 1:17 INFO  Got driver also from SeleniumLibrary.
     Open Browser    ${FRONT PAGE}    ${BROWSER}    remote_url=${REMOTE_URL}
     ...    desired_capabilities=${DESIRED_CAPABILITIES}
 
@@ -22,16 +22,16 @@ Event Firing Webdriver Go To (WebDriver)
     [Documentation]
     ...    LOG 1:2 INFO STARTS: Before navigate to
     ...    LOG 1:3 INFO Got driver also from SeleniumLibrary.
-    ...    LOG 1:7 INFO STARTS: After navigate to
+    ...    LOG 1:8 INFO STARTS: After navigate to
     Go To     ${ROOT}/forms/named_submit_buttons.html
 
 Event Firing Webdriver Input Text (WebElement)
     [Tags]    NoGrid
     [Documentation]
-    ...    LOG 1:5 INFO  Before clear and send_keys
-    ...    LOG 1:9 INFO  After clear and send_keys
-    ...    LOG 1:10 INFO  Before clear and send_keys
-    ...    LOG 1:14 INFO  After clear and send_keys
+    ...    LOG 1:6 INFO  Before clear and send_keys
+    ...    LOG 1:11 INFO  After clear and send_keys
+    ...    LOG 1:12 INFO  Before clear and send_keys
+    ...    LOG 1:17 INFO  After clear and send_keys
     Input Text    //input[@name="textfield"]    FooBar
 
 Event Firing Webdriver With Get WebElement (WebElement)

--- a/atest/acceptance/2-event_firing_webdriver/selenium_move_to_workaround.robot
+++ b/atest/acceptance/2-event_firing_webdriver/selenium_move_to_workaround.robot
@@ -14,19 +14,19 @@ ${CTRL_OR_COMMAND}    ${EMPTY}
 
 *** Test Cases ***
 Selenium move_to workaround Click Element At Coordinates
-    [Documentation]    LOG 1:5 DEBUG  Workaround for Selenium 3 bug.
+    [Documentation]    LOG 1:6 DEBUG  Workaround for Selenium 3 bug.
     Click Element At Coordinates    id:some_id    4    4
 
 Selenium move_to workaround Scroll Element Into View
-    [Documentation]    LOG 1:4 DEBUG  Workaround for Selenium 3 bug.
+    [Documentation]    LOG 1:5 DEBUG  Workaround for Selenium 3 bug.
     Scroll Element Into View    id:some_id
 
 Selenium move_to workaround Mouse Out
-    [Documentation]    LOG 1:5 DEBUG  Workaround for Selenium 3 bug.
+    [Documentation]    LOG 1:6 DEBUG  Workaround for Selenium 3 bug.
     Mouse Out    id:some_id
 
 Selenium move_to workaround Mouse Over
-    [Documentation]    LOG 1:5 DEBUG  Workaround for Selenium 3 bug.
+    [Documentation]    LOG 1:6 DEBUG  Workaround for Selenium 3 bug.
     Mouse Over    id:some_id
 
 Click Element
@@ -46,7 +46,7 @@ Click Element Action Chain
     [Tags]    NoGrid
     [Documentation]
     ...    LOB SETUP:1 INFO        Clicking 'singleClickButton' using an action chain.
-    ...    LOG 1:6 DEBUG GLOB: *actions {"actions": [{*
+    ...    LOG 1:7 DEBUG GLOB: *actions {"actions": [{*
     [Setup]    Initialize Page For Click Element
     Click Element    singleClickButton      action_chain=True
     Element Text Should Be    output    single clicked

--- a/atest/acceptance/create_webdriver.robot
+++ b/atest/acceptance/create_webdriver.robot
@@ -7,7 +7,7 @@ Library           Collections
 Create Webdriver Creates Functioning WebDriver
     [Documentation]
     ...    LOG 1:1 INFO REGEXP: Creating an instance of the \\w+ WebDriver.
-    ...    LOG 1:6 DEBUG REGEXP: Created \\w+ WebDriver instance with session id (\\w|-)+.
+    ...    LOG 1:7 DEBUG REGEXP: Created \\w+ WebDriver instance with session id (\\w|-)+.
     [Tags]    Known Issue Internet Explorer    Known Issue Safari
     [Setup]    Set Driver Variables
     Create Webdriver    ${DRIVER_NAME}    kwargs=${KWARGS}

--- a/atest/acceptance/create_webdriver.robot
+++ b/atest/acceptance/create_webdriver.robot
@@ -36,15 +36,13 @@ Create Webdriver With Bad Keyword Argument Dictionary
 Set Driver Variables
     [Documentation]    Selects proper driver
     ${drivers}=    Create Dictionary    ff=Firefox    firefox=Firefox    ie=Ie
-    ...    internetexplorer=Ie    googlechrome=Chrome    gc=Chrome
-    ...    chrome=Chrome    opera=Opera    phantomjs=PhantomJS    safari=Safari
-    ...    headlesschrome=Chrome    headlessfirefox=Firefox
+    ...    internetexplorer=Ie    googlechrome=Chrome    gc=Chrome    chrome=Chrome
+    ...    safari=Safari    headlesschrome=Chrome    headlessfirefox=Firefox
     ${name}=    Evaluate    "Remote" if "${REMOTE_URL}"!="None" else $drivers["${BROWSER}"]
     Set Test Variable    ${DRIVER_NAME}    ${name}
     ${dc names}=    Create Dictionary    ff=FIREFOX    firefox=FIREFOX    ie=INTERNETEXPLORER
     ...    internetexplorer=INTERNETEXPLORER    googlechrome=CHROME    gc=CHROME
-    ...    chrome=CHROME    opera=OPERA    phantomjs=PHANTOMJS    htmlunit=HTMLUNIT
-    ...    htmlunitwithjs=HTMLUNITWITHJS    android=ANDROID    iphone=IPHONE
+    ...    chrome=CHROME    htmlunit=HTMLUNIT    htmlunitwithjs=HTMLUNITWITHJS
     ...    safari=SAFARI    headlessfirefox=FIREFOX    headlesschrome=CHROME
     ${dc name}=    Get From Dictionary    ${dc names}    ${BROWSER.lower().replace(' ', '')}
     ${caps}=    Evaluate    selenium.webdriver.DesiredCapabilities.${dc name}

--- a/atest/acceptance/keywords/choose_file.robot
+++ b/atest/acceptance/keywords/choose_file.robot
@@ -44,11 +44,11 @@ Choose File With Grid From Library Using SL choose_file method
 
 Input Text Should Work Same Way When Not Using Grid
     [Documentation]
-    ...    LOG 1:5 DEBUG GLOB:    POST*/session/*/clear {"*
-    ...    LOG 1:7 DEBUG          Finished Request
-    ...    LOG 1:8 DEBUG GLOB:    POST*/session/*/value*"text": "*
-    ...    LOG 1:10 DEBUG         Finished Request
-    ...    LOG 1:11 DEBUG         NONE
+    ...    LOG 1:6 DEBUG GLOB:    POST*/session/*/clear {"*
+    ...    LOG 1:9 DEBUG          Finished Request
+    ...    LOG 1:10 DEBUG GLOB:    POST*/session/*/value*"text": "*
+    ...    LOG 1:13 DEBUG         Finished Request
+    ...    LOG 1:14 DEBUG         NONE
     [Tags]    NoGrid
     [Setup]    Touch    ${CURDIR}${/}temp.txt
     Input Text    file_to_upload    ${CURDIR}${/}temp.txt

--- a/atest/acceptance/keywords/click_element.robot
+++ b/atest/acceptance/keywords/click_element.robot
@@ -40,7 +40,7 @@ Click Element Action Chain
     [Tags]    NoGrid
     [Documentation]
     ...    LOB 1:1 INFO        Clicking 'singleClickButton' using an action chain.
-    ...    LOG 1:6 DEBUG GLOB: *actions {"actions": [{*
+    ...    LOG 1:7 DEBUG GLOB: *actions {"actions": [{*
     Click Element    singleClickButton      action_chain=True
     Element Text Should Be    output    single clicked
 

--- a/atest/acceptance/keywords/content_assertions.robot
+++ b/atest/acceptance/keywords/content_assertions.robot
@@ -7,7 +7,7 @@ Resource          ../resource.robot
 *** Test Cases ***
 Title Should Be
     [Tags]    NoGrid
-    [Documentation]    LOG 1:4 Page title is '(root)/index.html'.
+    [Documentation]    LOG 1:5 Page title is '(root)/index.html'.
     Title Should Be    (root)/index.html
     Run Keyword And Expect Error
     ...    Title should have been 'not a title' but was '(root)/index.html'.
@@ -41,16 +41,16 @@ Page Should Contain With Custom Log Level DEBUG
     [Tags]    NoGrid
     [Documentation]    Html content is shown at DEBUG level.
     ...    FAIL Page should have contained text 'non existing text' but did not.
-    ...    LOG 1:14 DEBUG REGEXP: (?i)<html.*</html>
-    ...    LOG 1:15 FAIL Page should have contained text 'non existing text' but did not.
+    ...    LOG 1:18 DEBUG REGEXP: (?i)<html.*</html>
+    ...    LOG 1:19 FAIL Page should have contained text 'non existing text' but did not.
     Page Should Contain    non existing text    DEBUG
 
 Page Should Contain With Custom Log Level TRACE
     [Tags]    NoGrid
     [Documentation]    Html content is shown at DEBUG level.
     ...    FAIL Page should have contained text 'non existing text' but did not.
-    ...    LOG 2:15 TRACE REGEXP: (?i)<html.*</html>
-    ...    LOG 2:16 FAIL Page should have contained text 'non existing text' but did not.
+    ...    LOG 2:19 TRACE REGEXP: (?i)<html.*</html>
+    ...    LOG 2:20 FAIL Page should have contained text 'non existing text' but did not.
     Set Log Level    TRACE
     Page Should Contain    non existing text    TRACE
     [Teardown]    Set Log Level    DEBUG
@@ -71,14 +71,14 @@ Page Should Not Contain
     [Tags]    NoGrid
     [Documentation]    Default log level does not have html output.
     ...    FAIL Page should not have contained text 'needle'.
-    ...    LOG 1:11 Current page does not contain text 'non existing text'.
-    ...    LOG 2:10 FAIL Page should not have contained text 'needle'.
+    ...    LOG 1:14 Current page does not contain text 'non existing text'.
+    ...    LOG 2:13 FAIL Page should not have contained text 'needle'.
     Page Should Not Contain    non existing text
     Page Should Not Contain    needle
 
 Page Should Not Contain With Custom Log Level
     [Tags]    NoGrid
-    [Documentation]    LOG 1.1:10 DEBUG REGEXP: (?i)<html.*</html>
+    [Documentation]    LOG 1.1:13 DEBUG REGEXP: (?i)<html.*</html>
     Run Keyword And Expect Error
     ...    Page should not have contained text 'needle'.
     ...    Page Should Not Contain    needle    DEBUG
@@ -189,7 +189,7 @@ Get Text
 
 Page Should Contain Checkbox
     [Tags]    NoGrid
-    [Documentation]    LOG 1:7 Current page contains checkbox 'can_send_email'.
+    [Documentation]    LOG 1:9 Current page contains checkbox 'can_send_email'.
     [Setup]    Go To Page "forms/prefilled_email_form.html"
     Page Should Contain Checkbox    can_send_email
     Page Should Contain Checkbox    xpath=//input[@type='checkbox' and @name='can_send_sms']
@@ -199,7 +199,7 @@ Page Should Contain Checkbox
 
 Page Should Not Contain Checkbox
     [Tags]    NoGrid
-    [Documentation]    LOG 1:7 Current page does not contain checkbox 'non-existing'.
+    [Documentation]    LOG 1:9 Current page does not contain checkbox 'non-existing'.
     [Setup]    Go To Page "forms/prefilled_email_form.html"
     Page Should Not Contain Checkbox    non-existing
     Run Keyword And Expect Error
@@ -290,7 +290,7 @@ Page Should Not Contain Text Field
 
 TextField Should Contain
     [Tags]    NoGrid
-    [Documentation]    LOG 1:10 Text field 'name' contains text ''.
+    [Documentation]    LOG 1:13 Text field 'name' contains text ''.
     [Setup]    Go To Page "forms/email_form.html"
     TextField Should contain    name    ${EMPTY}
     TextField Should contain    website    ${EMPTY}
@@ -307,7 +307,7 @@ TextField Should Contain
 
 TextField Value Should Be
     [Tags]    NoGrid
-    [Documentation]    LOG 1:10 Content of text field 'name' is ''.
+    [Documentation]    LOG 1:13 Content of text field 'name' is ''.
     [Setup]    Go To Page "forms/email_form.html"
     textfield Value Should Be    name    ${EMPTY}
     Input Text    name    my name

--- a/atest/acceptance/keywords/content_assertions.robot
+++ b/atest/acceptance/keywords/content_assertions.robot
@@ -20,9 +20,9 @@ Page Should Contain
     [Tags]    NoGrid
     [Documentation]    The last step fails and doesn't contain the html content.
     ...    FAIL Page should have contained text 'non existing text' but did not.
-    ...    LOG 1:7 Current page contains text 'needle'.
-    ...    LOG 2:7 INFO Current page contains text 'This is the haystack'.
-    ...    LOG 3:14 FAIL Page should have contained text 'non existing text' but did not.
+    ...    LOG 1:9 Current page contains text 'needle'.
+    ...    LOG 2:9 INFO Current page contains text 'This is the haystack'.
+    ...    LOG 3:18 FAIL Page should have contained text 'non existing text' but did not.
     Page Should Contain    needle
     Page Should Contain    This is the haystack
     Page Should Contain    non existing text

--- a/atest/acceptance/keywords/cookies.robot
+++ b/atest/acceptance/keywords/cookies.robot
@@ -106,7 +106,7 @@ Test Get Cookie Object Value
 Test Get Cookie Keyword Logging
     [Tags]    NoGrid
     [Documentation]
-    ...    LOG 1:4 ${cookie} = name=another
+    ...    LOG 1:5 ${cookie} = name=another
     ...    value=value
     ...    path=/
     ...    domain=localhost

--- a/atest/acceptance/keywords/cookies.robot
+++ b/atest/acceptance/keywords/cookies.robot
@@ -35,15 +35,15 @@ Add Cookie When Secure Is False
     Should Be Equal    ${cookie.secure}       ${False}
 
 Add Cookie When Expiry Is Epoch
-    Add Cookie    Cookie1    value1    expiry=1822137695
+    Add Cookie    Cookie1    value1    expiry=1698601011
     ${cookie} =    Get Cookie    Cookie1
-    ${expiry} =    Convert Date    ${1822137695}    exclude_millis=True
+    ${expiry} =    Convert Date    ${1698601011}    exclude_millis=True
     Should Be Equal As Strings    ${cookie.expiry}    ${expiry}
 
 Add Cookie When Expiry Is Human Readable Data&Time
-    Add Cookie    Cookie12    value12    expiry=2027-09-28 16:21:35
+    Add Cookie    Cookie12    value12    expiry=2023-10-29 19:36:51
     ${cookie} =    Get Cookie    Cookie12
-    Should Be Equal As Strings    ${cookie.expiry}    2027-09-28 16:21:35
+    Should Be Equal As Strings    ${cookie.expiry}    2023-10-29 19:36:51
 
 Delete Cookie
     [Tags]    Known Issue Safari
@@ -71,12 +71,12 @@ Get Cookies As Dict When There Are None
 
 Test Get Cookie Object Expiry
     ${cookie} =    Get Cookie      another
-    Should Be Equal As Integers    ${cookie.expiry.year}           2027
-    Should Be Equal As Integers    ${cookie.expiry.month}          09
-    Should Be Equal As Integers    ${cookie.expiry.day}            28
-    Should Be Equal As Integers    ${cookie.expiry.hour}           16
-    Should Be Equal As Integers    ${cookie.expiry.minute}         21
-    Should Be Equal As Integers    ${cookie.expiry.second}         35
+    Should Be Equal As Integers    ${cookie.expiry.year}           2023
+    Should Be Equal As Integers    ${cookie.expiry.month}          10
+    Should Be Equal As Integers    ${cookie.expiry.day}            29
+    Should Be Equal As Integers    ${cookie.expiry.hour}           19
+    Should Be Equal As Integers    ${cookie.expiry.minute}         36
+    Should Be Equal As Integers    ${cookie.expiry.second}         51
     Should Be Equal As Integers    ${cookie.expiry.microsecond}    0
 
 Test Get Cookie Object Domain
@@ -112,11 +112,11 @@ Test Get Cookie Keyword Logging
     ...    domain=localhost
     ...    secure=False
     ...    httpOnly=False
-    ...    expiry=2027-09-28 16:21:35
+    ...    expiry=2023-10-29 19:36:51
     ${cookie} =    Get Cookie     another
 
 *** Keyword ***
 Add Cookies
     Delete All Cookies
     Add Cookie    test       seleniumlibrary
-    Add Cookie    another    value   expiry=2027-09-28 16:21:35
+    Add Cookie    another    value   expiry=2023-10-29 19:36:51

--- a/atest/acceptance/keywords/counting_elements.robot
+++ b/atest/acceptance/keywords/counting_elements.robot
@@ -35,13 +35,13 @@ Page Should Contain Element When Limit Is None
 
 Page Should Contain Element When Limit Is Number
     [Tags]    NoGrid
-    [Documentation]    LOG 1:4    INFO Current page contains 2 element(s).
+    [Documentation]    LOG 1:5    INFO Current page contains 2 element(s).
     [Setup]    Go To Page "links.html"
     Page Should Contain Element    name: div_name    limit=2
 
 Page Should Contain Element Log Level Does Not Affect When Keyword Passes
     [Tags]    NoGrid
-    [Documentation]    LOG 1:4    INFO Current page contains 2 element(s).
+    [Documentation]    LOG 1:5    INFO Current page contains 2 element(s).
     [Setup]    Go To Page "links.html"
     Page Should Contain Element    name: div_name    loglevel=debug    limit=2
 
@@ -64,9 +64,9 @@ Page Should Contain Element When Error With Limit And Different Loglevels
     [Tags]    NoGrid
     [Documentation]    Only at DEBUG loglevel is the html placed in the log.
     ...    FAIL Page should have contained "99" element(s), but it did contain "2" element(s).
-    ...    LOG 1.1:7    FAIL Page should have contained "99" element(s), but it did contain "2" element(s).
-    ...    LOG 2:7    DEBUG REGEXP: .*links\\.html.*
-    ...    LOG 2:8    FAIL Page should have contained "99" element(s), but it did contain "2" element(s).
+    ...    LOG 1.1:9    FAIL Page should have contained "99" element(s), but it did contain "2" element(s).
+    ...    LOG 2:9    DEBUG REGEXP: .*links\\.html.*
+    ...    LOG 2:10    FAIL Page should have contained "99" element(s), but it did contain "2" element(s).
     [Setup]    Go To Page "links.html"
     Run Keyword And Ignore Error
     ...    Page Should Contain Element    name: div_name    limit=99

--- a/atest/acceptance/keywords/location.robot
+++ b/atest/acceptance/keywords/location.robot
@@ -6,7 +6,7 @@ Resource          ../resource.robot
 *** Test Cases ***
 Location Should Be
     [Tags]    NoGrid
-    [Documentation]    LOG 1:4 Current location is '${FRONT PAGE}'.
+    [Documentation]    LOG 1:5 Current location is '${FRONT PAGE}'.
     Location Should Be    ${FRONT PAGE}
     Location Should Be    ${FRONT PAGE}  message=taco
     Location Should Be    ${FRONT PAGE}  message=None
@@ -22,7 +22,7 @@ Location Should Be
 
 Location Should Contain
     [Tags]    NoGrid
-    [Documentation]    LOG 1:4 Current location contains 'html'.
+    [Documentation]    LOG 1:5 Current location contains 'html'.
     Location Should Contain    html
     Location Should Contain    html  message=foobar
     Location Should Contain    html  message=None

--- a/atest/acceptance/keywords/screenshots.robot
+++ b/atest/acceptance/keywords/screenshots.robot
@@ -8,8 +8,8 @@ Force Tags        Known Issue Internet Explorer
 Capture page screenshot to default location
     [Tags]    NoGrid
     [Documentation]
-    ...    LOG 1:4 </td></tr><tr><td colspan="3"><a href="selenium-screenshot-1.png"><img src="selenium-screenshot-1.png" width="800px"></a>
-    ...    LOG 7:4 </td></tr><tr><td colspan="3"><a href="selenium-screenshot-2.png"><img src="selenium-screenshot-2.png" width="800px"></a>
+    ...    LOG 1:5 </td></tr><tr><td colspan="3"><a href="selenium-screenshot-1.png"><img src="selenium-screenshot-1.png" width="800px"></a>
+    ...    LOG 7:5 </td></tr><tr><td colspan="3"><a href="selenium-screenshot-2.png"><img src="selenium-screenshot-2.png" width="800px"></a>
     [Setup]    Remove Files    ${OUTPUTDIR}/selenium-screenshot-*.png
     ${file} =    Capture Page Screenshot
     ${count} =    Count Files In Directory    ${OUTPUTDIR}    selenium-screenshot-*.png

--- a/atest/acceptance/keywords/screenshots_embed.robot
+++ b/atest/acceptance/keywords/screenshots_embed.robot
@@ -5,7 +5,7 @@ Resource          ../resource.robot
 Capture Page Screenshot Embedded By Screenshot Root Directory
     [Tags]    NoGrid
     [Documentation]
-    ...    LOG 2:4 INFO STARTS: </td></tr><tr><td colspan="3"><img alt="screenshot" class="robot-seleniumlibrary-screenshot" src="data:image/png;base64,
+    ...    LOG 2:5 INFO STARTS: </td></tr><tr><td colspan="3"><img alt="screenshot" class="robot-seleniumlibrary-screenshot" src="data:image/png;base64,
     [Setup]    Remove .png Files
     Set Screenshot Directory    Embed
     ${file} =    Capture Page Screenshot
@@ -15,7 +15,7 @@ Capture Page Screenshot Embedded By Screenshot Root Directory
 Capture Page Screenshot EMBED As File Name
     [Tags]    NoGrid
     [Documentation]
-    ...    LOG 2:4 INFO STARTS: </td></tr><tr><td colspan="3"><img alt="screenshot" class="robot-seleniumlibrary-screenshot" src="data:image/png;base64,
+    ...    LOG 2:5 INFO STARTS: </td></tr><tr><td colspan="3"><img alt="screenshot" class="robot-seleniumlibrary-screenshot" src="data:image/png;base64,
     [Setup]    Remove .png Files
     Set Screenshot Directory                None
     ${file} =    Capture Page Screenshot    EMBED
@@ -25,7 +25,7 @@ Capture Page Screenshot EMBED As File Name
 Capture Element Screenshot EMBED As File Name
     [Tags]    NoGrid
     [Documentation]
-    ...    LOG 3:7 INFO STARTS: </td></tr><tr><td colspan="3"><img alt="screenshot" class="robot-seleniumlibrary-screenshot" src="data:image/png;base64,
+    ...    LOG 3:9 INFO STARTS: </td></tr><tr><td colspan="3"><img alt="screenshot" class="robot-seleniumlibrary-screenshot" src="data:image/png;base64,
     [Setup]    Remove .png Files
     Go To Page "links.html"
     Set Screenshot Directory                   None

--- a/atest/acceptance/keywords/textfields.robot
+++ b/atest/acceptance/keywords/textfields.robot
@@ -32,13 +32,15 @@ Input Password Should Not Log Password String
     ...    LOG 1:1  INFO          Typing password into text field 'password_field'.
     ...    LOG 1:2  DEBUG STARTS: POST http
     ...    LOG 1:3  DEBUG STARTS: http
-    ...    LOG 1:4  DEBUG         Finished Request
-    ...    LOG 1:5  DEBUG STARTS: POST http
-    ...    LOG 1:6  DEBUG STARTS: http
-    ...    LOG 1:7  DEBUG         Finished Request
-    ...    LOG 1:8  INFO          Temporally setting log level to: NONE
-    ...    LOG 1:9  INFO          Log level changed from NONE to DEBUG.
-    ...    LOG 1:10 NONE
+    ...    LOG 1:3  DEBUG STARTS: Remote response
+    ...    LOG 1:5  DEBUG         Finished Request
+    ...    LOG 1:6  DEBUG STARTS: POST http
+    ...    LOG 1:7  DEBUG STARTS: http
+    ...    LOG 1:8  DEBUG STARTS: Remote response
+    ...    LOG 1:9  DEBUG         Finished Request
+    ...    LOG 1:10  INFO         Temporally setting log level to: NONE
+    ...    LOG 1:11  INFO         Log level changed from NONE to DEBUG.
+    ...    LOG 1:12 NONE
     ...    LOG 2:1  INFO          Typing text 'username' into text field 'username_field'.
     Input Password    password_field    password
     Input Text        username_field    username

--- a/atest/acceptance/keywords/textfields.robot
+++ b/atest/acceptance/keywords/textfields.robot
@@ -32,7 +32,7 @@ Input Password Should Not Log Password String
     ...    LOG 1:1  INFO          Typing password into text field 'password_field'.
     ...    LOG 1:2  DEBUG STARTS: POST http
     ...    LOG 1:3  DEBUG STARTS: http
-    ...    LOG 1:3  DEBUG STARTS: Remote response
+    ...    LOG 1:4  DEBUG STARTS: Remote response
     ...    LOG 1:5  DEBUG         Finished Request
     ...    LOG 1:6  DEBUG STARTS: POST http
     ...    LOG 1:7  DEBUG STARTS: http

--- a/atest/acceptance/open_and_close.robot
+++ b/atest/acceptance/open_and_close.robot
@@ -16,10 +16,10 @@ Close Browser Does Nothing When No Browser Is Opened
 
 Browser Open With Not Well-Formed URL Should Close
     [Documentation]    Verify after incomplete 'Open Browser' browser closes
-    ...    LOG 1.1:15 DEBUG STARTS: Opened browser with session id
-    ...    LOG 1.1:15 DEBUG REGEXP: .*but failed to open url.*
+    ...    LOG 1.1:19 DEBUG STARTS: Opened browser with session id
+    ...    LOG 1.1:19 DEBUG REGEXP: .*but failed to open url.*
     ...    LOG 2:2 DEBUG STARTS: DELETE
-    ...    LOG 2:4 DEBUG STARTS: Finished Request
+    ...    LOG 2:5 DEBUG STARTS: Finished Request
     Run Keyword And Expect Error    *    Open Browser    bad.url.bad    ${BROWSER}
     Close All Browsers
 
@@ -82,8 +82,8 @@ When Closing Browsers Causes An Error
     [Tags]    NoGrid
     [Documentation]
     ...    FAIL       AttributeError: 'NoneType' object has no attribute 'quit'
-    ...    LOG 3:8    ERROR When closing browser, received exception: 'NoneType' object has no attribute 'quit'
-    ...    LOG 3:9    ERROR When closing browser, received exception: 'NoneType' object has no attribute 'quit'
+    ...    LOG 3:10    ERROR When closing browser, received exception: 'NoneType' object has no attribute 'quit'
+    ...    LOG 3:11    ERROR When closing browser, received exception: 'NoneType' object has no attribute 'quit'
     Open Browser    ${ROOT}/forms/prefilled_email_form.html    ${BROWSER}    Browser 1
     ...    remote_url=${REMOTE_URL}    desired_capabilities=${DESIRED_CAPABILITIES}
     Invalidate Driver

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -83,8 +83,6 @@ class BrowserManagementKeywords(LibraryComponent):
         | Internet Explorer | internetexplorer, ie     |
         | Edge              | edge                     |
         | Safari            | safari                   |
-        | Opera             | opera                    |
-        | Android           | android                  |
         | Iphone            | iphone                   |
         | PhantomJS         | phantomjs                |
         | HTMLUnit          | htmlunit                 |
@@ -354,7 +352,7 @@ class BrowserManagementKeywords(LibraryComponent):
         the functionality provided by `Open Browser` is not adequate.
 
         ``driver_name`` must be a WebDriver implementation name like Firefox,
-        Chrome, Ie, Opera, Safari, PhantomJS, or Remote.
+        Chrome, Ie, Edge, Safari, or Remote.
 
         The initialized WebDriver can be configured either with a Python
         dictionary ``kwargs`` or by using keyword arguments ``**init_kwargs``.

--- a/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
+++ b/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
@@ -45,7 +45,6 @@ class WebDriverCreator:
         "ie": "ie",
         "internetexplorer": "ie",
         "edge": "edge",
-        "opera": "opera",
         "safari": "safari",
         "phantomjs": "phantomjs",
         "htmlunit": "htmlunit",
@@ -305,29 +304,6 @@ class WebDriverCreator:
                 **desired_capabilities,
             )
         return webdriver.Edge(
-            service_log_path=service_log_path,
-            executable_path=executable_path,
-            **desired_capabilities,
-        )
-
-    def create_opera(
-        self,
-        desired_capabilities,
-        remote_url,
-        options=None,
-        service_log_path=None,
-        executable_path="operadriver",
-    ):
-        if remote_url:
-            defaul_caps = webdriver.DesiredCapabilities.OPERA.copy()
-            desired_capabilities = self._remote_capabilities_resolver(
-                desired_capabilities, defaul_caps
-            )
-            return self._remote(desired_capabilities, remote_url, options=options)
-        if not executable_path:
-            executable_path = self._get_executable_path(webdriver.Opera)
-        return webdriver.Opera(
-            options=options,
             service_log_path=service_log_path,
             executable_path=executable_path,
             **desired_capabilities,

--- a/utest/test/keywords/approved_files/test_selenium_options_parser.test_importer.approved.txt
+++ b/utest/test/keywords/approved_files/test_selenium_options_parser.test_importer.approved.txt
@@ -5,9 +5,8 @@ Selenium options import
 2) <class 'selenium.webdriver.chrome.options.Options'>
 3) <class 'selenium.webdriver.chrome.options.Options'>
 4) <class 'selenium.webdriver.ie.options.Options'>
-5) <class 'selenium.webdriver.opera.options.Options'>
-6) <class 'selenium.webdriver.edge.options.Options'>
-7) <class 'selenium.webdriver.safari.options.Options'>
-8) htmlunit No module named
-9) htmlunit_with_js No module named
-10) iphone No module named
+5) <class 'selenium.webdriver.edge.options.Options'>
+6) <class 'selenium.webdriver.safari.options.Options'>
+7) htmlunit No module named
+8) htmlunit_with_js No module named
+9) iphone No module named

--- a/utest/test/keywords/test_selenium_options_parser.py
+++ b/utest/test/keywords/test_selenium_options_parser.py
@@ -187,7 +187,6 @@ def test_importer(options, reporter):
     results.append(options._import_options("chrome"))
     results.append(options._import_options("headless_chrome"))
     results.append(options._import_options("ie"))
-    results.append(options._import_options("opera"))
     results.append(options._import_options("edge"))
     results.append(error_formatter(options._import_options, "safari"))
     results.append(error_formatter(options._import_options, "htmlunit"))
@@ -349,36 +348,7 @@ def test_has_options(creator):
     assert creator._has_options(webdriver.Firefox)
     assert creator._has_options(webdriver.Ie)
     assert creator._has_options(webdriver.Edge)
-    assert creator._has_options(webdriver.Opera)
     assert creator._has_options(webdriver.Safari)
-
-
-def test_create_opera_with_options(creator):
-    options = mock()
-    expected_webdriver = mock()
-    executable_path = "operadriver"
-    when(webdriver).Opera(
-        options=options, service_log_path=None, executable_path=executable_path
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({}, None, options=options)
-    assert driver == expected_webdriver
-
-
-def test_create_opera_with_options_and_remote_url(creator):
-    url = "http://localhost:4444/wd/hub"
-    caps = webdriver.DesiredCapabilities.OPERA.copy()
-    options = mock()
-    expected_webdriver = mock()
-    file_detector = mock_file_detector(creator)
-    when(webdriver).Remote(
-        command_executor=url,
-        desired_capabilities=caps,
-        browser_profile=None,
-        options=options,
-        file_detector=file_detector,
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({}, url, options=options)
-    assert driver == expected_webdriver
 
 
 def test_create_safari_no_options_support(creator):

--- a/utest/test/keywords/test_webdrivercreator.py
+++ b/utest/test/keywords/test_webdrivercreator.py
@@ -530,64 +530,6 @@ def test_edge_no_browser_name(creator):
     assert driver == expected_webdriver
 
 
-def test_opera(creator):
-    expected_webdriver = mock()
-    executable_path = "operadriver"
-    when(webdriver).Opera(
-        options=None, service_log_path=None, executable_path=executable_path
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({}, None)
-    assert driver == expected_webdriver
-
-
-def test_opera_remote_no_caps(creator):
-    url = "http://localhost:4444/wd/hub"
-    expected_webdriver = mock()
-    capabilities = webdriver.DesiredCapabilities.OPERA.copy()
-    file_detector = mock_file_detector(creator)
-    when(webdriver).Remote(
-        command_executor=url,
-        browser_profile=None,
-        desired_capabilities=capabilities,
-        options=None,
-        file_detector=file_detector,
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({}, url)
-    assert driver == expected_webdriver
-
-
-def test_opera_remote_caps(creator):
-    url = "http://localhost:4444/wd/hub"
-    expected_webdriver = mock()
-    capabilities = {"browserName": "opera"}
-    file_detector = mock_file_detector(creator)
-    when(webdriver).Remote(
-        command_executor=url,
-        browser_profile=None,
-        desired_capabilities=capabilities,
-        options=None,
-        file_detector=file_detector,
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({"desired_capabilities": capabilities}, url)
-    assert driver == expected_webdriver
-
-
-def test_opera_no_browser_name(creator):
-    url = "http://localhost:4444/wd/hub"
-    expected_webdriver = mock()
-    capabilities = {"browserName": "opera", "key": "value"}
-    file_detector = mock_file_detector(creator)
-    when(webdriver).Remote(
-        command_executor=url,
-        browser_profile=None,
-        desired_capabilities=capabilities,
-        options=None,
-        file_detector=file_detector,
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({"desired_capabilities": {"key": "value"}}, url)
-    assert driver == expected_webdriver
-
-
 def test_safari(creator):
     expected_webdriver = mock()
     executable_path = "/usr/bin/safaridriver"

--- a/utest/test/keywords/test_webdrivercreator_executable_path.py
+++ b/utest/test/keywords/test_webdrivercreator_executable_path.py
@@ -50,9 +50,6 @@ def test_get_executable_path(creator):
     executable_path = creator._get_executable_path(webdriver.Ie)
     assert executable_path == "IEDriverServer.exe"
 
-    executable_path = creator._get_executable_path(webdriver.Opera)
-    assert executable_path is None
-
     executable_path = creator._get_executable_path(webdriver.Edge)
     assert executable_path == "msedgedriver"
 
@@ -204,27 +201,6 @@ def test_create_edge_executable_path_not_set(creator):
         service_log_path=None, executable_path=executable_path
     ).thenReturn(expected_webdriver)
     driver = creator.create_edge({}, None, executable_path=None)
-    assert driver == expected_webdriver
-
-
-def test_create_opera_executable_path_set(creator):
-    executable_path = "/path/to/operadriver"
-    expected_webdriver = mock()
-    when(webdriver).Opera(
-        service_log_path=None, options=None, executable_path=executable_path
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({}, None, executable_path=executable_path)
-    assert driver == expected_webdriver
-
-
-def test_create_opera_executable_path_not_set(creator):
-    executable_path = "operadriver"
-    expected_webdriver = mock()
-    when(creator)._get_executable_path(ANY).thenReturn(executable_path)
-    when(webdriver).Opera(
-        service_log_path=None, options=None, executable_path=executable_path
-    ).thenReturn(expected_webdriver)
-    driver = creator.create_opera({}, None, executable_path=None)
     assert driver == expected_webdriver
 
 

--- a/utest/test/keywords/test_webdrivercreator_service_log_path.py
+++ b/utest/test/keywords/test_webdrivercreator_service_log_path.py
@@ -175,17 +175,6 @@ def test_create_edge_with_service_log_path_real_path(creator):
     assert driver == expected_webdriver
 
 
-def test_create_opera_with_service_log_path_real_path(creator):
-    executable_path = "operadriver"
-    log_file = os.path.join(creator.output_dir, "ie-1.log")
-    expected_webdriver = mock()
-    when(webdriver).Opera(
-        options=None, service_log_path=log_file, executable_path=executable_path
-    ).thenReturn(expected_webdriver)
-    driver = creator.creator.create_opera({}, None, service_log_path=log_file)
-    assert driver == expected_webdriver
-
-
 def test_create_safari_no_support_for_service_log_path(creator):
     log_file = os.path.join(creator.output_dir, "ie-1.log")
     expected_webdriver = mock()


### PR DESCRIPTION
Pulls out Opera from the tests. Also updates the expected logging as Selenium version 4.1.4 made some modifications to the debug logging. Finally this includes a fix by @Brownies for the Cookies tests. As he notes in his pull request,

> [Chrome limits cookie expiry to max 400 days](https://chromestatus.com/feature/4887741241229312) since version 104 so adjusted the expiry times in cookie tests.