### PR TITLE
Return screenshot as base64 string and embed into log

### DIFF
--- a/src/SeleniumLibrary/__init__.py
+++ b/src/SeleniumLibrary/__init__.py
@@ -50,7 +50,7 @@ from SeleniumLibrary.keywords import (
     WebDriverCache,
     WindowKeywords,
 )
-from SeleniumLibrary.keywords.screenshot import EMBED
+from SeleniumLibrary.keywords.screenshot import EMBED, BASE64
 from SeleniumLibrary.locators import ElementFinder
 from SeleniumLibrary.utils import LibraryListener, is_truthy, _convert_timeout, _convert_delay
 
@@ -614,8 +614,8 @@ class SeleniumLibrary(DynamicCore):
         - ``run_on_failure``:
           Default action for the `run-on-failure functionality`.
         - ``screenshot_root_directory``:
-          Path to folder where possible screenshots are created or EMBED.
-          See `Set Screenshot Directory` keyword for further details about EMBED.
+          Path to folder where possible screenshots are created or EMBED or BASE64.
+          See `Set Screenshot Directory` keyword for further details about EMBED and BASE64.
           If not given, the directory where the log file is written is used.
         - ``plugins``:
           Allows extending the SeleniumLibrary with external Python classes.
@@ -846,6 +846,8 @@ class SeleniumLibrary(DynamicCore):
         if is_string(screenshot_root_directory):
             if screenshot_root_directory.upper() == EMBED:
                 self.screenshot_root_directory = EMBED
+            if screenshot_root_directory.upper() == BASE64:
+                self.screenshot_root_directory = BASE64
 
     @staticmethod
     def _get_translation(language: Union[str, None]) -> Union[Path, None]:

--- a/src/SeleniumLibrary/keywords/screenshot.py
+++ b/src/SeleniumLibrary/keywords/screenshot.py
@@ -61,6 +61,8 @@ class ScreenshotKeywords(LibraryComponent):
             path = None
         elif path.upper() == EMBED:
             path = EMBED
+        elif path.upper() == BASE64:
+            path = BASE64
         else:
             path = os.path.abspath(path)
             self._create_directory(path)

--- a/src/SeleniumLibrary/keywords/screenshot.py
+++ b/src/SeleniumLibrary/keywords/screenshot.py
@@ -130,7 +130,7 @@ class ScreenshotKeywords(LibraryComponent):
         screenshot_as_base64 = self.driver.get_screenshot_as_base64()
         base64_str = self._embed_to_log_as_base64(screenshot_as_base64, 800)
         if return_val == BASE64:
-            return_val base64_str
+            return base64_str
         return EMBED
 
     @keyword
@@ -194,12 +194,12 @@ class ScreenshotKeywords(LibraryComponent):
     def _decide_embedded(self, filename):
         filename = filename.upper()
         if (
-            filename == DEFAULT_FILENAME_PAGE
+            filename == DEFAULT_FILENAME_PAGE.upper()
             and self._screenshot_root_directory in EMBEDDED_OPTIONS
         ):
             return True, self._screenshot_root_directory
         if (
-            filename == DEFAULT_FILENAME_ELEMENT
+            filename == DEFAULT_FILENAME_ELEMENT.upper()
             and self._screenshot_root_directory in EMBEDDED_OPTIONS
         ):
             return True, self._screenshot_root_directory

--- a/src/SeleniumLibrary/keywords/screenshot.py
+++ b/src/SeleniumLibrary/keywords/screenshot.py
@@ -83,7 +83,14 @@ class ScreenshotKeywords(LibraryComponent):
 
         If ``filename`` equals to EMBED (case insensitive), then screenshot
         is embedded as Base64 image to the log.html. In this case file is not
-        created in the filesystem.
+        created in the filesystem. If ``filename`` equals to BASE64 (case
+        insensitive), then the base64 string is returned and the screenshot
+        is embedded to the log. This allows one to reuse the image elsewhere
+        in the report.
+
+        Example:
+        | ${ss}=            | `Capture Page Screenshot`  | BASE64                                          |
+        | Set Test Message  |   *HTML*Test Success<p><img src="data:image/png;base64,${ss}" width="256px"> |
 
         Starting from SeleniumLibrary 1.8, if ``filename`` contains marker
         ``{index}``, it will be automatically replaced with an unique running
@@ -93,9 +100,10 @@ class ScreenshotKeywords(LibraryComponent):
         format string syntax].
 
         An absolute path to the created screenshot file is returned or if
-        ``filename``  equals to EMBED, word `EMBED` is returned.
+        ``filename``  equals to EMBED, word `EMBED` is returned. If ``filename``
+        equals to BASE64, the base64 string containing the screenshot is returned.
 
-        Support for EMBED is new in SeleniumLibrary 4.2
+        Support for BASE64 is new in SeleniumLibrary 6.8
 
         Examples:
         | `Capture Page Screenshot` |                                        |
@@ -147,18 +155,24 @@ class ScreenshotKeywords(LibraryComponent):
         See the `Locating elements` section for details about the locator
         syntax.
 
-        An absolute path to the created element screenshot is returned.
+        An absolute path to the created element screenshot is returned. If the ``filename``
+        equals to BASE64 (case insensitive), then the base64 string is returned in addition
+        to the screenshot embedded to the log. See ``Capture Page Screenshot`` for more
+        information.
 
         Support for capturing the screenshot from an element has limited support
         among browser vendors. Please check the browser vendor driver documentation
         does the browser support capturing a screenshot from an element.
 
         New in SeleniumLibrary 3.3. Support for EMBED is new in SeleniumLibrary 4.2.
+        Support for BASE64 is new in SeleniumLibrary 6.8.
 
         Examples:
         | `Capture Element Screenshot` | id:image_id |                                |
         | `Capture Element Screenshot` | id:image_id | ${OUTPUTDIR}/id_image_id-1.png |
         | `Capture Element Screenshot` | id:image_id | EMBED                          |
+        | ${ess}= | `Capture Element Screenshot` | id:image_id | BASE64               |
+
         """
         if not self.drivers.current:
             self.info(

--- a/utest/test/keywords/test_screen_shot.py
+++ b/utest/test/keywords/test_screen_shot.py
@@ -22,24 +22,24 @@ def teardown_function():
 
 
 def test_defaults(screen_shot):
-    assert screen_shot._decide_embedded(SCREENSHOT_FILE_NAME) is False
-    assert screen_shot._decide_embedded(ELEMENT_FILE_NAME) is False
+    assert screen_shot._decide_embedded(SCREENSHOT_FILE_NAME) == (False, None)
+    assert screen_shot._decide_embedded(ELEMENT_FILE_NAME) == (False, None)
 
 
 def test_screen_shotdir_embeded(screen_shot):
     screen_shot.ctx.screenshot_root_directory = EMBED
-    assert screen_shot._decide_embedded(SCREENSHOT_FILE_NAME) is True
-    assert screen_shot._decide_embedded(SCREENSHOT_FILE_NAME.upper()) is True
-    assert screen_shot._decide_embedded(ELEMENT_FILE_NAME) is True
-    assert screen_shot._decide_embedded(ELEMENT_FILE_NAME.upper()) is True
-    assert screen_shot._decide_embedded("other.psn") is False
+    assert screen_shot._decide_embedded(SCREENSHOT_FILE_NAME) == (True, EMBED)
+    assert screen_shot._decide_embedded(SCREENSHOT_FILE_NAME.upper()) == (True, EMBED)
+    assert screen_shot._decide_embedded(ELEMENT_FILE_NAME) == (True, EMBED)
+    assert screen_shot._decide_embedded(ELEMENT_FILE_NAME.upper()) == (True, EMBED)
+    assert screen_shot._decide_embedded("other.psn") == (False, None)
 
 
 def test_file_name_embeded(screen_shot):
-    assert screen_shot._decide_embedded(EMBED) is True
-    assert screen_shot._decide_embedded("other.psn") is False
+    assert screen_shot._decide_embedded(EMBED) == (True, EMBED)
+    assert screen_shot._decide_embedded("other.psn") == (False, None)
     screen_shot.ctx.screenshot_root_directory = EMBED
-    assert screen_shot._decide_embedded(EMBED) is True
+    assert screen_shot._decide_embedded(EMBED) == (True, EMBED)
 
 
 def test_screenshot_path_embedded(screen_shot):

--- a/utest/test/keywords/test_screen_shot.py
+++ b/utest/test/keywords/test_screen_shot.py
@@ -8,7 +8,7 @@ from SeleniumLibrary import ScreenshotKeywords, SeleniumLibrary
 SCREENSHOT_FILE_NAME = "selenium-screenshot-{index}.png"
 ELEMENT_FILE_NAME = "selenium-element-screenshot-{index}.png"
 EMBED = "EMBED"
-
+BASE64 = "BASE64"
 
 @pytest.fixture(scope="module")
 def screen_shot():
@@ -35,11 +35,21 @@ def test_screen_shotdir_embeded(screen_shot):
     assert screen_shot._decide_embedded("other.psn") == (False, None)
 
 
+def test_screen_shotdir_return_base64(screen_shot):
+    screen_shot.ctx.screenshot_root_directory = BASE64
+    assert screen_shot._decide_embedded(SCREENSHOT_FILE_NAME) == (True, BASE64)
+    assert screen_shot._decide_embedded(SCREENSHOT_FILE_NAME.upper()) == (True, BASE64)
+    assert screen_shot._decide_embedded(ELEMENT_FILE_NAME) == (True, BASE64)
+    assert screen_shot._decide_embedded(ELEMENT_FILE_NAME.upper()) == (True, BASE64)
+    assert screen_shot._decide_embedded("other.psn") == (False, None)
+
+
 def test_file_name_embeded(screen_shot):
-    assert screen_shot._decide_embedded(EMBED) == (True, EMBED)
     assert screen_shot._decide_embedded("other.psn") == (False, None)
     screen_shot.ctx.screenshot_root_directory = EMBED
     assert screen_shot._decide_embedded(EMBED) == (True, EMBED)
+    screen_shot.ctx.screenshot_root_directory = BASE64
+    assert screen_shot._decide_embedded(BASE64) == (True, BASE64)
 
 
 def test_screenshot_path_embedded(screen_shot):
@@ -55,6 +65,12 @@ def test_sl_init_embed():
 
     sl = SeleniumLibrary(screenshot_root_directory=EMBED)
     assert sl.screenshot_root_directory == EMBED
+
+    sl = SeleniumLibrary(screenshot_root_directory="bAsE64")
+    assert sl.screenshot_root_directory == BASE64
+
+    sl = SeleniumLibrary(screenshot_root_directory=BASE64)
+    assert sl.screenshot_root_directory == BASE64
 
 
 def test_sl_init_not_embed():
@@ -75,6 +91,9 @@ def test_sl_set_screenshot_directory():
 
     sl.set_screenshot_directory(EMBED)
     assert sl.screenshot_root_directory == EMBED
+
+    sl.set_screenshot_directory(BASE64)
+    assert sl.screenshot_root_directory == BASE64
 
     sl.set_screenshot_directory("EEmBedD")
     assert "EEmBedD" in sl.screenshot_root_directory


### PR DESCRIPTION
This is a slightly modified version of https://github.com/robotframework/SeleniumLibrary/pull/1923 which instead of modifying the EMBED functionality currently implemented, it allows for returning the base64 tring is one uses BASE64 instead. The reason for providing this alternative method is to prevent signifigant increase in filesize for the current users whom might not need the returned string. 