### PR TITLE
fixed type hinting so that it is not converted to str

### DIFF
--- a/atest/acceptance/keywords/async_javascript.robot
+++ b/atest/acceptance/keywords/async_javascript.robot
@@ -19,6 +19,14 @@ Execute Async Javascript With ARGUMENTS and JAVASCRIPT Marker
     ...  alert(arguments[0]);
     Alert Should Be Present    123    timeout=10 s
 
+Execute Javascript with dictionary object
+    &{ARGS}=            Create Dictionary     key=value    number=${1}    boolean=${TRUE}
+    ${returned}    Execute Async Javascript      arguments[1](arguments[0]);    ARGUMENTS    ${ARGS}
+    Should Be True    type($returned) == dict
+    Should Be Equal    ${returned}[key]    value
+    Should Be Equal    ${returned}[number]    ${1}
+    Should Be Equal    ${returned}[boolean]    ${TRUE}
+
 Should Be Able To Return Javascript Primitives From Async Scripts Neither None Nor Undefined
     ${result} =    Execute Async Javascript    arguments[arguments.length - 1](123);
     Should Be Equal    ${result}    ${123}

--- a/atest/acceptance/keywords/javascript.robot
+++ b/atest/acceptance/keywords/javascript.robot
@@ -85,6 +85,14 @@ Execute Javascript from File With ARGUMENTS Marker
     ...    123
     Alert Should Be Present    123    timeout=10 s
 
+Execute Javascript with dictionary object
+    &{ARGS}=            Create Dictionary     key=value    number=${1}    boolean=${TRUE}
+    ${returned}    Execute JavaScript      return arguments[0]    ARGUMENTS    ${ARGS}
+    Should Be True    type($returned) == dict
+    Should Be Equal    ${returned}[key]    value
+    Should Be Equal    ${returned}[number]    ${1}
+    Should Be Equal    ${returned}[boolean]    ${TRUE}
+
 Open Context Menu
     [Tags]    Known Issue Safari
     Go To Page "javascript/context_menu.html"

--- a/src/SeleniumLibrary/keywords/javascript.py
+++ b/src/SeleniumLibrary/keywords/javascript.py
@@ -30,7 +30,7 @@ class JavaScriptKeywords(LibraryComponent):
     arg_marker = "ARGUMENTS"
 
     @keyword
-    def execute_javascript(self, *code: Union[WebElement, str]) -> Any:
+    def execute_javascript(self, *code: Any) -> Any:
         """Executes the given JavaScript code with possible arguments.
 
         ``code`` may be divided into multiple cells in the test data and
@@ -73,7 +73,7 @@ class JavaScriptKeywords(LibraryComponent):
         return self.driver.execute_script(js_code, *js_args)
 
     @keyword
-    def execute_async_javascript(self, *code: Union[WebElement, str]) -> Any:
+    def execute_async_javascript(self, *code: Any) -> Any:
         """Executes asynchronous JavaScript code with possible arguments.
 
         Similar to `Execute Javascript` except that scripts executed with


### PR DESCRIPTION
The problem was that the type hint `str` did convert everything to string.
So a dictionary `{'key': 'value'}` does become `"{'key': 'value'}"` and this is then put to `json.dumps`
That obviously is then not a js object anymore.

Added tests as well.