### PR TITLE
Open browser options bug #1877

### DIFF
--- a/atest/acceptance/keywords/elements.robot
+++ b/atest/acceptance/keywords/elements.robot
@@ -3,7 +3,6 @@ Documentation     Tests elements
 Test Setup        Go To Page "links.html"
 Resource          ../resource.robot
 Library           String
-Library           DebugLibrary
 
 *** Test Cases ***
 Get Many Elements

--- a/atest/acceptance/multiple_browsers_options.robot
+++ b/atest/acceptance/multiple_browsers_options.robot
@@ -51,3 +51,7 @@ Chrome Browser With Selenium Options Argument With Semicolon
     ...    LOG 1:14 DEBUG GLOB: *["has;semicolon"*
     Open Browser    ${FRONT PAGE}    ${BROWSER}    remote_url=${REMOTE_URL}
     ...    desired_capabilities=${DESIRED_CAPABILITIES}    options=add_argument("has;semicolon")
+
+Chrome Browser with Selenium Options Argument Ending With Semicolon
+    Open Browser    ${FRONT PAGE}    ${BROWSER}    remote_url=${REMOTE_URL}
+    ...    desired_capabilities=${DESIRED_CAPABILITIES}    options=add_argument("--disable-dev-shm-usage") ;

--- a/atest/acceptance/multiple_browsers_options.robot
+++ b/atest/acceptance/multiple_browsers_options.robot
@@ -52,6 +52,19 @@ Chrome Browser With Selenium Options Argument With Semicolon
     Open Browser    ${FRONT PAGE}    ${BROWSER}    remote_url=${REMOTE_URL}
     ...    desired_capabilities=${DESIRED_CAPABILITIES}    options=add_argument("has;semicolon")
 
-Chrome Browser with Selenium Options Argument Ending With Semicolon
+Chrome Browser with Selenium Options Ending With Semicolon
     Open Browser    ${FRONT PAGE}    ${BROWSER}    remote_url=${REMOTE_URL}
     ...    desired_capabilities=${DESIRED_CAPABILITIES}    options=add_argument("--disable-dev-shm-usage") ;
+
+Chrome Browser with Selenium Options Ending With A Few Semicolons
+    Open Browser    ${FRONT PAGE}    ${BROWSER}    remote_url=${REMOTE_URL}
+    ...    desired_capabilities=${DESIRED_CAPABILITIES}    options=add_argument("--disable-dev-shm-usage") ; ; ;
+
+Chrome Browser with Selenium Options Containing Empty Option
+    Open Browser    ${FRONT PAGE}    ${BROWSER}    remote_url=${REMOTE_URL}
+    ...    desired_capabilities=${DESIRED_CAPABILITIES}    options=add_argument ( "--disable-dev-shm-usage" ) ; ; add_argument ( "--headless=new" )
+
+Chrome Browser with Selenium Options With A Missing Semicolon
+    Run Keyword And Expect Error    ValueError: Unable to parse option: "add_argument ( "--disable-dev-shm-usage" ) add_argument ( "--headless=new" )"
+    ...    Open Browser    ${FRONT PAGE}    ${BROWSER}    remote_url=${REMOTE_URL}
+    ...    desired_capabilities=${DESIRED_CAPABILITIES}    options=add_argument ( "--disable-dev-shm-usage" ) add_argument ( "--headless=new" )

--- a/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
+++ b/src/SeleniumLibrary/keywords/webdrivertools/webdrivertools.py
@@ -503,6 +503,9 @@ class SeleniumOptions:
         selenium_options = selenium_options()
         for option in options:
             for key in option:
+                if key == '' and option[key]==[]:
+                    logger.warn('Empty selenium option found and ignored. Suggested you review options passed to `Open Browser` keyword')
+                    continue
                 attr = getattr(selenium_options, key)
                 if callable(attr):
                     attr(*option[key])
@@ -566,9 +569,12 @@ class SeleniumOptions:
         split_options = []
         start_position = 0
         tokens = generate_tokens(StringIO(options).readline)
-        for toknum, tokval, tokpos, _, _ in tokens:
-            if toknum == token.OP and tokval == ";":
+        for toktype, tokval, tokpos, _, _ in tokens:
+            if toktype == token.OP and tokval == ";":
                 split_options.append(options[start_position : tokpos[1]].strip())
                 start_position = tokpos[1] + 1
-        split_options.append(options[start_position:])
+            # Handles trailing semicolon
+            # !! Note: If multiline options allowed this splitter might fail !!
+            if toktype == token.NEWLINE and start_position != tokpos[1]:
+                split_options.append(options[start_position : tokpos[1]].strip())
         return split_options

--- a/utest/test/keywords/approved_files/test_selenium_options_parser.test_split_options.approved.txt
+++ b/utest/test/keywords/approved_files/test_selenium_options_parser.test_split_options.approved.txt
@@ -5,4 +5,4 @@ Selenium options string splitting
 2) ['attribute=True']
 3) ['attribute="semi;colons;middle"', 'other_attribute=True']
 4) ['method("arg1;")', 'method(";arg2;")']
-5) ['method ( " arg1 ")', ' method ( " arg2 " ) ']
+5) ['method ( " arg1 ")', 'method ( " arg2 " )']


### PR DESCRIPTION
Allow for semicolon at end of selenium options. Also handles issue of empty options if for example an extra semicolon is put into the options. In such cases we ignore the empty option and publish a warning.

Fixes #1877 