### PR TITLE
Fixed broken links within Open Browser keyword

### DIFF
--- a/src/SeleniumLibrary/__init__.py
+++ b/src/SeleniumLibrary/__init__.py
@@ -523,7 +523,7 @@ class SeleniumLibrary(DynamicCore):
     = EventFiringWebDriver =
 
     The SeleniumLibrary offers support for
-    [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.event_firing_webdriver.html#module-selenium.webdriver.support.event_firing_webdriver|EventFiringWebDriver].
+    [https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_support/selenium.webdriver.support.event_firing_webdriver.html#module-selenium.webdriver.support.event_firing_webdriver|EventFiringWebDriver].
     See the Selenium and SeleniumLibrary
     [https://github.com/robotframework/SeleniumLibrary/blob/master/docs/extending/extending.rst#EventFiringWebDriver|EventFiringWebDriver support]
     documentation for further details.
@@ -620,7 +620,7 @@ class SeleniumLibrary(DynamicCore):
           Allows extending the SeleniumLibrary with external Python classes.
         - ``event_firing_webdriver``:
           Class for wrapping Selenium with
-          [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.event_firing_webdriver.html#module-selenium.webdriver.support.event_firing_webdriver|EventFiringWebDriver]
+          [https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_support/selenium.webdriver.support.event_firing_webdriver.html#module-selenium.webdriver.support.event_firing_webdriver|EventFiringWebDriver]
         - ``page_load_timeout``:
           Default value to wait for page load to complete until a timeout exception is raised.
         - ``action_chain_delay``:

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -133,7 +133,7 @@ class BrowserManagementKeywords(LibraryComponent):
         Optional ``ff_profile_dir`` is the path to the Firefox profile
         directory if you wish to overwrite the default profile Selenium
         uses. The ``ff_profile_dir`` can also be an instance of the
-        [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_firefox/selenium.webdriver.firefox.firefox_profile.html|selenium.webdriver.FirefoxProfile]
+        [https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_firefox/selenium.webdriver.firefox.firefox_profile.html#module-selenium.webdriver.firefox.firefox_profile|selenium.webdriver.firefox.firefox_profile]
         . As a third option, it is possible to use `FirefoxProfile` methods
         and attributes to define the profile using methods and attributes
         in the same way as with ``options`` argument. Example: It is possible
@@ -149,9 +149,9 @@ class BrowserManagementKeywords(LibraryComponent):
         Optional ``options`` argument allows defining browser specific
         Selenium options. Example for Chrome, the ``options`` argument
         allows defining the following
-        [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_chrome/selenium.webdriver.chrome.options.html#selenium.webdriver.chrome.options.Options|methods and attributes]
+        [https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_chrome/selenium.webdriver.chrome.options.html#selenium.webdriver.chrome.options.Options|methods and attributes]
         and for Firefox these
-        [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_firefox/selenium.webdriver.firefox.options.html?highlight=firefox#selenium.webdriver.firefox.options.Options|methods and attributes]
+        [https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_firefox/selenium.webdriver.firefox.options.html#selenium.webdriver.firefox.options.Options|methods and attributes]
         are available. Selenium options are also supported, when ``remote_url``
         argument is used.
 
@@ -163,7 +163,7 @@ class BrowserManagementKeywords(LibraryComponent):
         methods or attributes.
 
         Example when using
-        [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_chrome/selenium.webdriver.chrome.options.html#selenium.webdriver.chrome.options.Options|Chrome options]
+        [https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_chrome/selenium.webdriver.chrome.options.html#selenium.webdriver.chrome.options.Options|Chrome options]
         method:
         | `Open Browser` | http://example.com | Chrome | options=add_argument("--disable-popup-blocking"); add_argument("--ignore-certificate-errors") | # Sting format.                    |
         | `Open Browser` | None               | Chrome | options=binary_location="/path/to/binary";add_argument("remote-debugging-port=port")          | # Start Chomium-based application. |

--- a/src/SeleniumLibrary/keywords/browsermanagement.py
+++ b/src/SeleniumLibrary/keywords/browsermanagement.py
@@ -289,7 +289,7 @@ class BrowserManagementKeywords(LibraryComponent):
         The initialized WebDriver can be configured either with a Python
         dictionary ``kwargs`` or by using keyword arguments ``**init_kwargs``.
         These arguments are passed directly to WebDriver without any
-        processing. See [https://seleniumhq.github.io/selenium/docs/api/py/api.html|
+        processing. See [https://www.selenium.dev/selenium/docs/api/py/api.html|
         Selenium API documentation] for details about the supported arguments.
 
         Examples:

--- a/src/SeleniumLibrary/keywords/element.py
+++ b/src/SeleniumLibrary/keywords/element.py
@@ -664,12 +664,12 @@ newDiv.parentNode.style.overflow = 'hidden';
         syntax.
 
         The ``modifier`` argument can be used to pass
-        [https://seleniumhq.github.io/selenium/docs/api/py/webdriver/selenium.webdriver.common.keys.html#selenium.webdriver.common.keys.Keys|Selenium Keys]
+        [https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_common/selenium.webdriver.common.keys.html#module-selenium.webdriver.common.keys|Selenium Keys]
         when clicking the element. The `+` can be used as a separator
         for different Selenium Keys. The `CTRL` is internally translated to
         the `CONTROL` key. The ``modifier`` is space and case insensitive, example
         "alt" and " aLt " are supported formats to
-        [https://seleniumhq.github.io/selenium/docs/api/py/webdriver/selenium.webdriver.common.keys.html#selenium.webdriver.common.keys.Keys.ALT|ALT key]
+        [https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_common/selenium.webdriver.common.keys.html#selenium.webdriver.common.keys.Keys.ALT|ALT key]
         . If ``modifier`` does not match to Selenium Keys, keyword fails.
 
         If ``action_chain`` argument is true, see `Boolean arguments` for more
@@ -943,7 +943,7 @@ return !element.dispatchEvent(evt);
 
         ``keys`` arguments can contain one or many strings, but it can not
         be empty. ``keys`` can also be a combination of
-        [https://seleniumhq.github.io/selenium/docs/api/py/webdriver/selenium.webdriver.common.keys.html|Selenium Keys]
+        [https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_common/selenium.webdriver.common.keys.html|Selenium Keys]
         and strings or a single Selenium Key. If Selenium Key is combined
         with strings, Selenium key and strings must be separated by the
         `+` character, like in `CONTROL+c`. Selenium Keys
@@ -961,9 +961,9 @@ return !element.dispatchEvent(evt);
         `+` character, example `E+N+D`.
 
         `CTRL` is alias for
-        [https://seleniumhq.github.io/selenium/docs/api/py/webdriver/selenium.webdriver.common.keys.html#selenium.webdriver.common.keys.Keys.CONTROL|Selenium CONTROL]
+        [https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_common/selenium.webdriver.common.keys.html#selenium.webdriver.common.keys.Keys.CONTROL|Selenium CONTROL]
         and ESC is alias for
-        [https://seleniumhq.github.io/selenium/docs/api/py/webdriver/selenium.webdriver.common.keys.html#selenium.webdriver.common.keys.Keys.ESCAPE|Selenium ESCAPE]
+        [https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_common/selenium.webdriver.common.keys.html#selenium.webdriver.common.keys.Keys.ESCAPE|Selenium ESCAPE]
 
         New in SeleniumLibrary 3.3
 

--- a/src/SeleniumLibrary/keywords/formelement.py
+++ b/src/SeleniumLibrary/keywords/formelement.py
@@ -220,7 +220,7 @@ class FormElementKeywords(LibraryComponent):
         The keyword does not check ``file_path`` is the file or folder
         available on the machine where tests are executed. If the ``file_path``
         points at a file and when using Selenium Grid, Selenium will
-        [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_remote/selenium.webdriver.remote.command.html?highlight=upload#selenium.webdriver.remote.command.Command.UPLOAD_FILE|magically],
+        [https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_remote/selenium.webdriver.remote.command.html#selenium.webdriver.remote.command.Command.UPLOAD_FILE|magically],
         transfer the file from the machine where the tests are executed
         to the Selenium Grid node where the browser is running.
         Then Selenium will send the file path, from the nodes file

--- a/src/SeleniumLibrary/keywords/javascript.py
+++ b/src/SeleniumLibrary/keywords/javascript.py
@@ -52,7 +52,7 @@ class JavaScriptKeywords(LibraryComponent):
         Return values are converted to the appropriate Python types.
 
         Starting from SeleniumLibrary 3.2 it is possible to provide JavaScript
-        [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_remote/selenium.webdriver.remote.webdriver.html#selenium.webdriver.remote.webdriver.WebDriver.execute_script|
+        [https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_remote/selenium.webdriver.remote.webdriver.html#selenium.webdriver.remote.webdriver.WebDriver.execute_script|
         arguments] as part of ``code`` argument. The JavaScript code and
         arguments must be separated with `JAVASCRIPT` and `ARGUMENTS` markers
         and must be used exactly with this format. If the Javascript code is
@@ -85,7 +85,7 @@ class JavaScriptKeywords(LibraryComponent):
         fail. See the `Timeout` section for more information.
 
         Starting from SeleniumLibrary 3.2 it is possible to provide JavaScript
-        [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_remote/selenium.webdriver.remote.webdriver.html#selenium.webdriver.remote.webdriver.WebDriver.execute_async_script|
+        [https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_remote/selenium.webdriver.remote.webdriver.html#selenium.webdriver.remote.webdriver.WebDriver.execute_async_script|
         arguments] as part of ``code`` argument. See `Execute Javascript` for
         more details.
 

--- a/utest/test/api/approved_files/PluginDocumentation.test_many_plugins.approved.txt
+++ b/utest/test/api/approved_files/PluginDocumentation.test_many_plugins.approved.txt
@@ -463,7 +463,7 @@ arguments to boolean values.
 = EventFiringWebDriver =
 
 The SeleniumLibrary offers support for
-[https://seleniumhq.github.io/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.event_firing_webdriver.html#module-selenium.webdriver.support.event_firing_webdriver|EventFiringWebDriver].
+[https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_support/selenium.webdriver.support.event_firing_webdriver.html#module-selenium.webdriver.support.event_firing_webdriver|EventFiringWebDriver].
 See the Selenium and SeleniumLibrary
 [https://github.com/robotframework/SeleniumLibrary/blob/master/docs/extending/extending.rst#EventFiringWebDriver|EventFiringWebDriver support]
 documentation for further details.

--- a/utest/test/api/approved_files/PluginDocumentation.test_parse_plugin_init_doc.approved.txt
+++ b/utest/test/api/approved_files/PluginDocumentation.test_parse_plugin_init_doc.approved.txt
@@ -14,7 +14,7 @@ SeleniumLibrary can be imported with several optional arguments.
   Allows extending the SeleniumLibrary with external Python classes.
 - ``event_firing_webdriver``:
   Class for wrapping Selenium with
-  [https://seleniumhq.github.io/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.event_firing_webdriver.html#module-selenium.webdriver.support.event_firing_webdriver|EventFiringWebDriver]
+  [https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_support/selenium.webdriver.support.event_firing_webdriver.html#module-selenium.webdriver.support.event_firing_webdriver|EventFiringWebDriver]
 - ``page_load_timeout``:
   Default value to wait for page load to complete until a timeout exception is raised.
 - ``action_chain_delay``:

--- a/utest/test/api/approved_files/PluginDocumentation.test_parse_plugin_kw_doc.approved.txt
+++ b/utest/test/api/approved_files/PluginDocumentation.test_parse_plugin_kw_doc.approved.txt
@@ -19,7 +19,7 @@ This keyword returns whatever the executed JavaScript code returns.
 Return values are converted to the appropriate Python types.
 
 Starting from SeleniumLibrary 3.2 it is possible to provide JavaScript
-[https://seleniumhq.github.io/selenium/docs/api/py/webdriver_remote/selenium.webdriver.remote.webdriver.html#selenium.webdriver.remote.webdriver.WebDriver.execute_script|
+[https://www.selenium.dev/selenium/docs/api/py/selenium_webdriver_remote/selenium.webdriver.remote.webdriver.html#selenium.webdriver.remote.webdriver.WebDriver.execute_script|
 arguments] as part of ``code`` argument. The JavaScript code and
 arguments must be separated with `JAVASCRIPT` and `ARGUMENTS` markers
 and must be used exactly with this format. If the Javascript code is


### PR DESCRIPTION
Replaced the instance of link failure within `Open Browser` keyword.

Also replaced other links to the old Python API hosted on github.io

Fixes 1976
