### PR TITLE
Update CI runs to inlcude firefox

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,5 +99,5 @@ jobs:
     - uses: actions/upload-artifact@v1
       if: success() || failure()
       with:
-        name: SeleniumLibrary Test results ${{ matrix.python-version }} ${{ matrix.rf-version}} ${{ matrix.selenium-version}}
+        name: SeleniumLibrary Test results
         path: atest/zip_results

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,7 @@ jobs:
         python-version: [3.8, 3.11]  # 3.12, pypy-3.9
         rf-version: [5.0.1, 6.1.1, 7.0]
         selenium-version: [4.14.0, 4.15.2, 4.16.0]  #4.17.0, 4.18.0
+        browser: [firefox, chrome, headlesschrome]
 
     steps:
     - uses: actions/checkout@v4
@@ -74,20 +75,10 @@ jobs:
       run: |
         xvfb-run --auto-servernum python atest/run.py --nounit --zip headlesschrome
 
-    - name: Run tests with normal Chrome if CPython
+    - name: Run tests with ${{ matrix.browser }} if CPython
       if: startsWith( matrix.python-version, 'pypy') == false
       run: |
-        xvfb-run --auto-servernum python atest/run.py --zip chrome
-
-    - name: Run tests with headless Chrome if CPython
-      if: startsWith( matrix.python-version, 'pypy') == false
-      run: |
-        xvfb-run --auto-servernum python atest/run.py --zip headlesschrome
-
-    - name: Run tests with Firefox if Cpython
-      if: startsWith( matrix.python-version, 'pypy') == false
-      run: |
-        xvfb-run --auto-servernum python atest/run.py --zip firefox
+        xvfb-run --auto-servernum python atest/run.py --zip ${{ matrix.browser }}
 
     # - name: Run tests with Selenium Grid
     #   if: matrix.python-version == '3.11' && matrix.rf-version == '3.2.2' && matrix.python-version != 'pypy-3.9'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,12 +11,12 @@ jobs:
       matrix:
         python-version: [3.8, 3.11]  # 3.12, pypy-3.9
         rf-version: [5.0.1, 6.1.1, 7.0]
-        selenium-version: [4.14.0, 4.15.2, 4.16.0, 4.17.0]
+        selenium-version: [4.14.0, 4.15.2, 4.16.0]  #4.17.0, 4.18.0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }} with Robot Framework ${{ matrix.rf-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup Chrome
@@ -99,5 +99,5 @@ jobs:
     - uses: actions/upload-artifact@v1
       if: success() || failure()
       with:
-        name: SeleniumLibrary Test results
+        name: SeleniumLibrary Test results ${{ matrix.python-version }} ${{ matrix.rf-version}} ${{ matrix.selenium-version}}
         path: atest/zip_results

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.11]  # 3.12, pypy-3.9
-        rf-version: [5.0.1, 6.1.1, 7.0b1]
-        selenium-version: [4.14.0, 4.15.2, 4.16.0]
+        rf-version: [5.0.1, 6.1.1, 7.0]
+        selenium-version: [4.14.0, 4.15.2, 4.16.0, 4.17.0]
 
     steps:
     - uses: actions/checkout@v3
@@ -27,6 +27,14 @@ jobs:
     - run: |
         echo Installed chromium version: ${{ steps.setup-chrome.outputs.chrome-version }}
         ${{ steps.setup-chrome.outputs.chrome-path }} --version
+    - name: Setup firefox
+      id: setup-firefox
+      uses: browser-actions/setup-firefox@v1
+      with:
+        firefox-version: latest
+    - run: |
+        echo Installed firefox versions: ${{ steps.setup-firefox.outputs.firefox-version }}
+        ${{ steps.setup-firefox.outputs.firefox-path }} --version
     - name: Start xvfb
       run: |
         export DISPLAY=:99.0
@@ -62,23 +70,22 @@ jobs:
 
     # Temporarily ignoring pypy execution
     - name: Run tests with headless Chrome and with PyPy
-      if: matrix.python-version == 'pypy-3.9'
+      if: startsWith( matrix.python-version, 'pypy') == true
       run: |
         xvfb-run --auto-servernum python atest/run.py --nounit --zip headlesschrome
 
     - name: Run tests with normal Chrome if CPython
-      if: matrix.python-version != 'pypy-3.9'
+      if: startsWith( matrix.python-version, 'pypy') == false
       run: |
         xvfb-run --auto-servernum python atest/run.py --zip chrome
 
-    # Recognize for the moment this will NOT run as we aren't using Python 3.9
-    - name: Run tests with headless Firefox with Python 3.9 and RF 4.1.3
-      if: matrix.python-version == '3.9' && matrix.rf-version == '4.1.3'
+    - name: Run tests with headless Chrome if CPython
+      if: startsWith( matrix.python-version, 'pypy') == false
       run: |
-        xvfb-run --auto-servernum python atest/run.py --zip headlessfirefox
+        xvfb-run --auto-servernum python atest/run.py --zip headlesschrome
 
-    - name: Run tests with normal Firefox with Python 3.9 and RF != 4.1.3
-      if: matrix.python-version == '3.9' && matrix.rf-version != '4.1.3'
+    - name: Run tests with Firefox if Cpython
+      if: startsWith( matrix.python-version, 'pypy') == false
       run: |
         xvfb-run --auto-servernum python atest/run.py --zip firefox
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
         python-version: [3.8, 3.11]  # 3.12, pypy-3.9
         rf-version: [5.0.1, 6.1.1, 7.0]
         selenium-version: [4.14.0, 4.15.2, 4.16.0]  #4.17.0, 4.18.0
-        browser: [firefox, chrome, headlesschrome]
+        browser: [firefox, chrome, headlesschrome]  #edge
 
     steps:
     - uses: actions/checkout@v4

--- a/atest/acceptance/keywords/cookies.robot
+++ b/atest/acceptance/keywords/cookies.robot
@@ -49,8 +49,9 @@ Add Cookie When Expiry Is Human Readable Data&Time
 Delete Cookie
     [Tags]    Known Issue Safari
     Delete Cookie    test
-    ${cookies} =    Get Cookies
-    Should Be Equal    ${cookies}    far_future=timemachine; another=value
+    ${cookies} =    Get Cookies  as_dict=True
+    ${expected_cookies}  Create Dictionary  far_future=timemachine  another=value
+    Dictionaries Should Be Equal    ${cookies}    ${expected_cookies}
 
 Non-existent Cookie
     Run Keyword And Expect Error


### PR DESCRIPTION
Split the CI runs on browser. Therefore there are now more runs, but each run only tests a single browser, so more parallel testing can be done.

Fixed a Cookies test on firefox, Cookies were different order than originally in test, but order does not matter so now comparing dict instead of string.

#TODO look at pypy and selenium grid testing. These are currently (still) not included.
