### PR TITLE
Latest Versions Oct2024

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         python-version: [3.8, 3.13.0]  # pypy-3.9
         rf-version: [6.1.1, 7.1.1]
-        selenium-version: [4.24.0, 4.25.0 4.26.1]
+        selenium-version: [4.24.0, 4.25.0, 4.26.1]
         browser: [firefox, chrome, headlesschrome]  #edge
 
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,7 +87,7 @@ jobs:
     #     sudo chmod u+x ./selenium-server-standalone.jar
     #     xvfb-run --auto-servernum python atest/run.py --zip headlesschrome  --grid True
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: SeleniumLibrary Test results

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,9 +9,9 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        python-version: [3.8, 3.12]  # pypy-3.9
-        rf-version: [6.1.1, 7.0.1]
-        selenium-version: [4.21.0, 4.22.0, 4.23.1, 4.24.0]
+        python-version: [3.8, 3.13.0rc2]  # pypy-3.9
+        rf-version: [6.1.1, 7.1]
+        selenium-version: [4.23.1, 4.24.0, 4.25.0]
         browser: [firefox, chrome, headlesschrome]  #edge
 
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,9 +9,9 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        python-version: [3.8, 3.12]  # pypy-3.9
-        rf-version: [6.1.1, 7.0.1]
-        selenium-version: [4.21.0, 4.22.0, 4.23.1, 4.24.0]
+        python-version: [3.8, 3.13.0]  # pypy-3.9
+        rf-version: [6.1.1, 7.1.1]
+        selenium-version: [4.24.0, 4.25.0 4.26.1]
         browser: [firefox, chrome, headlesschrome]  #edge
 
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        python-version: [3.8, 3.13.0rc2]  # pypy-3.9
+        python-version: [3.8, 3.13.0-rc.2]  # pypy-3.9
         rf-version: [6.1.1, 7.1]
         selenium-version: [4.23.1, 4.24.0, 4.25.0]
         browser: [firefox, chrome, headlesschrome]  #edge

--- a/atest/acceptance/keywords/cookies.robot
+++ b/atest/acceptance/keywords/cookies.robot
@@ -36,15 +36,15 @@ Add Cookie When Secure Is False
     Should Be Equal    ${cookie.secure}       ${False}
 
 Add Cookie When Expiry Is Epoch
-    Add Cookie    Cookie1    value1    expiry=1730205247
+    Add Cookie    Cookie1    value1    expiry=1761755100
     ${cookie} =    Get Cookie    Cookie1
-    ${expiry} =    Convert Date    ${1730205247}    exclude_millis=True
+    ${expiry} =    Convert Date    ${1761755100}    exclude_millis=True
     Should Be Equal As Strings    ${cookie.expiry}    ${expiry}
 
 Add Cookie When Expiry Is Human Readable Data&Time
-    Add Cookie    Cookie12    value12    expiry=2024-10-29 19:36:51
+    Add Cookie    Cookie12    value12    expiry=2025-10-29 12:25:00
     ${cookie} =    Get Cookie    Cookie12
-    Should Be Equal As Strings    ${cookie.expiry}    2024-10-29 19:36:51
+    Should Be Equal As Strings    ${cookie.expiry}    2025-10-29 12:25:00
 
 Delete Cookie
     [Tags]    Known Issue Safari

--- a/atest/acceptance/keywords/cookies.robot
+++ b/atest/acceptance/keywords/cookies.robot
@@ -114,12 +114,15 @@ Test Get Cookie Keyword Logging
     ...    domain=localhost
     ...    secure=False
     ...    httpOnly=False
-    ...    expiry=2024-09-15 *:22:33
+    ...    expiry=2025-09-01 *:25:00
     ...    extra={'sameSite': 'Lax'}
     ${cookie} =    Get Cookie     far_future
 
 *** Keywords ***
 Add Cookies
+    # To update time each September (as Chrome limits cookies to one year expiry date) use
+    #    import datetime
+    #    print (datetime.datetime.strptime("2025-09-01 12:25:00", "%Y-%m-%d %I:%M:%S").timestamp())
     Delete All Cookies
     Add Cookie    test       seleniumlibrary
     ${now} =    Get Current Date
@@ -127,4 +130,4 @@ Add Cookies
     ${tomorrow_thistime_datetime} =    Convert Date    ${tomorrow_thistime}    datetime
     Set Suite Variable    ${tomorrow_thistime_datetime}
     Add Cookie    another    value   expiry=${tomorrow_thistime}
-    Add Cookie    far_future    timemachine    expiry=1726399353    # 2024-09-15 11:22:33
+    Add Cookie    far_future    timemachine    expiry=1756700700    # 2025-09-01 12:25:00


### PR DESCRIPTION
- Fixes the cookie tests which need to be updated each year because Chrome, at least, does not allow cookies to expire further out than a year.
- Updates upload-artifacts to supported version 3. Have not moved to version 4 due to need to update artifact naming convention. (Will need to do this soon as V3 is also being deprecated)
- Updated Python version to include 3.13.0, robot framework v7.1.1, and selenium 4.24.0, 4.25.0, and 4.26.1