### PR TITLE
Add info log for Wait Until Page Contains Keyword in waiting.py | Issue 1941

### DIFF
--- a/src/SeleniumLibrary/keywords/waiting.py
+++ b/src/SeleniumLibrary/keywords/waiting.py
@@ -196,6 +196,7 @@ class WaitingKeywords(LibraryComponent):
             timeout,
             error,
         )
+        self.info(f"Text '{text}' appeared on the page.")
 
     @keyword
     def wait_until_page_does_not_contain(


### PR DESCRIPTION
Log information when text appears on the page.

What Changed: Added 'Info' step inside wait_until_page_contains function in keywords/waiting.py.

Result:
For Passing (INFO is added):<img width="1672" height="105" alt="image" src="https://github.com/user-attachments/assets/8f13df9f-d08a-4ba6-912f-2a598c40e965" />

For Fail (no change):<img width="1183" height="632" alt="image" src="https://github.com/user-attachments/assets/a7986d7b-47bc-42bd-a3cb-0c5fc0ba56ca" />

Related Issue: Wait Until Page Contains: Add INFO with the value of the text to the Keyword results #1941