### PR TITLE
Remove deprecated rebot option

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,9 +12,9 @@ jobs:
         rf-version: [3.2.2, 4.1.3]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }} with Robot Framework ${{ matrix.rf-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Start xvfb

--- a/atest/acceptance/windows.robot
+++ b/atest/acceptance/windows.robot
@@ -95,14 +95,14 @@ Get and Set Inner Window Size with Frames
     ...    Set Window Size         ${400}    ${300}    ${True}
 
 Get and Set Window Position
-    [Tags]  Known Issue Chrome    Known Issue Safari
+    [Tags]    Known Issue Safari
     Set Window Position    ${300}    ${200}
     ${x}    ${y}=    Get Window Position
     Should Be Equal    ${x}    ${300}
     Should Be Equal    ${y}    ${200}
 
 Set Window Position using strings
-    [Tags]  Known Issue Chrome    Known Issue Safari
+    [Tags]    Known Issue Safari
     Set Window Position    200    100
     ${x}    ${y}=    Get Window Position
     Should Be Equal    ${x}    ${200}

--- a/atest/run.py
+++ b/atest/run.py
@@ -97,8 +97,6 @@ ROBOT_OPTIONS = [
 REBOT_OPTIONS = [
     "--outputdir",
     RESULTS_DIR,
-    "--noncritical",
-    "known issue {browser}",
 ]
 
 
@@ -208,6 +206,7 @@ def execute_tests(interpreter, browser, rf_options, grid, event_firing):
     options.extend([opt.format(browser=browser) for opt in ROBOT_OPTIONS])
     if rf_options:
         options += rf_options
+    options += ["--exclude", f"known issue {browser.replace('headless', '')}"]
     command = runner
     if grid:
         command += [


### PR DESCRIPTION
Fixes #1788 

Also updates `checkout` action to `v3` and `setup-python` action to `v4`.
Actions based on Node12 now emit warnings like
`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-python, actions/setup-python, actions/checkout`