### PR TITLE
updated *** Setting/Keyword/Variable *** to *** Settings/Keywords/Variables ***

### DIFF
--- a/atest/acceptance/2-event_firing_webdriver/resource_event_firing_webdriver.robot
+++ b/atest/acceptance/2-event_firing_webdriver/resource_event_firing_webdriver.robot
@@ -6,7 +6,7 @@ ${DESIRED_CAPABILITIES}=    ${NONE}
 ${ROOT}=                    http://${SERVER}/html
 ${FRONT_PAGE}=              ${ROOT}/
 
-*** Keyword ***
+*** Keywords ***
 
 Go To Page "${relative url}"
     [Documentation]    Goes to page

--- a/atest/acceptance/__init__.robot
+++ b/atest/acceptance/__init__.robot
@@ -1,4 +1,4 @@
-*** Setting ***
+*** Settings ***
 Resource          resource.robot
 Force Tags        Regression
 

--- a/atest/acceptance/big_list_of_naught_strings.robot
+++ b/atest/acceptance/big_list_of_naught_strings.robot
@@ -1,4 +1,4 @@
-*** Setting ***
+*** Settings ***
 Resource          resource.robot
 Library           BigListOfNaughtyStrings.BigListOfNaughtyStrings    WITH NAME    blns
 

--- a/atest/acceptance/create_webdriver.robot
+++ b/atest/acceptance/create_webdriver.robot
@@ -1,4 +1,4 @@
-*** Setting ***
+*** Settings ***
 Documentation     Tests Webdriver
 Resource          resource.robot
 Library           Collections

--- a/atest/acceptance/keywords/cookies.robot
+++ b/atest/acceptance/keywords/cookies.robot
@@ -1,4 +1,4 @@
-*** Setting ***
+*** Settings ***
 Documentation     Tests cookies
 Suite Setup       Go To Page "cookies.html"
 Suite Teardown    Delete All Cookies
@@ -117,7 +117,7 @@ Test Get Cookie Keyword Logging
     ...    extra={'sameSite': 'Lax'}
     ${cookie} =    Get Cookie     far_future
 
-*** Keyword ***
+*** Keywords ***
 Add Cookies
     Delete All Cookies
     Add Cookie    test       seleniumlibrary

--- a/atest/acceptance/keywords/frames.robot
+++ b/atest/acceptance/keywords/frames.robot
@@ -1,4 +1,4 @@
-*** Setting ***
+*** Settings ***
 Documentation     Tests frames
 Test Setup        Go To Page "frames/frameset.html"
 Test Teardown     UnSelect Frame

--- a/atest/acceptance/keywords/textfields.robot
+++ b/atest/acceptance/keywords/textfields.robot
@@ -1,4 +1,4 @@
-*** Setting ***
+*** Settings ***
 Test Setup        Go To Page "forms/prefilled_email_form.html"
 Resource          ../resource.robot
 Force Tags        Known Issue Internet Explorer

--- a/atest/acceptance/keywords/textfields_html5.robot
+++ b/atest/acceptance/keywords/textfields_html5.robot
@@ -1,4 +1,4 @@
-*** Setting ***
+*** Settings ***
 Test Setup        Go To Page "forms/html5_input_types.html"
 Resource          ../resource.robot
 

--- a/atest/acceptance/multiple_browsers_multiple_windows.robot
+++ b/atest/acceptance/multiple_browsers_multiple_windows.robot
@@ -1,4 +1,4 @@
-*** Setting ***
+*** Settings ***
 Documentation     These tests must open own browser because windows opened by
 ...               earlier tests would otherwise be visible to Get Window XXX keywords
 ...               even if those windows were closed.

--- a/atest/acceptance/resource.robot
+++ b/atest/acceptance/resource.robot
@@ -1,10 +1,10 @@
-*** Setting ***
+*** Settings ***
 Library           SeleniumLibrary    run_on_failure=Nothing    implicit_wait=0.2 seconds
 Library           Collections
 Library           OperatingSystem
 Library           DateTime
 
-*** Variable ***
+*** Variables ***
 ${SERVER}=         localhost:7000
 ${BROWSER}=        firefox
 ${REMOTE_URL}=     ${NONE}
@@ -13,7 +13,7 @@ ${ROOT}=           http://${SERVER}/html
 ${FRONT_PAGE}=     ${ROOT}/
 ${SPEED}=          0
 
-*** Keyword ***
+*** Keywords ***
 Open Browser To Start Page
     [Documentation]    This keyword also tests 'Set Selenium Speed' and 'Set Selenium Timeout'
     ...    against all reason.

--- a/atest/acceptance/windows.robot
+++ b/atest/acceptance/windows.robot
@@ -1,4 +1,4 @@
-*** Setting ***
+*** Settings ***
 Documentation     These tests must open own browser because windows opened by
 ...               earlier tests would otherwise be visible to Get Window XXX keywords
 ...               even if those windows were closed.


### PR DESCRIPTION
Singular section header names are deprecated in RF7.0.
This is to remove warnings in log when running atests