### PR TITLE
Remove deprecated headless option for chrome and firefox.

### DIFF
--- a/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
+++ b/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
@@ -161,7 +161,7 @@ class WebDriverCreator:
     ):
         if not options:
             options = webdriver.ChromeOptions()
-        options.headless = True
+        options.add_argument('--headless=new')
         return self.create_chrome(
             desired_capabilities, remote_url, options, service_log_path, executable_path
         )
@@ -224,7 +224,7 @@ class WebDriverCreator:
                     else:
                         setattr(ff_profile, key, *option[key])
             return ff_profile
-    
+
     @property
     def _geckodriver_log(self):
         log_file = self._get_log_path(
@@ -244,7 +244,7 @@ class WebDriverCreator:
     ):
         if not options:
             options = webdriver.FirefoxOptions()
-        options.headless = True
+        options.add_argument('-headless')
         return self.create_firefox(
             desired_capabilities,
             remote_url,


### PR DESCRIPTION
Deprecated in Version 4.8.0 of Selenium
Removed in version 4.13.0