### PR TITLE
Use python interpreter that executed atest/run.py instead of python

### DIFF
--- a/atest/run.py
+++ b/atest/run.py
@@ -110,7 +110,7 @@ def acceptance_tests(
     os.mkdir(RESULTS_DIR)
     if grid:
         hub, node = start_grid()
-    with http_server():
+    with http_server(interpreter):
         execute_tests(interpreter, browser, rf_options, grid, event_firing)
     failures = process_output(browser)
     if failures:
@@ -179,17 +179,18 @@ def _grid_status(status=False, role="hub"):
 
 
 @contextmanager
-def http_server():
+def http_server(interpreter):
     serverlog = open(os.path.join(RESULTS_DIR, "serverlog.txt"), "w")
+    interpreter = "python" if not interpreter else interpreter
     process = subprocess.Popen(
-        ["python", HTTP_SERVER_FILE, "start"],
+        [interpreter, HTTP_SERVER_FILE, "start"],
         stdout=serverlog,
         stderr=subprocess.STDOUT,
     )
     try:
         yield
     finally:
-        subprocess.call(["python", HTTP_SERVER_FILE, "stop"])
+        subprocess.call([interpreter, HTTP_SERVER_FILE, "stop"])
         process.wait()
         serverlog.close()
 

--- a/atest/run.py
+++ b/atest/run.py
@@ -277,7 +277,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--interpreter",
         "-I",
-        default="python",
+        default=sys.executable,
         help=textwrap.dedent(
             """\
                             Any Python interpreter supported by the library.
@@ -313,7 +313,7 @@ if __name__ == "__main__":
     args, rf_options = parser.parse_known_args()
     browser = args.browser.lower().strip()
     selenium_grid = is_truthy(args.grid)
-    interpreter = args.interpreter
+    interpreter = "python" if not args.interpreter else args.interpreter
     event_firing_webdriver = args.event_firing_webdriver
     if args.nounit:
         print("Not running unit tests.")


### PR DESCRIPTION
When running under a virtualenv, using `python` as the interpreter forgets the virtualenv python which executed atest.run.py. Instead using sys.executable which will execute with same interpreter used to execute atest/run.py. I also later check to make sure the interpreter is not None nor an empty string as doc states [1] it may be if "Python is unable to retrieve the interpreter".

Fixes #1796

[1] https://docs.python.org/3.10/library/sys.html#sys.executable