### PR TITLE
Fix _find_by_data_locator

### DIFF
--- a/src/SeleniumLibrary/locators/elementfinder.py
+++ b/src/SeleniumLibrary/locators/elementfinder.py
@@ -223,7 +223,7 @@ class ElementFinder(ContextAware):
 
     def _find_by_data_locator(self, criteria, tag, constraints, parent):
         try:
-            name, value = criteria.split(":", 2)
+            name, value = criteria.split(":", 1)
             if "" in [name, value]:
                 raise ValueError
         except ValueError:


### PR DESCRIPTION
Off by one in _find_by_data_locator which causes opaque failure on data values which contain a colon.

Example html:
`<div data-automation-id="foo:bar">This might be trouble</div>`

Example robot:
`Scroll Element Into View    data:automation-id:foo:bar`

Error message: 
`Provided selector (automation-id:foo:bar) is malformed. Correct format: name:value.`

I don't love the person putting colons in their automation ID, but we don't always get to choose the html we're testing. 