### PR TITLE
Update cookie validation regex in Get Cookies test

### DIFF
--- a/atest/acceptance/keywords/cookies.robot
+++ b/atest/acceptance/keywords/cookies.robot
@@ -9,8 +9,11 @@ Library           DateTime
 *** Test Cases ***
 Get Cookies
     ${cookies}=    Get Cookies
+    Should Contain    ${cookies}    test=seleniumlibrary
+    Should Contain    ${cookies}    another=value
+    Should Contain    ${cookies}    far_future=timemachine
     Should Match Regexp    ${cookies}
-    ...    ^(test=seleniumlibrary; another=value)|(another=value; test=seleniumlibrary)$
+    ...    ^(?:test=seleniumlibrary|another=value|far_future=timemachine)(?:; (?:test=seleniumlibrary|another=value|far_future=timemachine)){2}$
 
 Get Cookies As Dict
     ${cookies}=    Get Cookies        as_dict=True


### PR DESCRIPTION
Fix flaky Get Cookies test

The previous regex used | to handle any cookie ordering, but the ^ and $ anchors were not wrapping both alternatives, leaving each side only partially anchored and allowing substring matches. For example, the first alternative only required the string to start with test=seleniumlibrary; another=value, meaning a third cookie appended at the end would still pass.

All 3 cookies were always being returned, but the test was silently passing in the past because the browser was consistently returning cookies in an order that accidentally satisfied the faulty regex.

Replaced the regex with a stricter pattern that matches exactly 3 known cookies in any order, with no room for unexpected extras.