### PR TITLE
Updated `Test Get Cookie Keyword Logging` with Samesite attribute

### DIFF
--- a/atest/acceptance/keywords/cookies.robot
+++ b/atest/acceptance/keywords/cookies.robot
@@ -113,6 +113,7 @@ Test Get Cookie Keyword Logging
     ...    secure=False
     ...    httpOnly=False
     ...    expiry=2023-10-29 19:36:51
+    ...    extra={'sameSite': 'Lax'}
     ${cookie} =    Get Cookie     another
 
 *** Keyword ***


### PR DESCRIPTION
Updated expected result to include the samesite cookie attribute. For more information about this attribute see,

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite

It is unclear why the cookie response now includes this. As noted in the reference above this may be browser dependent.

Additional reference from the source above - https://web.dev/samesite-cookies-explained/