### PR TITLE
Preconfigure chrome browser

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,18 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Setup Chrome
+      uses: browser-actions/setup-chrome@latest
+      with:
+        chrome-version: latest
+      id: setup-chrome
+    - run: |
+        echo Installed chromium version: ${{ steps.setup-chrome.outputs.chrome-version }}
+        ${{ steps.setup-chrome.outputs.chrome-path }} --version
+    - run: |
+        SELENIUM_MANAGER_EXE=$(python -c 'from selenium.webdriver.common.selenium_manager import SeleniumManager; sm=SeleniumManager(); print(f"{str(sm.get_binary())}")')
+        echo "$SELENIUM_MANAGER_EXE"
+        $SELENIUM_MANAGER_EXE --browser chrome --debug
     - name: Start xvfb
       run: |
         export DISPLAY=:99.0

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         SELENIUM_MANAGER_EXE=$(python -c 'from selenium.webdriver.common.selenium_manager import SeleniumManager; sm=SeleniumManager(); print(f"{str(sm.get_binary())}")')
         echo "$SELENIUM_MANAGER_EXE"
-        WEBDRIVERPATH=$($SELENIUM_MANAGER_EXE --browser chrome --debug | awk '/INFO[[:space:]]Driver path:/ {print $NF;exit}')
+        source WEBDRIVERPATH=$($SELENIUM_MANAGER_EXE --browser chrome --debug | awk '/INFO[[:space:]]Driver path:/ {print $NF;exit}')
         echo "$WEBDRIVERPATH"
     - name: Generate stub file for ${{ matrix.python-version }}
       if: matrix.python-version != 'pypy-3.7'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,8 @@ jobs:
       run: |
         SELENIUM_MANAGER_EXE=$(python -c 'from selenium.webdriver.common.selenium_manager import SeleniumManager; sm=SeleniumManager(); print(f"{str(sm.get_binary())}")')
         echo "$SELENIUM_MANAGER_EXE"
-        DRIVER_PATH=$($SELENIUM_MANAGER_EXE --browser chrome --debug | awk '/INFO[[:space:]]Driver path:/ {print $NF;exit}')
+        WEBDRIVERPATH=$($SELENIUM_MANAGER_EXE --browser chrome --debug | awk '/INFO[[:space:]]Driver path:/ {print $NF;exit}')
+        echo "$WEBDRIVERPATH"
     - name: Generate stub file for ${{ matrix.python-version }}
       if: matrix.python-version != 'pypy-3.7'
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,10 +25,6 @@ jobs:
     - run: |
         echo Installed chromium version: ${{ steps.setup-chrome.outputs.chrome-version }}
         ${{ steps.setup-chrome.outputs.chrome-path }} --version
-    - run: |
-        SELENIUM_MANAGER_EXE=$(python -c 'from selenium.webdriver.common.selenium_manager import SeleniumManager; sm=SeleniumManager(); print(f"{str(sm.get_binary())}")')
-        echo "$SELENIUM_MANAGER_EXE"
-        $SELENIUM_MANAGER_EXE --browser chrome --debug
     - name: Start xvfb
       run: |
         export DISPLAY=:99.0
@@ -48,6 +44,11 @@ jobs:
     - name: Install RF ${{ matrix.rf-version }}
       run: |
         pip install -U --pre robotframework==${{ matrix.rf-version }}
+    - name: Install drivers via selenium-manager
+      run: |
+        SELENIUM_MANAGER_EXE=$(python -c 'from selenium.webdriver.common.selenium_manager import SeleniumManager; sm=SeleniumManager(); print(f"{str(sm.get_binary())}")')
+        echo "$SELENIUM_MANAGER_EXE"
+        $SELENIUM_MANAGER_EXE --browser chrome --debug
     - name: Generate stub file for ${{ matrix.python-version }}
       if: matrix.python-version != 'pypy-3.7'
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         SELENIUM_MANAGER_EXE=$(python -c 'from selenium.webdriver.common.selenium_manager import SeleniumManager; sm=SeleniumManager(); print(f"{str(sm.get_binary())}")')
         echo "$SELENIUM_MANAGER_EXE"
-        export WEBDRIVERPATH=$($SELENIUM_MANAGER_EXE --browser chrome --debug | awk '/INFO[[:space:]]Driver path:/ {print $NF;exit}')
+        echo "WEBDRIVERPATH=$($SELENIUM_MANAGER_EXE --browser chrome --debug | awk '/INFO[[:space:]]Driver path:/ {print $NF;exit}')" >> "$GITHUB_ENV"
         echo "$WEBDRIVERPATH"
     - name: Generate stub file for ${{ matrix.python-version }}
       if: matrix.python-version != 'pypy-3.7'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         SELENIUM_MANAGER_EXE=$(python -c 'from selenium.webdriver.common.selenium_manager import SeleniumManager; sm=SeleniumManager(); print(f"{str(sm.get_binary())}")')
         echo "$SELENIUM_MANAGER_EXE"
-        source WEBDRIVERPATH=$($SELENIUM_MANAGER_EXE --browser chrome --debug | awk '/INFO[[:space:]]Driver path:/ {print $NF;exit}')
+        export WEBDRIVERPATH=$($SELENIUM_MANAGER_EXE --browser chrome --debug | awk '/INFO[[:space:]]Driver path:/ {print $NF;exit}')
         echo "$WEBDRIVERPATH"
     - name: Generate stub file for ${{ matrix.python-version }}
       if: matrix.python-version != 'pypy-3.7'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         SELENIUM_MANAGER_EXE=$(python -c 'from selenium.webdriver.common.selenium_manager import SeleniumManager; sm=SeleniumManager(); print(f"{str(sm.get_binary())}")')
         echo "$SELENIUM_MANAGER_EXE"
-        $SELENIUM_MANAGER_EXE --browser chrome --debug
+        DRIVER_PATH=$($SELENIUM_MANAGER_EXE --browser chrome --debug | awk '/INFO[[:space:]]Driver path:/ {print $NF;exit}')
     - name: Generate stub file for ${{ matrix.python-version }}
       if: matrix.python-version != 'pypy-3.7'
       run: |

--- a/atest/acceptance/2-event_firing_webdriver/event_firing_webdriver.robot
+++ b/atest/acceptance/2-event_firing_webdriver/event_firing_webdriver.robot
@@ -2,7 +2,7 @@
 Library           SeleniumLibrary    event_firing_webdriver=${CURDIR}/../../resources/testlibs/MyListener.py
 Resource          resource_event_firing_webdriver.robot
 Suite Setup       Open Browser    ${FRONT PAGE}    ${BROWSER}    alias=event_firing_webdriver
-...                   remote_url=${REMOTE_URL}    executable_path=%{DRIVER_PATH}
+...                   remote_url=${REMOTE_URL}    executable_path=%{WEBDRIVERPATH}
 Suite Teardown    Close All Browsers
 
 *** Variables ***

--- a/atest/acceptance/2-event_firing_webdriver/event_firing_webdriver.robot
+++ b/atest/acceptance/2-event_firing_webdriver/event_firing_webdriver.robot
@@ -2,7 +2,7 @@
 Library           SeleniumLibrary    event_firing_webdriver=${CURDIR}/../../resources/testlibs/MyListener.py
 Resource          resource_event_firing_webdriver.robot
 Suite Setup       Open Browser    ${FRONT PAGE}    ${BROWSER}    alias=event_firing_webdriver
-...                   remote_url=${REMOTE_URL}    desired_capabilities=${DESIRED_CAPABILITIES}
+...                   remote_url=${REMOTE_URL}    executable_path=%{DRIVER_PATH}
 Suite Teardown    Close All Browsers
 
 *** Variables ***

--- a/atest/acceptance/2-event_firing_webdriver/event_firing_webdriver.robot
+++ b/atest/acceptance/2-event_firing_webdriver/event_firing_webdriver.robot
@@ -2,7 +2,7 @@
 Library           SeleniumLibrary    event_firing_webdriver=${CURDIR}/../../resources/testlibs/MyListener.py
 Resource          resource_event_firing_webdriver.robot
 Suite Setup       Open Browser    ${FRONT PAGE}    ${BROWSER}    alias=event_firing_webdriver
-...                   remote_url=${REMOTE_URL}    executable_path=%{WEBDRIVERPATH}
+...                   remote_url=${REMOTE_URL}    executable_path=/usr/bin/chromedriver
 Suite Teardown    Close All Browsers
 
 *** Variables ***

--- a/atest/acceptance/2-event_firing_webdriver/event_firing_webdriver.robot
+++ b/atest/acceptance/2-event_firing_webdriver/event_firing_webdriver.robot
@@ -2,7 +2,7 @@
 Library           SeleniumLibrary    event_firing_webdriver=${CURDIR}/../../resources/testlibs/MyListener.py
 Resource          resource_event_firing_webdriver.robot
 Suite Setup       Open Browser    ${FRONT PAGE}    ${BROWSER}    alias=event_firing_webdriver
-...                   remote_url=${REMOTE_URL}    executable_path=/usr/bin/chromedriver
+...                   remote_url=${REMOTE_URL}    executable_path=%{WEBDRIVERPATH}
 Suite Teardown    Close All Browsers
 
 *** Variables ***


### PR DESCRIPTION
Setup the chromer broswer and driver prior to executing tests so that selenium-manager does not configure test systems at execution time. It was also hoped that this would prevent selenium-manager from logging but for that to happen with current selenium-manager (Selenium v4.14.0) one must tell the Open Browser keyword where the driver is (using executable_directory argument).