### PR TITLE
Fix deprecation warnings and improve logging in tests

### DIFF
--- a/src/SeleniumLibrary/__init__.py
+++ b/src/SeleniumLibrary/__init__.py
@@ -214,7 +214,7 @@ class SeleniumLibrary(DynamicCore):
     | ${locator_list} =             | `Create List`   | css:div#div_id             | xpath: //*[text(), " >> "] |
     | `Page Should Contain Element` | ${locator_list} |                            |                            |
     | ${element} =                  | Get WebElement  | xpath: //*[text(), " >> "] |                            |
-    | ${locator_list} =             | `Create List`   | css:div#div_id             | ${element }                |
+    | ${locator_list} =             | `Create List`   | css:div#div_id             | ${element}                 |
     | `Page Should Contain Element` | ${locator_list} |                            |                            |
 
     Chaining locators in new in SeleniumLibrary 5.0

--- a/utest/test/api/approved_files/PluginDocumentation.test_many_plugins.approved.txt
+++ b/utest/test/api/approved_files/PluginDocumentation.test_many_plugins.approved.txt
@@ -148,14 +148,14 @@ and not for the element found be the previous locator. Chaining is supported by 
 are based on Selenium API, like `xpath` or `css`, but example chaining is not supported by `sizzle` or `jquery
 
 Examples:
-| `Click Element` | css:.bar >> xpath://a | # To find a link which is present after an element with class "bar" |
+| `Click Element` | css:.bar >> xpath: //a | # To find a link which is present after an element with class "bar" |
 
 List examples:
-| ${locator_list} =             | `Create List`   | css:div#div_id            | xpath://*[text(), " >> "] |
-| `Page Should Contain Element` | ${locator_list} |                           |                           |
-| ${element} =                  | Get WebElement  | xpath://*[text(), " >> "] |                           |
-| ${locator_list} =             | `Create List`   | css:div#div_id            | ${element}                |
-| `Page Should Contain Element` | ${locator_list} |                           |                           |
+| ${locator_list} =             | `Create List`   | css:div#div_id             | xpath: //*[text(), " >> "] |
+| `Page Should Contain Element` | ${locator_list} |                            |                            |
+| ${element} =                  | Get WebElement  | xpath: //*[text(), " >> "] |                            |
+| ${locator_list} =             | `Create List`   | css:div#div_id             | ${element}                 |
+| `Page Should Contain Element` | ${locator_list} |                            |                            |
 
 Chaining locators in new in SeleniumLibrary 5.0
 

--- a/utest/test/api/test_plugin_documentation.py
+++ b/utest/test/api/test_plugin_documentation.py
@@ -2,9 +2,11 @@ import os
 import unittest
 
 from approvaltests.approvals import verify
+from approvaltests.reporters.first_working_reporter import FirstWorkingReporter
 from approvaltests.reporters.generic_diff_reporter_factory import (
     GenericDiffReporterFactory,
 )
+from approvaltests.reporters.python_native_reporter import PythonNativeReporter
 from robot.utils import WINDOWS
 
 from SeleniumLibrary import SeleniumLibrary
@@ -24,7 +26,9 @@ class PluginDocumentation(unittest.TestCase):
         )
         factory = GenericDiffReporterFactory()
         factory.load(reporter_json)
-        self.reporter = factory.get_first_working()
+        self.reporter = FirstWorkingReporter(
+            factory.get_first_working(), PythonNativeReporter()
+        )
 
     @unittest.skipIf(WINDOWS, reason="ApprovalTest do not support different line feeds")
     def test_many_plugins(self):

--- a/utest/test/keywords/test_browsermanagement.py
+++ b/utest/test/keywords/test_browsermanagement.py
@@ -1,5 +1,5 @@
 import pytest
-from mockito import when, mock, verify, verifyNoMoreInteractions, ANY
+from mockito import when, mock, verify, ensureNoUnverifiedInteractions, ANY
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service as ChromeService
 from selenium.webdriver.chrome.service import Service
@@ -21,8 +21,8 @@ def test_set_selenium_timeout_only_affects_open_browsers():
     verify(second_browser).set_script_timeout(10.0)
     ctx._drivers.active_drivers = []
     bm.set_selenium_timeout("20 seconds")
-    verifyNoMoreInteractions(first_browser)
-    verifyNoMoreInteractions(second_browser)
+    ensureNoUnverifiedInteractions(first_browser)
+    ensureNoUnverifiedInteractions(second_browser)
 
 
 def test_action_chain_delay_default():


### PR DESCRIPTION
**Testing utility improvements:**

* Replaced the use of `verifyNoMoreInteractions` with `ensureNoUnverifiedInteractions` in `utest/test/keywords/test_browsermanagement.py` as fix for deprecation.

**Test reporter enhancements:**

* Changed the reporter setup in `utest/test/api/test_plugin_documentation.py` to use `FirstWorkingReporter` with a fallback to `PythonNativeReporter`, to give better readable logging in pipeline runs.
Now when a test fails in CI, instead of the `ReporterNotWorkingException`, we get a full inline diff printed to log showing exactly what changed. `FirstWorkingReporter` will try the GUI diff tool first (useful locally if Diffuse is installed), and fall back to `PythonNativeReporter`