### PR TITLE
1986 set minimum selenium version

### DIFF
--- a/.github/workflows/Select.yml
+++ b/.github/workflows/Select.yml
@@ -12,19 +12,19 @@ jobs:
           - description: latest
             python-version: 3.14.4
             rf-version: 7.4.2
-            selenium-version:  4.43.0
+            selenium-version:  4.44.0
             browser: chrome
           - description: previous
             python-version: 3.12.12
             rf-version: 7.3.2
-            selenium-version: 4.38.0
+            selenium-version: 4.40.0
             browser: chrome
           - description: older_rf_version
             python-version: 3.11.14
             rf-version: 6.1.1
             selenium-version: 4.37.0
             browser: chrome
-          - description: latest
+          - description: latest_firefox
             python-version: 3.14.4
             rf-version: 7.4.1
             selenium-version: 4.39.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-selenium >= 4.3.0
+selenium >= 4.25.0
 robotframework >= 4.1.3
 robotframework-pythonlibcore >= 4.4.1
 click >= 8.0


### PR DESCRIPTION
Setting minimum require Selenium to 4.25.0 within requirements.txt. Also bumping up the latest and previous Selenium version with the select workflow.